### PR TITLE
fix(MarkdownEditor): harden sanitize normalizer against invalid Slate trees

### DIFF
--- a/src/MarkdownEditor/editor/plugins/__tests__/withSanitizeInvalidChildren.test.ts
+++ b/src/MarkdownEditor/editor/plugins/__tests__/withSanitizeInvalidChildren.test.ts
@@ -51,4 +51,15 @@ describe('withSanitizeInvalidChildren', () => {
 
     expect((editor.children[1] as any).children).toEqual([{ text: '' }]);
   });
+
+  it('does not throw when normalizeNode runs on a text leaf', () => {
+    const editor = withSanitizeInvalidChildren(createEditor());
+    editor.children = [
+      { type: 'paragraph', children: [{ text: 'hi' }] },
+    ] as any;
+
+    expect(() =>
+      editor.normalizeNode([{ text: 'hi' }, [0, 0]] as any),
+    ).not.toThrow();
+  });
 });

--- a/src/MarkdownEditor/editor/plugins/__tests__/withSanitizeInvalidChildren.test.ts
+++ b/src/MarkdownEditor/editor/plugins/__tests__/withSanitizeInvalidChildren.test.ts
@@ -14,9 +14,9 @@ describe('withSanitizeInvalidChildren', () => {
     Editor.normalize(editor, { force: true });
 
     expect(editor.children[0].children).toEqual([{ text: '' }]);
-    expect(Node.string(editor.children[0] as Parameters<typeof Node.string>[0])).toBe(
-      '',
-    );
+    expect(
+      Node.string(editor.children[0] as Parameters<typeof Node.string>[0]),
+    ).toBe('');
   });
 
   it('restores a default paragraph when editor root has no blocks', () => {
@@ -28,5 +28,27 @@ describe('withSanitizeInvalidChildren', () => {
     expect(editor.children).toEqual([
       { type: 'paragraph', children: [{ text: '' }] },
     ]);
+  });
+
+  it('does not throw when editor.children is undefined', () => {
+    const editor = withSanitizeInvalidChildren(createEditor());
+    (editor as any).children = undefined;
+
+    expect(() => Editor.normalize(editor, { force: true })).not.toThrow();
+    expect(editor.children).toEqual([
+      { type: 'paragraph', children: [{ text: '' }] },
+    ]);
+  });
+
+  it('repairs element nodes with missing children array', () => {
+    const editor = withSanitizeInvalidChildren(createEditor());
+    editor.children = [
+      { type: 'paragraph', children: [{ text: 'ok' }] },
+      { type: 'paragraph' } as any,
+    ] as any;
+
+    Editor.normalize(editor, { force: true });
+
+    expect((editor.children[1] as any).children).toEqual([{ text: '' }]);
   });
 });

