### PR TITLE
fix(TagPopup): 修复连续选择下拉选项时抛出 'path' is null 错误

### DIFF
--- a/src/MarkdownEditor/editor/elements/index.tsx
+++ b/src/MarkdownEditor/editor/elements/index.tsx
@@ -280,14 +280,24 @@ const MLeafComponent = (
                     `${triggerText ?? '$'}${v}`,
                   ) || `${triggerText ?? '$'}${v}`;
 
+                // 使用 Point 而不是 Path 来避免 Slate 的 Range 转换问题
+                // 先删除节点的全部文本，再在起始位置插入新文本
+                const startPoint = Editor.start(markdownEditorRef.current, path);
+                const endPoint = Editor.end(markdownEditorRef.current, path);
+
+                // 删除节点的全部文本
+                Transforms.delete(markdownEditorRef.current, {
+                  at: { anchor: startPoint, focus: endPoint },
+                });
+
+                // 在节点起始位置插入新文本
                 Transforms.insertText(markdownEditorRef.current, newText, {
-                  at: path,
+                  at: startPoint,
                 });
 
                 Transforms.setNodes(
                   markdownEditorRef.current,
                   {
-                    text: newText,
                     tag: true,
                     code: true,
                     placeholder,


### PR DESCRIPTION
问题描述:
- 在 TagPopup 组件中，第一次选择下拉选项后内容正常回填
- 再次选择时: 内容被清空, 并且抛出错误: Cannot destructure property 'path' of 'at' as it is null ； 
- 问题如下图
![钉钉录屏_2026-01-15 001153](https://github.com/user-attachments/assets/db673480-c2dc-4dd6-bd2a-a43d0351030d)


根本原因:
原来的代码使用 Transforms.insertText(editor, newText, { at: path }) 直接传入 Path。 当 Slate 处理非空节点时，会将 Path 转换为覆盖整个节点的 Range，然后先删除
Range 内的文本再插入新文本。在这个过程中，pointRef.unref() 可能返回 null， 导致后续解构失败。

修复方案:
改用显式的 Point 操作:
1. 先获取节点的 startPoint 和 endPoint
2. 使用明确的 Range 调用 Transforms.delete 删除原有文本
3. 然后使用 startPoint 作为插入位置调用 Transforms.insertText

同时添加了测试用例:
- 测试连续多次选择下拉选项场景
- 测试节点已有内容时的选择场景
- 修复后效果如下图
![钉钉录屏_2026-01-15 001510](https://github.com/user-attachments/assets/85f084f2-0f22-4172-b843-57a75f185463)
