### PR TITLE
docs: 调整文档中的组件引入的名称和首页链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ function hello() {
 
 ## 📖 文档
 
-- [快速开始](./docs/components/markdown-editor.md)
+- [快速开始](./docs/components/api.md)
 - [API 文档](./docs/components/api.md)
 - [组件文档](./docs/components/)
 - [插件开发](./docs/plugin/)

--- a/docs/components/SchemaEditor.md
+++ b/docs/components/SchemaEditor.md
@@ -2,6 +2,7 @@
 nav:
   title: 组件
   order: 1
+atomId: SchemaEditor
 group:
   title: 渲染器
   order: 3

--- a/docs/components/ThoughtChainList.md
+++ b/docs/components/ThoughtChainList.md
@@ -1,6 +1,7 @@
 ---
 nav:
   order: 1
+atomId: ThoughtChainList
 group:
   title: 数据展示
   order: 3

--- a/docs/components/api.md
+++ b/docs/components/api.md
@@ -1,6 +1,7 @@
 ---
 nav:
   order: 1
+atomId: MarkdownEditor
 group:
   title: 编辑器
   order: 1

--- a/docs/components/api.md
+++ b/docs/components/api.md
@@ -501,7 +501,7 @@ export default () => {
 
 ## 🔗 相关链接
 
-- [组件演示](/components/markdown-editor)
+- [组件演示](/components/api)
 - [插件开发指南](/plugin/)
 - [开发指南](/development/)
 - [常见问题](/faq/)

--- a/docs/components/area-chart.md
+++ b/docs/components/area-chart.md
@@ -1,5 +1,6 @@
 ---
 title: AreaChart 面积图
+atomId: AreaChart
 group:
   title: 图表
   order: 1

--- a/docs/components/bar-chart.md
+++ b/docs/components/bar-chart.md
@@ -1,5 +1,6 @@
 ---
 title: BarChart 柱状图
+atomId: BarChart
 group:
   title: 图表
   order: 2

--- a/docs/components/bubble.md
+++ b/docs/components/bubble.md
@@ -803,7 +803,7 @@ const groupedMessages = useMemo(() => {
 
 ## 🔗 相关资源
 
-- [MarkdownEditor 组件](/components/markdown-editor) - 配套的 Markdown 编辑器
+- [MarkdownEditor 组件](/components/api) - 配套的 Markdown 编辑器
 - [ThoughtChainList 组件](/components/thought-chain-list) - 思维链展示组件
 - [TaskList 组件](/components/task-list) - 任务列表组件
 - [设计规范文档](/guide/design) - 组件设计原则和规范

--- a/docs/components/bubble.md
+++ b/docs/components/bubble.md
@@ -1,5 +1,6 @@
 ---
 title: Bubble 气泡组件
+atomId: Bubble
 group:
   title: 组件
   order: 2

--- a/docs/components/donut-chart.md
+++ b/docs/components/donut-chart.md
@@ -1,5 +1,6 @@
 ---
 title: DonutChart 环形图
+atomId: DonutChart
 group:
   title: 图表
   order: 3

--- a/docs/components/history.md
+++ b/docs/components/history.md
@@ -1,5 +1,6 @@
 ---
 title: History 历史记录
+atomId: History
 group:
   title: 数据展示
   order: 4

--- a/docs/components/line-chart.md
+++ b/docs/components/line-chart.md
@@ -1,5 +1,6 @@
 ---
 title: LineChart 折线图
+atomId: LineChart
 group:
   title: 图表
   order: 4

--- a/docs/components/loading.md
+++ b/docs/components/loading.md
@@ -1,5 +1,6 @@
 ---
 title: Loading 加载
+atomId: Loading
 group:
   title: 基础组件
   order: 1

--- a/docs/components/markdownInputField.md
+++ b/docs/components/markdownInputField.md
@@ -1,6 +1,7 @@
 ---
 nav:
   order: 1
+atomId: MarkdownInputField
 group:
   title: 编辑器
   order: 1

--- a/docs/components/radar-chart.md
+++ b/docs/components/radar-chart.md
@@ -1,5 +1,6 @@
 ---
 title: RadarChart 雷达图
+atomId: RadarChart
 group:
   title: 图表
   order: 5

--- a/docs/components/scatter-chart.md
+++ b/docs/components/scatter-chart.md
@@ -1,5 +1,6 @@
 ---
 title: ScatterChart 散点图
+atomId: ScatterChart
 group:
   title: 图表
   order: 6

--- a/docs/components/task-list.md
+++ b/docs/components/task-list.md
@@ -1,5 +1,6 @@
 ---
 title: TaskList 任务列表
+atomId: TaskList
 group:
   title: 数据展示
   order: 3

--- a/docs/components/task-running.md
+++ b/docs/components/task-running.md
@@ -1,5 +1,6 @@
 ---
 title: TaskRunning 任务运行状态
+atomId: TaskRunning
 group:
   title: 数据展示
   order: 3

--- a/docs/components/tool-use-bar.md
+++ b/docs/components/tool-use-bar.md
@@ -1,5 +1,6 @@
 ---
 title: ToolUseBar 工具使用栏
+atomId: ToolUseBar
 group:
   title: 功能组件
   order: 2

--- a/docs/components/workspace.md
+++ b/docs/components/workspace.md
@@ -1,5 +1,6 @@
 ---
 title: Workspace 工作空间
+atomId: Workspace
 group:
   title: 组件
   order: 2

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ hero:
   description: 基于 React + TypeScript 的现代化 Markdown 编辑器，提供丰富的编辑功能和插件系统
   actions:
     - text: 快速开始
-      link: /components/markdown-editor
+      link: /components/api
     - text: 查看 GitHub
       link: https://github.com/ant-design/md-editor
       type: primary


### PR DESCRIPTION
- 更新首页「快速开始」的链接地址
- 调整文档中的组件引入的名称
<img width="590" height="169" alt="image" src="https://github.com/user-attachments/assets/f84117f9-4a09-48f0-bd52-a5f9a362cc3a" />