--- a/src/MarkdownEditor/editor/plugins/withListsPlugin.ts
+++ b/src/MarkdownEditor/editor/plugins/withListsPlugin.ts
@@ -53,8 +53,11 @@ export const withListsPlugin = (editor: Editor) => {
 
     // 规则 2: list-item 的子节点结构规范化
     if (Element.isElement(node) && node.type === 'list-item') {
+      const listItemChildren = Array.isArray(node.children)
+        ? node.children
+        : [];
       // 确保 list-item 至少有一个子节点
-      if (node.children.length === 0) {
+      if (listItemChildren.length === 0) {
         Transforms.insertNodes(
           editor,
           { type: 'paragraph', children: [{ text: '' }] },
@@ -64,7 +67,7 @@ export const withListsPlugin = (editor: Editor) => {
       }
 
       // 确保第一个子节点是块级元素（paragraph 或其他块级元素）
-      const firstChild = node.children[0];
+      const firstChild = listItemChildren[0];
       if (
         Element.isElement(firstChild) &&
         !Editor.isBlock(editor, firstChild) &&
@@ -81,8 +84,8 @@ export const withListsPlugin = (editor: Editor) => {
 
       // 确保 list-item 的子节点中，除了第一个块级元素外，其他都是列表类型
       // 允许的结构: [paragraph, bulleted-list?, numbered-list?]
-      for (let i = 1; i < node.children.length; i++) {
-        const child = node.children[i];
+      for (let i = 1; i < listItemChildren.length; i++) {
+        const child = listItemChildren[i];
         if (Element.isElement(child)) {
           if (!isListType(child)) {
             if (Editor.isBlock(editor, child)) {

--- a/src/MarkdownEditor/editor/plugins/withSanitizeInvalidChildren.ts
+++ b/src/MarkdownEditor/editor/plugins/withSanitizeInvalidChildren.ts
@@ -1,20 +1,116 @@
 import { Editor, Node, NodeEntry, Transforms } from 'slate';
+import { HistoryEditor } from 'slate-history';
+
+import { EditorUtils } from '../utils/editorUtils';
 
 const isValidChild = (child: unknown): child is Node =>
   child !== undefined && child !== null && Node.isNode(child);
+
+const getChildList = (node: Node): unknown[] => {
+  if (!('children' in node)) {
+    return [];
+  }
+  const { children } = node as { children?: unknown };
+  return Array.isArray(children) ? children : [];
+};
 
 const createDefaultBlock = () => ({
   type: 'paragraph' as const,
   children: [{ text: '' }],
 });
 
-const rebuildElement = (node: Node & { children: unknown[] }): Node => {
-  let children = node.children.filter(isValidChild) as Node[];
-  if (children.length === 0 && 'type' in node && (node as { type?: string }).type) {
+const rebuildElement = (node: Node): Node => {
+  let children = getChildList(node).filter(isValidChild) as Node[];
+  if (
+    children.length === 0 &&
+    'type' in node &&
+    (node as { type?: string }).type
+  ) {
     children = [{ text: '' }];
   }
-  const { children: _drop, ...rest } = node as Node & { children: unknown[] };
+  const { children: _drop, ...rest } = node as Node & { children?: unknown };
   return { ...rest, children } as Node;
+};
+
+const runWithoutHistory = (editor: Editor, fn: () => void) => {
+  if (HistoryEditor.isHistoryEditor(editor)) {
+    HistoryEditor.withoutSaving(editor, fn);
+  } else {
+    fn();
+  }
+};
+
+/**
+ * Slate 的 `Node.nodes` / `Editor.normalize` 在遍历时假定非文本节点必有数组型 `children`。
+ * 若仅有 `type` 而缺少 `children`，会在进入自定义 `normalizeNode` 之前就抛错，必须先修树。
+ */
+const rebuildOrDefaultBlock = (raw: unknown): Node => {
+  if (
+    raw &&
+    typeof raw === 'object' &&
+    !Node.isText(raw as Node) &&
+    typeof (raw as { type?: unknown }).type === 'string'
+  ) {
+    return rebuildElement(raw as Node);
+  }
+  return createDefaultBlock();
+};
+
+const repairBrokenChildArrays = (editor: Editor): boolean => {
+  if (!Array.isArray(editor.children)) {
+    /* eslint-disable no-param-reassign */
+    editor.children = [createDefaultBlock()];
+    /* eslint-enable no-param-reassign */
+    return true;
+  }
+
+  if (editor.children.length === 0) {
+    EditorUtils.replaceEditorContent(editor, [createDefaultBlock()]);
+    return true;
+  }
+
+  for (let i = 0; i < editor.children.length; i++) {
+    const child = editor.children[i];
+    if (!isValidChild(child)) {
+      /* eslint-disable no-param-reassign */
+      editor.children[i] = rebuildOrDefaultBlock(child);
+      /* eslint-enable no-param-reassign */
+      return true;
+    }
+  }
+
+  const fixBranch = (node: unknown): boolean => {
+    if (!node || typeof node !== 'object') {
+      return false;
+    }
+    if (Node.isText(node as Node)) {
+      return false;
+    }
+    const rawChildren = (node as { children?: unknown }).children;
+    if (!Array.isArray(rawChildren)) {
+      Object.assign(node as object, rebuildElement(node as Node));
+      return true;
+    }
+    if (rawChildren.some((c) => !isValidChild(c))) {
+      const fixedChildren = rawChildren.filter(isValidChild) as Node[];
+      (node as { children: Node[] }).children =
+        fixedChildren.length === 0 ? [{ text: '' }] : fixedChildren;
+      return true;
+    }
+    for (let i = 0; i < rawChildren.length; i++) {
+      if (fixBranch(rawChildren[i])) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  for (let i = 0; i < editor.children.length; i++) {
+    if (fixBranch(editor.children[i])) {
+      return true;
+    }
+  }
+  return false;
 };
 
 /**
@@ -23,22 +119,30 @@ const rebuildElement = (node: Node & { children: unknown[] }): Node => {
  * 在 normalize 最外层剔除非法子节点，避免编辑器与 toMarkdown 崩溃。
  */
 export const withSanitizeInvalidChildren = (editor: Editor) => {
-  const { normalizeNode } = editor;
+  const { normalizeNode, normalize } = editor;
+
+  editor.normalize = (options?: Parameters<Editor['normalize']>[0]) => {
+    let guard = 0;
+    while (guard < 100 && repairBrokenChildArrays(editor)) {
+      guard += 1;
+    }
+    return normalize.call(editor, options);
+  };
 
   editor.normalizeNode = (entry: NodeEntry) => {
     const [node, path] = entry;
 
     if (Editor.isEditor(node) && path.length === 0) {
-      const hasInvalid = node.children.some((c) => !isValidChild(c));
-      if (hasInvalid) {
-        const clean = node.children.filter(isValidChild);
-        editor.children =
-          clean.length === 0 ? [createDefaultBlock()] : clean;
-        normalizeNode(entry);
-        return;
-      }
-      if (node.children.length === 0) {
-        editor.children = [createDefaultBlock()];
+      const childList = getChildList(node);
+      const hasInvalid = childList.some((c) => !isValidChild(c));
+      if (hasInvalid || childList.length === 0) {
+        const nextNodes =
+          childList.length === 0
+            ? [createDefaultBlock()]
+            : (childList.map((c) =>
+                isValidChild(c) ? c : rebuildOrDefaultBlock(c),
+              ) as Node[]);
+        EditorUtils.replaceEditorContent(editor, nextNodes);
         normalizeNode(entry);
         return;
       }
@@ -46,14 +150,27 @@ export const withSanitizeInvalidChildren = (editor: Editor) => {
       return;
     }
 
+    if (!Editor.isEditor(node) && !Node.isText(node)) {
+      const rawChildren = (node as { children?: unknown }).children;
+      if (!Array.isArray(rawChildren)) {
+        Object.assign(node as object, rebuildElement(node as Node));
+        normalizeNode(entry);
+        return;
+      }
+    }
+
     if (Node.isElement(node)) {
-      const hasInvalid = node.children.some((c) => !isValidChild(c));
+      const childList = getChildList(node);
+      const hasInvalid = childList.some((c) => !isValidChild(c));
       if (hasInvalid) {
-        Editor.withoutNormalizing(editor, () => {
-          const rebuilt = rebuildElement(node);
-          Transforms.removeNodes(editor, { at: path, voids: true });
-          Transforms.insertNodes(editor, rebuilt, { at: path, voids: true });
-        });
+        const applyRebuild = () => {
+          Editor.withoutNormalizing(editor, () => {
+            const rebuilt = rebuildElement(node);
+            Transforms.removeNodes(editor, { at: path, voids: true });
+            Transforms.insertNodes(editor, rebuilt, { at: path, voids: true });
+          });
+        };
+        runWithoutHistory(editor, applyRebuild);
         return;
       }
     }

--- a/src/MarkdownEditor/editor/plugins/withSanitizeInvalidChildren.ts
+++ b/src/MarkdownEditor/editor/plugins/withSanitizeInvalidChildren.ts
@@ -132,6 +132,12 @@ export const withSanitizeInvalidChildren = (editor: Editor) => {
   editor.normalizeNode = (entry: NodeEntry) => {
     const [node, path] = entry;
 
+    // `Node.isNode` is true for text leaves, but they have no `children`; never call `.some` on them.
+    if (Node.isText(node)) {
+      normalizeNode(entry);
+      return;
+    }
+
     if (Editor.isEditor(node) && path.length === 0) {
       const childList = getChildList(node);
       const hasInvalid = childList.some((c) => !isValidChild(c));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes runtime `TypeError: Cannot read properties of undefined (reading 'some' | 'length')` when the editor receives corrupted Slate values (e.g. `editor.children` undefined, element nodes with `children: undefined`, or invalid entries in `children` arrays).

Also fixes a follow-up: `normalizeNode` must not assume `node.children` exists when `node` is a **text leaf** (`Node.isNode` is true for `{ text: '' }` but text nodes have no `children`). Early-return with `Node.isText` and delegate to the inner normalizer.

## Root cause

- `withSanitizeInvalidChildren` called `.some` on `node.children` without guarding when `children` was missing.
- Slate's `Editor.normalize({ force: true })` walks the tree with `Node.nodes` **before** custom `normalizeNode` runs; nodes that are not valid elements but still have a `children` key set to `undefined` hit Slate's default `normalizeNode`, which does `element.children.length` and throws.
- Replacing invalid top-level blocks by filtering `Node.isNode` could drop partially-valid `{ type }` stubs and briefly leave the document in a bad shape.
- Text leaves can receive `normalizeNode([text, path])`; using `Node.isNode` + `children.some` is invalid for them.

## Changes

- Pre-repair the tree inside a wrapped `editor.normalize` (root + descendants) so `Node.nodes` never sees `children` that is not an array.
- For hostile non-text nodes with non-array `children`, merge a rebuilt node before delegating to the inner `normalizeNode`.
- Use `EditorUtils.replaceEditorContent` for root replacement; map invalid top-level children through `rebuildOrDefaultBlock` instead of dropping them.
- Wrap sanitize rebuild transforms with `HistoryEditor.withoutSaving` when available.
- Harden `withListsPlugin` `list-item` handling when `children` is not an array.
- Add tests for `editor.children === undefined`, paragraph without `children`, and `normalizeNode` on a text leaf.

## Testing

- `pnpm exec vitest run src/MarkdownEditor/editor/plugins/__tests__/withSanitizeInvalidChildren.test.ts`
- `pnpm exec vitest run src/MarkdownEditor/editor/plugins/__tests__/withListsPlugin.test.ts`
- `pnpm exec tsc --noEmit`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35706d67-1d2f-444c-949e-c18e21328f69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35706d67-1d2f-444c-949e-c18e21328f69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

