### PR TITLE
feat(ChatFlowContainer): 补充置顶置底按钮 demo，增加 ref 输出

### DIFF
--- a/docs/demos/ChatFlowContainer/index.tsx
+++ b/docs/demos/ChatFlowContainer/index.tsx
@@ -1,7 +1,9 @@
 import {
+  BackTo,
   BubbleList,
   BubbleMetaData,
   ChatFlowContainer,
+  ChatFlowContainerRef,
   MessageBubbleData,
   TASK_RUNNING_STATUS,
   TASK_STATUS,
@@ -40,12 +42,6 @@ const createMockMessage = (
   } as BubbleMetaData,
 });
 
-// 初始消息
-const initialMessages: MessageBubbleData[] = [
-  createMockMessage('1', 'assistant', '欢迎使用 BubbleList 组件！'),
-  createMockMessage('2', 'user', '这个组件功能很强大！'),
-];
-
 /**
  * ChatFlowContainer 对话流容器组件演示
  *
@@ -58,8 +54,20 @@ const initialMessages: MessageBubbleData[] = [
 const ChatFlowContainerDemo: React.FC = () => {
   const [leftCollapsed, setLeftCollapsed] = useState(false);
   const [rightCollapsed, setRightCollapsed] = useState(true); // 状态管理
-  const [bubbleList, setBubbleList] =
-    useState<MessageBubbleData[]>(initialMessages);
+  const [bubbleList, setBubbleList] = useState<MessageBubbleData[]>(() => {
+    const messageCount = 20;
+    const messages: MessageBubbleData[] = [];
+
+    for (let i = 0; i < messageCount; i++) {
+      const role = i % 2 === 0 ? 'assistant' : 'user';
+      const content = `这是第 ${i + 1} 条消息`;
+      messages.push(createMockMessage(`msg-${i}`, role, content));
+    }
+
+    return messages;
+  });
+
+  const containerRef = useRef<ChatFlowContainerRef>(null);
 
   // 使用 useRef 管理重试状态，避免全局污染
   const isRetryingRef = useRef(false);
@@ -158,6 +166,7 @@ const ChatFlowContainerDemo: React.FC = () => {
       {/* 主对话区域 */}
       <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
         <ChatFlowContainer
+          ref={containerRef}
           className="custom-chat-container"
           title="AI 助手"
           onLeftCollapse={handleLeftCollapse}
