### PR TITLE
fix(MarkdownEditor): 仅在config存在时生成配置注释

### DIFF
--- a/src/MarkdownEditor/editor/parser/parserSlateNodeToMarkdown.ts
+++ b/src/MarkdownEditor/editor/parser/parserSlateNodeToMarkdown.ts
@@ -270,7 +270,8 @@ export const parserSlateNodeToMarkdown = (
 
       // 只有当 configProps 不为空对象时才生成注释
       if (Object.keys(configProps).length > 0) {
-        str += `<!--${JSON.stringify((node.type === 'chart' && configProps.config) ? configProps.config : configProps)}-->\n`;
+        const propsToSerialize = (node.type === 'chart' && configProps.config) ? configProps.config : configProps;
+        str += `<!--${JSON.stringify(propsToSerialize)}-->\n`;
       }
     }
     const p = parent.at(-1) || ({} as any);


### PR DESCRIPTION
## 📖 变更描述

简要描述此 PR 的目的和实现的功能。

## 🔧 变更类型

-  错误修复 (fix)


## 🧪 测试

- 手动测试验证功能正常

## 📸 截图/演示

无

## 🔗 相关 Issue

Closes #159 

## 📋 检查清单

- [ x ] 代码通过 lint 检查
- [ x ] 所有测试通过
- [ x ] 类型检查通过
- [ x ] 遵循项目代码规范
- [ x ] PR 标题符合规范

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 优化了 Markdown 编辑器中生成的注释：仅在存在非空配置时输出注释；当节点类型为图表且包含具体配置时，仅序列化该配置以减小注释体积；其他节点与不含配置的图表保持原有行为，确保兼容性并减少冗余信息。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->