### PR TITLE
feat: 新增自定义附件按钮 Popover 组件及示例

### DIFF
--- a/docs/components/attachment-button-custom-popover.md
+++ b/docs/components/attachment-button-custom-popover.md
@@ -1,0 +1,47 @@
+---
+title: AttachmentButton 自定义 Popover
+atomId: AttachmentButtonCustomPopover
+group:
+  title: 组件
+  order: 2
+---
+
+# 自定义附件按钮 Popover
+
+通过 `customPopover` 属性，您可以完全替换默认的 `AttachmentButtonPopover` 组件，实现自定义的附件按钮交互体验。
+
+## 代码演示
+
+<code src="../demos/markdownInputField/custom-attachment-popover.tsx" background="var(--main-bg-color)" iframe=800></code>
+
+## 属性定义
+
+## 基础用法
+
+### customPopover
+
+| 参数          | 说明                    | 类型                                                | 默认值 | 版本 |
+| ------------- | ----------------------- | --------------------------------------------------- | ------ | ---- |
+| customPopover | 自定义 Popover 组件函数 | `(props: CustomPopoverProps) => React.ReactElement` | -      | -    |
+
+### CustomPopoverProps
+
+| 参数            | 说明                                    | 类型                                              | 默认值 | 版本 |
+| --------------- | --------------------------------------- | ------------------------------------------------- | ------ | ---- |
+| children        | 需要包装的子元素，通常是 Paperclip 图标 | `React.ReactNode`                                 | -      | -    |
+| supportedFormat | 支持的文件格式配置                      | `AttachmentButtonPopoverProps['supportedFormat']` | -      | -    |
+
+### supportedFormat
+
+| 参数       | 说明                 | 类型              | 默认值 | 版本 |
+| ---------- | -------------------- | ----------------- | ------ | ---- |
+| type       | 文件类型名称         | `string`          | -      | -    |
+| maxSize    | 最大文件大小（KB）   | `number`          | -      | -    |
+| extensions | 支持的文件扩展名数组 | `string[]`        | -      | -    |
+| icon       | 文件类型图标         | `React.ReactNode` | -      | -    |
+
+## 兼容性
+
+- 完全向后兼容，不使用 `customPopover` 时保持原有行为
+- 支持所有现有的 `AttachmentButton` 属性
+- 可与其他附件配置选项（如 `supportedFormat`、`maxFileSize` 等）配合使用