@@ -165,11 +174,50 @@ const ChatFlowContainerDemo: React.FC = () => {
           footer={
             <div
               style={{
+                position: 'relative',
                 display: 'flex',
+                flexDirection: 'column',
                 alignItems: 'center',
                 justifyContent: 'center',
               }}
             >
+              <div
+                style={{
+                  position: 'absolute',
+                  top: '-16px',
+                  left: '50%',
+                  transform: 'translate(-50%, -100%)',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: 16,
+                }}
+              >
+                <BackTo.Top
+                  tooltip="去顶部"
+                  shouldVisible={200}
+                  target={() =>
+                    containerRef.current?.scrollContainer as HTMLElement
+                  }
+                  style={{
+                    position: 'relative',
+                    bottom: 0,
+                    insetInlineEnd: 0,
+                  }}
+                />
+                <BackTo.Bottom
+                  tooltip="去底部"
+                  shouldVisible={200}
+                  target={() =>
+                    containerRef.current?.scrollContainer as HTMLElement
+                  }
+                  style={{
+                    position: 'relative',
+                    bottom: 0,
+                    insetInlineEnd: 0,
+                  }}
+                />
+              </div>
               <TaskRunning
                 title={`任务已完成, 耗时03分00秒`}
                 taskStatus={TASK_STATUS.SUCCESS}

--- a/docs/demos/back-to.tsx
+++ b/docs/demos/back-to.tsx
@@ -67,11 +67,11 @@ export default () => {
         userMeta={userMeta}
       />
       <BackTo.Top
-        tooltip="回到顶部"
+        tooltip="去顶部"
         shouldVisible={() => true}
         style={{ insetInlineEnd: 64 }}
       />
-      <BackTo.Bottom tooltip="回到底部" shouldVisible={() => true} />
+      <BackTo.Bottom tooltip="去底部" shouldVisible={() => true} />
     </div>
   );
 };

--- a/src/components/ChatFlowContainer/index.tsx
+++ b/src/components/ChatFlowContainer/index.tsx
@@ -1,8 +1,8 @@
 import useAutoScroll from '@ant-design/md-editor/hooks/useAutoScroll';
 import { PanelLeftIcon, ShareIcon } from '@ant-design/md-editor/icons';
-import React from 'react';
+import React, { forwardRef, useImperativeHandle } from 'react';
 import { useStyle } from './style';
-import type { ChatFlowContainerProps } from './types';
+import type { ChatFlowContainerProps, ChatFlowContainerRef } from './types';
 
 const COMPONENT_NAME = 'chat-flow-container';
 
@@ -43,106 +43,118 @@ const COMPONENT_NAME = 'chat-flow-container';
  *
  * @returns {React.ReactElement} 渲染的对话流容器组件
  */
-const ChatFlowContainer: React.FC<ChatFlowContainerProps> = ({
-  title = 'AI 助手',
-  showLeftCollapse = true,
-  showRightCollapse = false,
-  showShare = true,
-  onLeftCollapse,
-  onRightCollapse,
-  onShare,
-  children,
-  footer,
-  className,
-  style,
-}) => {
-  const { wrapSSR, hashId } = useStyle(COMPONENT_NAME);
-  const { containerRef } = useAutoScroll({
-    SCROLL_TOLERANCE: 30,
-    onResize: () => {},
-    timeout: 200,
-  });
+const ChatFlowContainer = forwardRef<
+  ChatFlowContainerRef,
+  ChatFlowContainerProps
+>(
+  (
+    {
+      title = 'AI 助手',
+      showLeftCollapse = true,
+      showRightCollapse = false,
+      showShare = true,
+      onLeftCollapse,
+      onRightCollapse,
+      onShare,
+      children,
+      footer,
+      className,
+      style,
+    },
+    ref,
+  ) => {
+    const { wrapSSR, hashId } = useStyle(COMPONENT_NAME);
+    const { containerRef } = useAutoScroll({
+      SCROLL_TOLERANCE: 30,
+      onResize: () => {},
+      timeout: 200,
+    });
 
-  const handleLeftCollapse = () => {
-    onLeftCollapse?.();
-  };
+    const handleLeftCollapse = () => {
+      onLeftCollapse?.();
+    };
 
-  const handleRightCollapse = () => {
-    onRightCollapse?.();
-  };
+    const handleRightCollapse = () => {
+      onRightCollapse?.();
+    };
 
-  const handleShare = () => {
-    onShare?.();
-  };
+    const handleShare = () => {
+      onShare?.();
+    };
 
-  return wrapSSR(
-    <div
-      className={`${COMPONENT_NAME} ${hashId} ${className || ''}`}
-      style={style}
-    >
-      {/* 头部区域 */}
-      <div className={`${COMPONENT_NAME}-header ${hashId}`}>
-        {/* 左侧区域：标题和左侧折叠按钮 */}
-        <div className={`${COMPONENT_NAME}-header-left ${hashId}`}>
-          {showLeftCollapse && (
-            <button
-              className={`${COMPONENT_NAME}-header-left-collapse-btn ${hashId}`}
-              onClick={handleLeftCollapse}
-              aria-label="折叠左侧边栏"
-              type="button"
-            >
-              <PanelLeftIcon />
-            </button>
-          )}
-          <h1 className={`${COMPONENT_NAME}-header-left-title ${hashId}`}>
-            {title}
-          </h1>
+    useImperativeHandle(ref, () => ({
+      scrollContainer: containerRef.current,
+    }));
+
+    return wrapSSR(
+      <div
+        className={`${COMPONENT_NAME} ${hashId} ${className || ''}`}
+        style={style}
+      >
+        {/* 头部区域 */}
+        <div className={`${COMPONENT_NAME}-header ${hashId}`}>
+          {/* 左侧区域：标题和左侧折叠按钮 */}
+          <div className={`${COMPONENT_NAME}-header-left ${hashId}`}>
+            {showLeftCollapse && (
+              <button
+                className={`${COMPONENT_NAME}-header-left-collapse-btn ${hashId}`}
+                onClick={handleLeftCollapse}
+                aria-label="折叠左侧边栏"
+                type="button"
+              >
+                <PanelLeftIcon />
+              </button>
+            )}
+            <h1 className={`${COMPONENT_NAME}-header-left-title ${hashId}`}>
+              {title}
+            </h1>
+          </div>
+
+          {/* 右侧区域：分享按钮和右侧折叠按钮 */}
+          <div className={`${COMPONENT_NAME}-header-right ${hashId}`}>
+            {showShare && (
+              <button
+                className={`${COMPONENT_NAME}-header-right-share-btn ${hashId}`}
+                onClick={handleShare}
+                aria-label="分享对话"
+                type="button"
+              >
+                <ShareIcon />
+                &nbsp;分享
+              </button>
+            )}
+            {showRightCollapse && (
+              <button
+                className={`${COMPONENT_NAME}-header-right-collapse-btn ${hashId}`}
+                onClick={handleRightCollapse}
+                aria-label="折叠右侧边栏"
+                type="button"
+              >
+                <PanelLeftIcon />
+              </button>
+            )}
+          </div>
         </div>
 
-        {/* 右侧区域：分享按钮和右侧折叠按钮 */}
-        <div className={`${COMPONENT_NAME}-header-right ${hashId}`}>
-          {showShare && (
-            <button
-              className={`${COMPONENT_NAME}-header-right-share-btn ${hashId}`}
-              onClick={handleShare}
-              aria-label="分享对话"
-              type="button"
-            >
-              <ShareIcon />
-              &nbsp;分享
-            </button>
-          )}
-          {showRightCollapse && (
-            <button
-              className={`${COMPONENT_NAME}-header-right-collapse-btn ${hashId}`}
-              onClick={handleRightCollapse}
-              aria-label="折叠右侧边栏"
-              type="button"
-            >
-              <PanelLeftIcon />
-            </button>
-          )}
+        {/* 内容区域 */}
+        <div className={`${COMPONENT_NAME}-content ${hashId}`}>
+          <div
+            className={`${COMPONENT_NAME}-content-scrollable ${hashId}`}
+            ref={containerRef}
+          >
+            {children}
+          </div>
         </div>
-      </div>
 
-      {/* 内容区域 */}
-      <div className={`${COMPONENT_NAME}-content ${hashId}`}>
-        <div
-          className={`${COMPONENT_NAME}-content-scrollable ${hashId}`}
-          ref={containerRef}
-        >
-          {children}
-        </div>
-      </div>
-
-      {/* 底部区域 */}
-      {footer && (
-        <div className={`${COMPONENT_NAME}-footer ${hashId}`}>{footer}</div>
-      )}
-    </div>,
-  );
-};
+        {/* 底部区域 */}
+        {footer && (
+          <div className={`${COMPONENT_NAME}-footer ${hashId}`}>{footer}</div>
+        )}
+      </div>,
+    );
+  },
+);
 
 export default ChatFlowContainer;
-export type { ChatFlowContainerProps } from './types';
+export type { ChatFlowContainerProps, ChatFlowContainerRef } from './types';
 export { ChatFlowContainer };

--- a/src/components/ChatFlowContainer/style.ts
+++ b/src/components/ChatFlowContainer/style.ts
@@ -130,7 +130,6 @@ const genStyle: GenerateStyle<ChatTokenType> = (token) => {
           overflowY: 'auto',
           overflowX: 'hidden',
           padding: 'var(--padding-6x)',
-          scrollBehavior: 'smooth',
 
           '&::-webkit-scrollbar': {
             width: '6px',

--- a/src/components/ChatFlowContainer/types.ts
+++ b/src/components/ChatFlowContainer/types.ts
@@ -27,3 +27,7 @@ export interface ChatFlowContainerProps {
   /** 自定义样式 */
   style?: CSSProperties;
 }
+
+export interface ChatFlowContainerRef {
+  scrollContainer: HTMLDivElement | null;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 新功能
  * 在聊天流容器底部新增“返回顶部/底部”快捷控件，支持一键跳转到消息开头或结尾，提升长对话浏览效率。
* 样式
  * 优化底部区域布局以容纳新控件；移除强制平滑滚动，滚动动画改为遵循浏览器默认表现。
* 文档
  * 演示页改为动态生成多条示例消息，便于体验长列表场景；“返回顶部/底部”提示文案更新为“去顶部/去底部”。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->