### PR TITLE
fix: 修复分组展示顺序错误问题

### DIFF
--- a/src/History/components/HistoryList.tsx
+++ b/src/History/components/HistoryList.tsx
@@ -80,21 +80,17 @@ export const generateHistoryItems = ({
     },
   );
 
+  const groupMaxTimes = Object.fromEntries(
+    Object.entries(groupList).map(([key, list]) => [
+      key,
+      Math.max(...list.map((item) => dayjs(item.gmtCreate).valueOf())),
+    ]),
+  );
+
   // 按照时间顺序对分组进行排序：今日 > 昨日 > 一周内 > 其他
-  const sortedGroupKeys = Object.keys(groupList).sort((keyA, keyB) => {
-    const listA = groupList[keyA];
-    const listB = groupList[keyB];
-
-    // 使用最新的时间戳进行比较
-    const timeA = Math.max(
-      ...listA.map((item) => dayjs(item.gmtCreate).valueOf()),
-    );
-    const timeB = Math.max(
-      ...listB.map((item) => dayjs(item.gmtCreate).valueOf()),
-    );
-
-    return timeB - timeA;
-  });
+  const sortedGroupKeys = Object.keys(groupList).sort(
+    (keyA, keyB) => (groupMaxTimes[keyB] || 0) - (groupMaxTimes[keyA] || 0),
+  );
 
   const items = sortedGroupKeys.map((key) => {
     const list = groupList[key];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复历史记录列表的分组排序逻辑：按每组内最新条目的时间从近到远排序，确保最近活动的组优先显示。
  * 保留既有条目渲染和首项标签格式化行为，排序变更仅影响组显示顺序，提升浏览效率与可发现性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->