### PR TITLE
chore: 更新浏览器插件sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@better-scroll/scroll-bar": "^2.5.1",
         "@galacean/effects": "^2.6.5",
         "@juggle/resize-observer": "^3.4.0",
-        "@schema-element-editor/host-sdk": "^2.1.0",
+        "@schema-element-editor/host-sdk": "^2.1.1",
         "@sofa-design/icons": "^1.6.1",
         "ace-builds": "^1.43.4",
         "ajv": "^8.17.1",
@@ -4707,9 +4707,9 @@
       }
     },
     "node_modules/@schema-element-editor/host-sdk": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@schema-element-editor/host-sdk/-/host-sdk-2.1.0.tgz",
-      "integrity": "sha512-TkJDEvmbNgbfcm2d9s46vU8u/XFzNJ3mRG3kG6v54pHaOCCzgPhpFasJA67i5dS+5jKdWkud4xF12mB0G/VVXA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@schema-element-editor/host-sdk/-/host-sdk-2.1.1.tgz",
+      "integrity": "sha512-EOJVj+CbIcceCHevUWCmjLFTeCUtWZOotuf1ysQGnpwASeHXPXZyXwn3tCpG+xD4nJ7WQ77axbP+4Ec45BIOBQ==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=17.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@better-scroll/scroll-bar": "^2.5.1",
     "@galacean/effects": "^2.6.5",
     "@juggle/resize-observer": "^3.4.0",
-    "@schema-element-editor/host-sdk": "^2.1.0",
+    "@schema-element-editor/host-sdk": "^2.1.1",
     "@sofa-design/icons": "^1.6.1",
     "ace-builds": "^1.43.4",
     "ajv": "^8.17.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^3.4.0
         version: 3.4.0
       '@schema-element-editor/host-sdk':
-        specifier: ^2.1.0
-        version: 2.1.0(react@18.3.1)
+        specifier: ^2.1.1
+        version: 2.1.1(react@18.3.1)
       '@sofa-design/icons':
         specifier: ^1.6.1
         version: 1.6.1(react@18.3.1)
@@ -272,7 +272,7 @@ importers:
         version: 4.5.3(eslint@8.57.1)(stylelint@14.16.1)(typescript@5.9.3)
       '@vitejs/plugin-react':
         specifier: ^4.7.0
-        version: 4.7.0(vite@5.4.21(@types/node@25.0.3)(less@4.4.2)(lightningcss@1.22.1)(sass@1.54.0)(terser@5.44.1))
+        version: 4.7.0(vite@5.4.21(@types/node@25.0.3)(less@4.4.2)(lightningcss@1.22.1)(sass@1.93.3)(terser@5.44.1))
       '@vitest/coverage-istanbul':
         specifier: ^2.1.9
         version: 2.1.9(vitest@2.1.9)
@@ -344,7 +344,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@25.0.3)(@vitest/ui@2.1.9)(jsdom@25.0.1)(less@4.4.2)(lightningcss@1.22.1)(sass@1.54.0)(terser@5.44.1)
+        version: 2.1.9(@types/node@25.0.3)(@vitest/ui@2.1.9)(jsdom@25.0.1)(less@4.4.2)(lightningcss@1.22.1)(sass@1.93.3)(terser@5.44.1)
 
 packages:
 
@@ -2126,8 +2126,8 @@ packages:
   '@rushstack/ts-command-line@4.21.0':
     resolution: {integrity: sha512-z38FLUCn8M9FQf19gJ9eltdwkvc47PxvJmVZS6aKwbBAa3Pis3r3A+ZcBCVPNb9h/Tbga+i0tHdzoSGUoji9GQ==}
 
-  '@schema-element-editor/host-sdk@2.1.0':
-    resolution: {integrity: sha512-TkJDEvmbNgbfcm2d9s46vU8u/XFzNJ3mRG3kG6v54pHaOCCzgPhpFasJA67i5dS+5jKdWkud4xF12mB0G/VVXA==}
+  '@schema-element-editor/host-sdk@2.1.1':
+    resolution: {integrity: sha512-EOJVj+CbIcceCHevUWCmjLFTeCUtWZOotuf1ysQGnpwASeHXPXZyXwn3tCpG+xD4nJ7WQ77axbP+4Ec45BIOBQ==}
     peerDependencies:
       react: '>=17.0.0'
       vue: '>=3.0.0'
@@ -11482,7 +11482,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@schema-element-editor/host-sdk@2.1.0(react@18.3.1)':
+  '@schema-element-editor/host-sdk@2.1.1(react@18.3.1)':
     optionalDependencies:
       react: 18.3.1
 
