### PR TITLE
fix(MarkdownEditor): prevent Backspace from clearing empty paragraph as full-doc delete

### DIFF
--- a/src/MarkdownEditor/editor/plugins/hotKeyCommands/__tests__/backspace.markdown.test.ts
+++ b/src/MarkdownEditor/editor/plugins/hotKeyCommands/__tests__/backspace.markdown.test.ts
@@ -341,6 +341,19 @@ describe('BackspaceKey - Markdown 输出测试', () => {
       expect(result).toBeUndefined();
     });
 
+    it('折叠选区在空段落时不应误判为全选并 deleteAll', () => {
+      editor.children = [{ type: 'paragraph', children: [{ text: '' }] }];
+      Transforms.select(editor, {
+        anchor: { path: [0, 0], offset: 0 },
+        focus: { path: [0, 0], offset: 0 },
+      });
+      const deleteAllSpy = vi.spyOn(EditorUtils, 'deleteAll');
+      const result = backspaceKey.range();
+      expect(result).toBe(false);
+      expect(deleteAllSpy).not.toHaveBeenCalled();
+      deleteAllSpy.mockRestore();
+    });
+
     it('应该在非全选时返回 false', () => {
       editor.children = [{ type: 'paragraph', children: [{ text: 'Test' }] }];
 

--- a/src/MarkdownEditor/editor/plugins/hotKeyCommands/backspace.ts
+++ b/src/MarkdownEditor/editor/plugins/hotKeyCommands/backspace.ts
@@ -3,13 +3,14 @@ import { Elements } from '../../../el';
 import { EditorUtils } from '../../utils/editorUtils';
 import { isListType } from '../withListsPlugin';
 
-
 export class BackspaceKey {
   constructor(private readonly editor: Editor) {}
 
   range() {
     const sel = this.editor.selection;
     if (!sel) return;
+    // 折叠选区下 start/end 与文档起止可能重合（如空段落），不能当作「全选」
+    if (!Range.isExpanded(sel)) return false;
     let [start, end] = Range.edges(sel);
     if (
       Point.equals(start, Editor.start(this.editor, [])) &&
@@ -266,7 +267,10 @@ export class BackspaceKey {
           }
 
           const nextPath = Path.next(path);
-          if (Editor.isEditor(parent[0]) && Editor.hasPath(this.editor, nextPath)) {
+          if (
+            Editor.isEditor(parent[0]) &&
+            Editor.hasPath(this.editor, nextPath)
+          ) {
             const [nextNode] = Editor.node(this.editor, nextPath);
             if ((nextNode as Record<string, unknown>)?.type !== 'hr') {
               Transforms.delete(this.editor, { at: path });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`BackspaceKey.range()` treated a **collapsed** selection on an **empty** document as “select entire document” because `Editor.start` and `Editor.end` coincide with the cursor. That triggered `EditorUtils.deleteAll`, so a single Backspace could wipe the input.

## Changes

- Only run the full-document delete path when the selection is **expanded** (`Range.isExpanded`).
- Add a regression test for collapsed selection on an empty paragraph.

## Testing

- `pnpm exec vitest run src/MarkdownEditor/editor/plugins/hotKeyCommands/__tests__/backspace.markdown.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83bdc78e-28c0-4d40-b7bd-641b3aceed05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83bdc78e-28c0-4d40-b7bd-641b3aceed05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

