### PR TITLE
fix: upload功能增加disabled属性

### DIFF
--- a/src/MarkdownInputField/SendActions/index.tsx
+++ b/src/MarkdownInputField/SendActions/index.tsx
@@ -139,7 +139,7 @@ export const SendActions: React.FC<SendActionsProps> = ({
           onFileMapChange={(fileMap) => {
             attachment?.onFileMapChange?.(fileMap);
           }}
-          disabled={!fileUploadDone}
+          disabled={!fileUploadDone || attachment?.disabled}
         />
       ) : null,
       voiceRecognizer ? (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 发布说明

## Bug Fixes
* 改进了附件上传按钮的状态管理，现在在文件上传未完成或附件被禁用时，附件按钮会正确保持禁用状态。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->