### PR TITLE
fix(MarkdownEditor): sanitize invalid Slate children to prevent Node.string crash

### DIFF
--- a/src/MarkdownEditor/editor/plugins/__tests__/withSanitizeInvalidChildren.test.ts
+++ b/src/MarkdownEditor/editor/plugins/__tests__/withSanitizeInvalidChildren.test.ts
@@ -1,0 +1,32 @@
+import { createEditor, Editor, Node } from 'slate';
+import { withSanitizeInvalidChildren } from '../withSanitizeInvalidChildren';
+
+describe('withSanitizeInvalidChildren', () => {
+  it('strips undefined children so Node.string does not throw', () => {
+    const editor = withSanitizeInvalidChildren(createEditor());
+    editor.children = [
+      {
+        type: 'paragraph',
+        children: [{ text: '' }, undefined] as any,
+      },
+    ] as any;
+
+    Editor.normalize(editor, { force: true });
+
+    expect(editor.children[0].children).toEqual([{ text: '' }]);
+    expect(Node.string(editor.children[0] as Parameters<typeof Node.string>[0])).toBe(
+      '',
+    );
+  });
+
+  it('restores a default paragraph when editor root has no blocks', () => {
+    const editor = withSanitizeInvalidChildren(createEditor());
+    editor.children = [] as any;
+
+    Editor.normalize(editor, { force: true });
+
+    expect(editor.children).toEqual([
+      { type: 'paragraph', children: [{ text: '' }] },
+    ]);
+  });
+});

--- a/src/MarkdownEditor/editor/plugins/index.ts
+++ b/src/MarkdownEditor/editor/plugins/index.ts
@@ -5,5 +5,6 @@ export * from './withInlineNodes';
 export * from './withLinkAndMediaPlugin';
 export * from './withListsPlugin';
 export * from './withMarkdown';
+export * from './withSanitizeInvalidChildren';
 export * from './withSchemaPlugin';
 export * from './withVoidNodes';

--- a/src/MarkdownEditor/editor/plugins/withMarkdown.ts
+++ b/src/MarkdownEditor/editor/plugins/withMarkdown.ts
@@ -5,6 +5,7 @@ import { withInlineNodes } from './withInlineNodes';
 import { withLinkAndMediaPlugin } from './withLinkAndMediaPlugin';
 import { withListsPlugin } from './withListsPlugin';
 import { withSchemaPlugin } from './withSchemaPlugin';
+import { withSanitizeInvalidChildren } from './withSanitizeInvalidChildren';
 import { withVoidNodes } from './withVoidNodes';
 
 /**
@@ -25,10 +26,12 @@ import { withVoidNodes } from './withVoidNodes';
  * 插件按顺序应用，每个插件都会增强编辑器的特定功能。
  */
 export const withMarkdown = (editor: Editor) => {
-  return withCodeTagPlugin(
-    withSchemaPlugin(
-      withLinkAndMediaPlugin(
-        withCardPlugin(withListsPlugin(withVoidNodes(withInlineNodes(editor)))),
+  return withSanitizeInvalidChildren(
+    withCodeTagPlugin(
+      withSchemaPlugin(
+        withLinkAndMediaPlugin(
+          withCardPlugin(withListsPlugin(withVoidNodes(withInlineNodes(editor)))),
+        ),
       ),
     ),
   );

--- a/src/MarkdownEditor/editor/plugins/withSanitizeInvalidChildren.ts
+++ b/src/MarkdownEditor/editor/plugins/withSanitizeInvalidChildren.ts
@@ -1,0 +1,65 @@
+import { Editor, Node, NodeEntry, Transforms } from 'slate';
+
+const isValidChild = (child: unknown): child is Node =>
+  child !== undefined && child !== null && Node.isNode(child);
+
+const createDefaultBlock = () => ({
+  type: 'paragraph' as const,
+  children: [{ text: '' }],
+});
+
+const rebuildElement = (node: Node & { children: unknown[] }): Node => {
+  let children = node.children.filter(isValidChild) as Node[];
+  if (children.length === 0 && 'type' in node && (node as { type?: string }).type) {
+    children = [{ text: '' }];
+  }
+  const { children: _drop, ...rest } = node as Node & { children: unknown[] };
+  return { ...rest, children } as Node;
+};
+
+/**
+ * 外部或合并后的 value 可能在 `children` 中混入 `undefined` / `null`；
+ * Slate 的 `Node.string` 会对每个子节点调用 `Text.isText`，遇 `undefined` 即抛错。
+ * 在 normalize 最外层剔除非法子节点，避免编辑器与 toMarkdown 崩溃。
+ */
+export const withSanitizeInvalidChildren = (editor: Editor) => {
+  const { normalizeNode } = editor;
+
+  editor.normalizeNode = (entry: NodeEntry) => {
+    const [node, path] = entry;
+
+    if (Editor.isEditor(node) && path.length === 0) {
+      const hasInvalid = node.children.some((c) => !isValidChild(c));
+      if (hasInvalid) {
+        const clean = node.children.filter(isValidChild);
+        editor.children =
+          clean.length === 0 ? [createDefaultBlock()] : clean;
+        normalizeNode(entry);
+        return;
+      }
+      if (node.children.length === 0) {
+        editor.children = [createDefaultBlock()];
+        normalizeNode(entry);
+        return;
+      }
+      normalizeNode(entry);
+      return;
+    }
+
+    if (Node.isElement(node)) {
+      const hasInvalid = node.children.some((c) => !isValidChild(c));
+      if (hasInvalid) {
+        Editor.withoutNormalizing(editor, () => {
+          const rebuilt = rebuildElement(node);
+          Transforms.removeNodes(editor, { at: path, voids: true });
+          Transforms.insertNodes(editor, rebuilt, { at: path, voids: true });
+        });
+        return;
+      }
+    }
+
+    normalizeNode(entry);
+  };
+
+  return editor;
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Slate's `Text.isText` reads `node.text` without guarding against `undefined`. When `children` contains holes (e.g. `[{ text: '' }, undefined]`), `Node.string` crashes during serialization or editor normalization.

## Changes

- Add `withSanitizeInvalidChildren` as the outermost `withMarkdown` wrapper so normalization runs first.
- For the editor root: filter invalid top-level children; if empty after filter, insert a default paragraph.
- For elements with invalid children: replace the node with a rebuilt copy (valid children only; empty block elements get a single empty text leaf).
- Add unit tests covering undefined paragraph children and empty editor root.

## Notes

Upstream data or merges can still introduce invalid nodes; this keeps the editor resilient without changing public APIs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc674499-2278-481f-b6cb-1efb8c52ec2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc674499-2278-481f-b6cb-1efb8c52ec2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

