### PR TITLE
style(SkillModeBar): 调整布局对齐方式和标题高度-将容器改为顶部对齐，标题最小高度设置为 28px

### DIFF
--- a/src/MarkdownInputField/SkillModeBar/style.ts
+++ b/src/MarkdownInputField/SkillModeBar/style.ts
@@ -32,7 +32,6 @@ const genStyle: GenerateStyle<ChatTokenType> = (token) => {
       font: 'var(--font-text-h5-base)',
       letterSpacing: 'var(--letter-spacing-h5-base, normal)',
       color: 'var(--color-primary-control-fill-primary)',
-      lineHeight: '28px',
       minHeight: '28px',
     },
 


### PR DESCRIPTION
样式调整，左右侧区域改为顶部对齐，并设置title的最小高度

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **样式优化**
  * 调整了技能模式栏的布局对齐方式
  * 改进了标题元素的最小高度设置

<!-- end of auto-generated comment: release notes by coderabbit.ai -->