@@ -12654,7 +12654,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@25.0.3)(less@4.4.2)(lightningcss@1.22.1)(sass@1.54.0)(terser@5.44.1))':
+  '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@25.0.3)(less@4.4.2)(lightningcss@1.22.1)(sass@1.93.3)(terser@5.44.1))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
@@ -12662,7 +12662,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 5.4.21(@types/node@25.0.3)(less@4.4.2)(lightningcss@1.22.1)(sass@1.54.0)(terser@5.44.1)
+      vite: 5.4.21(@types/node@25.0.3)(less@4.4.2)(lightningcss@1.22.1)(sass@1.93.3)(terser@5.44.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -12678,7 +12678,7 @@ snapshots:
       magicast: 0.3.5
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.9(@types/node@25.0.3)(@vitest/ui@2.1.9)(jsdom@25.0.1)(less@4.4.2)(lightningcss@1.22.1)(sass@1.54.0)(terser@5.44.1)
+      vitest: 2.1.9(@types/node@25.0.3)(@vitest/ui@2.1.9)(jsdom@25.0.1)(less@4.4.2)(lightningcss@1.22.1)(sass@1.93.3)(terser@5.44.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -12689,13 +12689,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@25.0.3)(less@4.4.2)(lightningcss@1.22.1)(sass@1.54.0)(terser@5.44.1))':
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@25.0.3)(less@4.4.2)(lightningcss@1.22.1)(sass@1.93.3)(terser@5.44.1))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 5.4.21(@types/node@25.0.3)(less@4.4.2)(lightningcss@1.22.1)(sass@1.54.0)(terser@5.44.1)
+      vite: 5.4.21(@types/node@25.0.3)(less@4.4.2)(lightningcss@1.22.1)(sass@1.93.3)(terser@5.44.1)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -12725,7 +12725,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 1.2.0
-      vitest: 2.1.9(@types/node@25.0.3)(@vitest/ui@2.1.9)(jsdom@25.0.1)(less@4.4.2)(lightningcss@1.22.1)(sass@1.54.0)(terser@5.44.1)
+      vitest: 2.1.9(@types/node@25.0.3)(@vitest/ui@2.1.9)(jsdom@25.0.1)(less@4.4.2)(lightningcss@1.22.1)(sass@1.93.3)(terser@5.44.1)
 
   '@vitest/utils@2.1.9':
     dependencies:
@@ -20843,13 +20843,13 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-node@2.1.9(@types/node@25.0.3)(less@4.4.2)(lightningcss@1.22.1)(sass@1.54.0)(terser@5.44.1):
+  vite-node@2.1.9(@types/node@25.0.3)(less@4.4.2)(lightningcss@1.22.1)(sass@1.93.3)(terser@5.44.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 1.1.2
-      vite: 5.4.21(@types/node@25.0.3)(less@4.4.2)(lightningcss@1.22.1)(sass@1.54.0)(terser@5.44.1)
+      vite: 5.4.21(@types/node@25.0.3)(less@4.4.2)(lightningcss@1.22.1)(sass@1.93.3)(terser@5.44.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -20874,7 +20874,7 @@ snapshots:
       sass: 1.93.3
       terser: 5.44.1
 
-  vite@5.4.21(@types/node@25.0.3)(less@4.4.2)(lightningcss@1.22.1)(sass@1.54.0)(terser@5.44.1):
+  vite@5.4.21(@types/node@25.0.3)(less@4.4.2)(lightningcss@1.22.1)(sass@1.93.3)(terser@5.44.1):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
@@ -20884,13 +20884,13 @@ snapshots:
       fsevents: 2.3.3
       less: 4.4.2
       lightningcss: 1.22.1
-      sass: 1.54.0
+      sass: 1.93.3
       terser: 5.44.1
 
-  vitest@2.1.9(@types/node@25.0.3)(@vitest/ui@2.1.9)(jsdom@25.0.1)(less@4.4.2)(lightningcss@1.22.1)(sass@1.54.0)(terser@5.44.1):
+  vitest@2.1.9(@types/node@25.0.3)(@vitest/ui@2.1.9)(jsdom@25.0.1)(less@4.4.2)(lightningcss@1.22.1)(sass@1.93.3)(terser@5.44.1):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@25.0.3)(less@4.4.2)(lightningcss@1.22.1)(sass@1.54.0)(terser@5.44.1))
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@25.0.3)(less@4.4.2)(lightningcss@1.22.1)(sass@1.93.3)(terser@5.44.1))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -20906,8 +20906,8 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.1.1
       tinyrainbow: 1.2.0
-      vite: 5.4.21(@types/node@25.0.3)(less@4.4.2)(lightningcss@1.22.1)(sass@1.54.0)(terser@5.44.1)
-      vite-node: 2.1.9(@types/node@25.0.3)(less@4.4.2)(lightningcss@1.22.1)(sass@1.54.0)(terser@5.44.1)
+      vite: 5.4.21(@types/node@25.0.3)(less@4.4.2)(lightningcss@1.22.1)(sass@1.93.3)(terser@5.44.1)
+      vite-node: 2.1.9(@types/node@25.0.3)(less@4.4.2)(lightningcss@1.22.1)(sass@1.93.3)(terser@5.44.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.0.3


### PR DESCRIPTION
- Upgraded @schema-element-editor/host-sdk from 2.0.1 to 2.1.0.
- Updated slate and slate-react to version 0.120.0, and slate-dom to 0.119.0.
- Adjusted package-lock and pnpm-lock files to reflect these changes and ensure compatibility with the latest versions.
- Updated @types/node to 25.0.3 across various dependencies for improved type definitions.


SDK在2.1.0中增加了初始化&卸载时的sdk实例协调机制，以在同时存在多sdk实例时让插件可以正常工作。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 将第三方依赖 @schema-element-editor/host-sdk 的版本从 2.0.1 升级到 2.1.1，以获取兼容性改进与修复。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->