### PR TITLE
fix(SendActions): 移除 fileMap 对 isSendable 的影响

### DIFF
--- a/src/MarkdownInputField/SendActions/index.tsx
+++ b/src/MarkdownInputField/SendActions/index.tsx
@@ -184,7 +184,6 @@ export const SendActions: React.FC<SendActionsProps> = ({
         isSendable={
           allowEmptySubmit ||
           !!value?.trim() ||
-          (fileMap && fileMap.size > 0) ||
           recording
         }
         disabled={disabled}


### PR DESCRIPTION
isSendable 控制发送按钮的视觉状态（hover 高亮等），fileMap 有内容不应使按钮 显示为可发送状态，纯附件场景应由 allowEmptySubmit 控制，否则会出现只上传了文件但字符内容为空时候 ui 上已经启用了，send 的逻辑层却不能发送，两者不统一