--- a/docs/demos/markdownInputField/custom-attachment-popover.tsx
+++ b/docs/demos/markdownInputField/custom-attachment-popover.tsx
@@ -1,0 +1,297 @@
+import {
+  FileImageOutlined,
+  InfoCircleOutlined,
+  UploadOutlined,
+} from '@ant-design/icons';
+import type { AttachmentFile } from '@ant-design/md-editor';
+import { MarkdownInputField } from '@ant-design/md-editor';
+import {
+  Button,
+  Card,
+  Divider,
+  Modal,
+  Popover,
+  Space,
+  Tooltip,
+  message,
+} from 'antd';
+import React, { useState } from 'react';
+
+/**
+ * 自定义附件按钮 Popover 演示
+ */
+const CustomAttachmentPopoverDemo: React.FC = () => {
+  const [value, setValue] = useState('尝试点击不同样式的附件按钮来上传文件...');
+  const [fileMap, setFileMap] = useState<Map<string, AttachmentFile>>(
+    new Map(),
+  );
+
+  // 模拟文件上传
+  const handleUpload = async (file: AttachmentFile) => {
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    return `https://example.com/files/${file.name}`;
+  };
+
+  // 处理文件映射变化
+  const handleFileMapChange = (files?: Map<string, AttachmentFile>) => {
+    if (files) {
+      setFileMap(files);
+    }
+  };
+
+  // 示例1：简单的 Tooltip 替换
+  const SimpleTooltipPopover = ({ children, supportedFormat }: any) => (
+    <Tooltip
+      title={`点击上传${supportedFormat?.type || '文件'}`}
+      placement="top"
+    >
+      {children}
+    </Tooltip>
+  );
+
+  // 示例2：自定义 Popover 内容
+  const CustomContentPopover = ({ children, supportedFormat }: any) => {
+    const content = (
+      <div style={{ maxWidth: 200 }}>
+        <div style={{ marginBottom: 8, fontWeight: 'bold' }}>
+          <FileImageOutlined /> 上传{supportedFormat?.type || '文件'}
+        </div>
+        <div style={{ fontSize: 12, color: '#666' }}>
+          支持格式: {supportedFormat?.extensions?.join(', ')}
+        </div>
+        <div style={{ fontSize: 12, color: '#666', marginTop: 4 }}>
+          最大大小:{' '}
+          {supportedFormat?.maxSize ? `${supportedFormat.maxSize}KB` : '无限制'}
+        </div>
+        <Divider style={{ margin: '8px 0' }} />
+        <Button type="link" size="small" icon={<InfoCircleOutlined />}>
+          查看上传帮助
+        </Button>
+      </div>
+    );
+
+    return (
+      <Popover
+        content={content}
+        title="文件上传"
+        trigger="hover"
+        placement="topRight"
+      >
+        {children}
+      </Popover>
+    );
+  };
+
+  // 示例3：点击触发 Modal 的 Popover
+  const ModalTriggerPopover = ({ children, supportedFormat }: any) => {
+    const [isModalOpen, setIsModalOpen] = useState(false);
+
+    const handleClick = (e: React.MouseEvent) => {
+      e.stopPropagation();
+      setIsModalOpen(true);
+    };
+
+    return (
+      <>
+        <Tooltip title="点击打开上传向导">
+          <div
+            onClick={handleClick}
+            style={{ display: 'inline-block', cursor: 'pointer' }}
+          >
+            {children}
+          </div>
+        </Tooltip>
+        <Modal
+          title="文件上传向导"
+          open={isModalOpen}
+          onCancel={() => setIsModalOpen(false)}
+          footer={[
+            <Button key="cancel" onClick={() => setIsModalOpen(false)}>
+              取消
+            </Button>,
+            <Button
+              key="upload"
+              type="primary"
+              icon={<UploadOutlined />}
+              onClick={() => {
+                message.success('上传功能演示');
+                setIsModalOpen(false);
+              }}
+            >
+              选择文件上传
+            </Button>,
+          ]}
+        >
+          <Space direction="vertical" style={{ width: '100%' }}>
+            <Card size="small">
+              <div style={{ display: 'flex', alignItems: 'center' }}>
+                {supportedFormat?.icon}
+                <span style={{ marginLeft: 8 }}>
+                  支持{supportedFormat?.type || '文件'}格式
+                </span>
+              </div>
+            </Card>
+            <div>
+              <strong>支持的文件类型:</strong>
+              <div style={{ marginTop: 4 }}>
+                {supportedFormat?.extensions?.map((ext: string) => (
+                  <span
+                    key={ext}
+                    style={{
+                      display: 'inline-block',
+                      background: '#f0f0f0',
+                      padding: '2px 6px',
+                      borderRadius: 3,
+                      fontSize: 12,
+                      marginRight: 4,
+                      marginBottom: 4,
+                    }}
+                  >
+                    .{ext}
+                  </span>
+                ))}
+              </div>
+            </div>
+            <div>
+              <strong>文件大小限制:</strong>{' '}
+              {supportedFormat?.maxSize
+                ? `${supportedFormat.maxSize}KB`
+                : '无限制'}
+            </div>
+          </Space>
+        </Modal>
+      </>
+    );
+  };
+
+  // 示例4：彩色样式的 Popover
+  const ColorfulPopover = ({ children, supportedFormat }: any) => {
+    const content = (
+      <div
+        style={{
+          background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+          color: 'white',
+          padding: 12,
+          borderRadius: 8,
+          border: 'none',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', marginBottom: 8 }}>
+          {supportedFormat?.icon}
+          <span style={{ marginLeft: 8, fontWeight: 'bold' }}>
+            拖拽或点击上传{supportedFormat?.type}
+          </span>
+        </div>
+        <div style={{ fontSize: 12, opacity: 0.9 }}>
+          {supportedFormat?.extensions?.slice(0, 3).join(', ')}
+          {supportedFormat?.extensions?.length > 3 &&
+            ` 等${supportedFormat.extensions.length}种格式`}
+        </div>
+      </div>
+    );
+
+    return (
+      <Popover
+        content={content}
+        trigger="hover"
+        placement="top"
+        overlayInnerStyle={{ padding: 0 }}
+      >
+        {children}
+      </Popover>
+    );
+  };
+
+  return (
+    <div style={{ padding: 24 }}>
+      <h2>自定义附件按钮 Popover 演示</h2>
+      <p>
+        通过 <code>customPopover</code>{' '}
+        属性，您可以完全自定义附件按钮的交互体验。
+      </p>
+
+      <Space direction="vertical" size="large" style={{ width: '100%' }}>
+        {/* 默认样式 */}
+        <Card title="默认样式" size="small">
+          <MarkdownInputField
+            value={value}
+            onChange={setValue}
+            attachment={{
+              enable: true,
+              upload: handleUpload,
+              fileMap: fileMap,
+              onFileMapChange: handleFileMapChange,
+            }}
+            placeholder="默认的附件按钮样式..."
+          />
+        </Card>
+
+        {/* 简单 Tooltip */}
+        <Card title="简单 Tooltip 替换" size="small">
+          <MarkdownInputField
+            value={value}
+            onChange={setValue}
+            attachment={{
+              enable: true,
+              upload: handleUpload,
+              fileMap: fileMap,
+              onFileMapChange: handleFileMapChange,
+              customPopover: SimpleTooltipPopover,
+            }}
+            placeholder="使用简单 Tooltip 的附件按钮..."
+          />
+        </Card>
+
+        {/* 自定义内容 */}
+        <Card title="自定义 Popover 内容" size="small">
+          <MarkdownInputField
+            value={value}
+            onChange={setValue}
+            attachment={{
+              enable: true,
+              upload: handleUpload,
+              fileMap: fileMap,
+              onFileMapChange: handleFileMapChange,
+              customPopover: CustomContentPopover,
+            }}
+            placeholder="显示详细信息的附件按钮..."
+          />
+        </Card>
+
+        {/* Modal 触发器 */}
+        <Card title="Modal 上传向导" size="small">
+          <MarkdownInputField
+            value={value}
+            onChange={setValue}
+            attachment={{
+              enable: true,
+              upload: handleUpload,
+              fileMap: fileMap,
+              onFileMapChange: handleFileMapChange,
+              customPopover: ModalTriggerPopover,
+            }}
+            placeholder="点击附件按钮打开上传向导..."
+          />
+        </Card>
+
+        {/* 彩色样式 */}
+        <Card title="彩色样式 Popover" size="small">
+          <MarkdownInputField
+            value={value}
+            onChange={setValue}
+            attachment={{
+              enable: true,
+              upload: handleUpload,
+              fileMap: fileMap,
+              onFileMapChange: handleFileMapChange,
+              customPopover: ColorfulPopover,
+            }}
+            placeholder="彩色样式的附件按钮..."
+          />
+        </Card>
+      </Space>
+    </div>
+  );
+};
+
+export default CustomAttachmentPopoverDemo;

--- a/src/MarkdownInputField/AttachmentButton/index.tsx
+++ b/src/MarkdownInputField/AttachmentButton/index.tsx
@@ -64,6 +64,23 @@ export type AttachmentButtonProps = {
   disabled?: boolean;
 
   /**
+   * 自定义 Popover 组件，用于完全替换默认的 AttachmentButtonPopover
+   * @param children - 需要包装的子元素（通常是 Paperclip 图标）
+   * @param supportedFormat - 支持的文件格式配置
+   * @returns 自定义的 Popover 组件
+   * @example
+   * const CustomPopover = ({ children, supportedFormat }) => (
+   *   <Tooltip title="自定义上传提示">
+   *     {children}
+   *   </Tooltip>
+   * );
+   */
+  customPopover?: (props: {
+    children: React.ReactNode;
+    supportedFormat?: AttachmentButtonPopoverProps['supportedFormat'];
+  }) => React.ReactElement;
+
+  /**
    * 删除文件的回调函数
    * @param file - 被删除的文件对象
    * @example
@@ -176,13 +193,34 @@ export const upLoadFileToServer = async (
  * @param {(file: AttachmentFile) => Promise<string>} [props.upload] - 文件上传处理函数，返回文件URL的Promise
  * @param {Array<{icon: React.ReactNode, type: string, maxSize: number, extensions: string[]}>} [props.supportedFormats] - 支持的文件格式配置，
  *   如不提供则使用默认配置（包括图片、文档、音频、视频格式）
+ * @param {function} [props.customPopover] - 自定义 Popover 组件函数，用于完全替换默认的 AttachmentButtonPopover
  *
  * @example
+ * // 使用默认 Popover
  * ```tsx
  * <AttachmentButton
  *   fileMap={fileMap}
  *   onFileMapChange={handleFileMapChange}
  *   upload={uploadFileToServer}
+ * />
+ * ```
+ *
+ * @example
+ * // 使用自定义 Popover
+ * ```tsx
+ * const CustomPopover = ({ children, supportedFormat }) => (
+ *   <Tooltip title={`支持 ${supportedFormat?.type} 格式`}>
+ *     <div className="custom-attachment-wrapper">
+ *       {children}
+ *     </div>
+ *   </Tooltip>
+ * );
+ *
+ * <AttachmentButton
+ *   fileMap={fileMap}
+ *   onFileMapChange={handleFileMapChange}
+ *   upload={uploadFileToServer}
+ *   customPopover={CustomPopover}
  * />
  * ```
  *
@@ -217,9 +255,16 @@ export const AttachmentButton: React.FC<
       }}
       data-testid="attachment-button"
     >
-      <AttachmentButtonPopover supportedFormat={supportedFormat}>
-        <Paperclip />
-      </AttachmentButtonPopover>
+      {props.customPopover ? (
+        props.customPopover({
+          children: <Paperclip />,
+          supportedFormat: supportedFormat,
+        })
+      ) : (
+        <AttachmentButtonPopover supportedFormat={supportedFormat}>
+          <Paperclip />
+        </AttachmentButtonPopover>
+      )}
     </div>,
   );
 };


### PR DESCRIPTION
- 在 `AttachmentButton` 组件中添加 `customPopover` 属性，允许用户自定义 Popover 组件。
- 新增 `custom-attachment-popover` 示例，展示多种自定义 Popover 的用法，包括 Tooltip、Modal 触发器等。
- 更新文档，详细说明 `customPopover` 的用法及相关属性。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - AttachmentButton 新增 customPopover，支持以自定义气泡/弹层完全替换默认弹窗，可获取 children 与文件格式配置；与现有属性兼容，未提供时保持原行为。

- 文档
  - 新增自定义 AttachmentButton Popover 指南，包含函数签名、参数说明、supportedFormat 字段与兼容性说明。

- 示例
  - 新增多种自定义弹层示例：简单提示、富内容、模态向导、渐变样式等，含默认行为对比、模拟上传与格式展示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->