### PR TITLE
新增插槽功能，允许在历史列表之前插入自定义内容，更新HistoryProps接口以支持该功能。

### DIFF
--- a/src/History/__tests__/History.test.tsx
+++ b/src/History/__tests__/History.test.tsx
@@ -452,6 +452,7 @@ describe('History Component', () => {
       render(
         <History
           {...defaultProps}
+          standalone
           slots={{ beforeHistoryList: () => <div>beforeHistoryList</div> }}
         />,
       );

--- a/src/History/__tests__/History.test.tsx
+++ b/src/History/__tests__/History.test.tsx
@@ -141,7 +141,6 @@ const TestWrapper: React.FC<{ children: React.ReactNode; locale?: any }> = ({
     </ConfigProvider>
   );
 };
-
 describe('History Component', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -446,6 +445,17 @@ describe('History Component', () => {
         expect(mockRequest).toHaveBeenCalled();
       });
       // 应该重新调用请求
+    });
+  });
+  describe('slots', () => {
+    it('should render beforeHistoryList when slots.beforeHistoryList is provided', () => {
+      render(
+        <History
+          {...defaultProps}
+          slots={{ beforeHistoryList: () => <div>beforeHistoryList</div> }}
+        />,
+      );
+      expect(screen.getByText('beforeHistoryList')).toBeInTheDocument();
     });
   });
 });

--- a/src/History/index.tsx
+++ b/src/History/index.tsx
@@ -108,6 +108,9 @@ export const History: React.FC<HistoryProps> = (props) => {
           />
         )}
 
+        {!!props.slots?.beforeHistoryList &&
+          props.slots.beforeHistoryList(filteredList)}
+
         <GroupMenu
           selectedKeys={[props.sessionId]}
           inlineIndent={20}

--- a/src/History/index.tsx
+++ b/src/History/index.tsx
@@ -108,8 +108,7 @@ export const History: React.FC<HistoryProps> = (props) => {
           />
         )}
 
-        {!!props.slots?.beforeHistoryList &&
-          props.slots.beforeHistoryList(filteredList)}
+        {props.slots?.beforeHistoryList?.(filteredList)}
 
         <GroupMenu
           selectedKeys={[props.sessionId]}

--- a/src/History/types/index.ts
+++ b/src/History/types/index.ts
@@ -107,6 +107,10 @@ export interface HistoryProps {
     /** 正在运行的记录ID列表，这些记录将显示运行图标 */
     runningId?: string[];
   };
+  /** 插槽 */
+  slots?: {
+    beforeHistoryList?: (list: HistoryDataType[]) => React.ReactNode;
+  };
 }
 
 export interface HistoryActionsBoxProps {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - History 组件在独立渲染模式下支持可选插槽，可在历史列表前渲染自定义内容（通过 beforeHistoryList 回调插入节点）；非独立模式行为不变。
- 类型
  - 为 HistoryProps 增加可选 slots 属性，支持 beforeHistoryList 回调签名以接收历史项列表并返回自定义节点。
- 测试
  - 新增插槽相关测试，覆盖 beforeHistoryList 渲染。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->