### PR TITLE
fix(ChatLayout): auto-scroll on streaming text mutations, not only childList add

### DIFF
--- a/src/Hooks/useAutoScroll.tsx
+++ b/src/Hooks/useAutoScroll.tsx
@@ -141,15 +141,20 @@ export const useAutoScroll = <T extends HTMLDivElement>(
     if (!container) return;
 
     observer.current = new MutationObserver((mutations) => {
-      const hasAddedNodes = mutations.some((m) => m.addedNodes.length > 0);
-      if (hasAddedNodes) checkScroll?.();
+      const shouldCheck = mutations.some(
+        (m) =>
+          (m.addedNodes?.length ?? 0) > 0 ||
+          (m.removedNodes?.length ?? 0) > 0 ||
+          m.type === 'characterData',
+      );
+      if (shouldCheck) checkScroll?.();
     });
 
     observer.current.observe(container, {
       childList: true,
       subtree: true,
       attributes: false,
-      characterData: false,
+      characterData: true,
     });
 
     return () => observer.current?.disconnect();

--- a/tests/hooks/useAutoScroll.targeted-coverage.test.tsx
+++ b/tests/hooks/useAutoScroll.targeted-coverage.test.tsx
@@ -134,6 +134,49 @@ describe('useAutoScroll targeted coverage', () => {
     expect(div.scrollTo).toHaveBeenCalled();
   });
 
+  it('MutationObserver invokes checkScroll on characterData (streaming text updates)', () => {
+    let observerCallback: MutationCallback = () => {};
+    global.MutationObserver = vi.fn(function MockMutationObserver(callback: MutationCallback) {
+      observerCallback = callback;
+      return {
+        observe: mutationObserverObserve,
+        disconnect: mutationObserverDisconnect,
+        takeRecords: () => [],
+      };
+    });
+
+    const Wrapper = () => {
+      const { containerRef } = useAutoScroll({ timeout: 16 });
+      return (
+        <div
+          ref={containerRef as React.RefObject<HTMLDivElement>}
+          data-testid="scroll-container"
+          style={{ height: 50, overflow: 'auto' }}
+        />
+      );
+    };
+    const { container } = render(<Wrapper />);
+    const div = container.querySelector('[data-testid="scroll-container"]') as HTMLDivElement;
+    Object.defineProperty(div, 'scrollHeight', { value: 100, configurable: true });
+    Object.defineProperty(div, 'scrollTop', { value: 80, writable: true, configurable: true });
+    Object.defineProperty(div, 'clientHeight', { value: 50, configurable: true });
+    div.scrollTo = vi.fn();
+
+    expect(mutationObserverObserve).toHaveBeenCalled();
+
+    act(() => {
+      observerCallback(
+        [{ type: 'characterData' } as MutationRecord],
+        {} as MutationObserver,
+      );
+    });
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+
+    expect(div.scrollTo).toHaveBeenCalled();
+  });
+
   it('disconnect called on unmount', () => {
     const Wrapper = () => {
       const { containerRef } = useAutoScroll({ timeout: 16 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`ChatLayout` uses `useAutoScroll`, whose `MutationObserver` only reacted when `addedNodes.length > 0`. During streaming replies, the DOM often updates via **text node changes** (`characterData`) or **node removal** (e.g. removing a typing placeholder). Those mutations do not add nodes, so the list could finish without a final scroll-to-bottom.

## Solution

- Observe `characterData: true` (subtree).
- Trigger `checkScroll` when mutations include `characterData`, `removedNodes`, or `addedNodes`.
- Use optional chaining on `addedNodes` / `removedNodes` for defensive compatibility with partial test doubles.

## Tests

- `pnpm exec vitest run tests/hooks/useAutoScroll.targeted-coverage.test.tsx`

## Notes

`ThoughtChainList` and `Workspace/RealtimeFollow` also use `useAutoScroll`, so they benefit from the same fix.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83bdc78e-28c0-4d40-b7bd-641b3aceed05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83bdc78e-28c0-4d40-b7bd-641b3aceed05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

