### PR TITLE
fix(SendButton): resolve fillOpacity animation warning by disabling i…

### DIFF
--- a/src/MarkdownInputField/SendButton/index.tsx
+++ b/src/MarkdownInputField/SendButton/index.tsx
@@ -37,6 +37,7 @@ function SendIcon(
         cx="50%"
         cy="50%"
         r="0.5em"
+        initial={false}
         animate={{
           fill: hover ? '#14161C' : '#001C39',
           fillOpacity: hover ? 1 : 0.03530000150203705,
@@ -50,6 +51,7 @@ function SendIcon(
         <motion.path
           d="M16.667 12.943l3.528 3.528a.667.667 0 00.943-.942l-4.666-4.667a.665.665 0 00-.943 0l-4.667 4.667a.667.667 0 10.943.942l3.528-3.528v7.724a.667.667 0 101.334 0v-7.724z"
           fillRule="evenodd"
+          initial={false}
           animate={{
             fill: hover ? '#fff' : '#00183D',
             fillOpacity: hover ? 1 : 0.24709999561309814,


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

> Fix console warning: `You are trying to animate fillOpacity from "undefined" to ...`

### 💡 需求背景和解决方案

**需求背景：**
在使用 `SendButton` 组件时（如在 `ChatBootPage` 或 `MarkdownInputField` 中），控制台会报出 `framer-motion` 的警告。这是因为组件挂载时，`framer-motion` 尝试读取 SVG 元素的 `fillOpacity` 初始值，但默认为 `undefined`，导致无法进行插值动画。
<img width="578" height="600" alt="image" src="https://github.com/user-attachments/assets/2ae29996-f918-45e4-b2dd-c9a0c33d3935" />


**解决方案：**
在 `SendButton` 组件内部的 `motion.circle` 和 `motion.path` 元素上添加 `initial={false}` 属性。
这指示 `framer-motion` 在组件挂载时直接应用 `animate` 中定义的目标状态，而不进行初始过渡，从而避免了从 `undefined` 开始动画的问题。

### 📝 更新日志

> - 郑重地阅读 [如何维护更新日志](https://keepachangelog.com/zh-CN/1.1.0/)
> - 描述改动对开发者有哪些影响，而非解决方式
> - 可参考：https://x.ant.design/changelog-cn

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix console warning about `fillOpacity` animation from "undefined" in SendButton. |
| 🇨🇳 中文 | 修复 SendButton 组件中 `fillOpacity` 动画初始值为 undefined 导致的控制台警告。 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 修复

* **Bug Fixes**
  * 修复了发送按钮在组件初始加载时的不必要动画问题。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->