### PR TITLE
fix(MarkdownEditor): repair sparse Slate children before renderLeaf crashes

### DIFF
--- a/src/MarkdownEditor/editor/plugins/__tests__/withSanitizeInvalidChildren.test.ts
+++ b/src/MarkdownEditor/editor/plugins/__tests__/withSanitizeInvalidChildren.test.ts
@@ -19,6 +19,39 @@ describe('withSanitizeInvalidChildren', () => {
     ).toBe('');
   });
 
+  it('compacts sparse children arrays (holes) so Node.string does not throw', () => {
+    const editor = withSanitizeInvalidChildren(createEditor());
+    const paragraph = {
+      type: 'paragraph',
+      children: [{ text: '' }],
+    } as any;
+    paragraph.children.length = 2;
+
+    editor.children = [paragraph] as any;
+
+    Editor.normalize(editor, { force: true });
+
+    expect(editor.children[0].children).toEqual([{ text: '' }]);
+    expect(
+      Node.string(editor.children[0] as Parameters<typeof Node.string>[0]),
+    ).toBe('');
+  });
+
+  it('compacts sparse editor root without duplicating blocks', () => {
+    const editor = withSanitizeInvalidChildren(createEditor());
+    const root = [
+      { type: 'paragraph', children: [{ text: 'a' }] },
+    ] as any;
+    root.length = 2;
+    editor.children = root;
+
+    Editor.normalize(editor, { force: true });
+
+    expect(editor.children).toEqual([
+      { type: 'paragraph', children: [{ text: 'a' }] },
+    ]);
+  });
+
   it('restores a default paragraph when editor root has no blocks', () => {
     const editor = withSanitizeInvalidChildren(createEditor());
     editor.children = [] as any;

--- a/src/MarkdownEditor/editor/plugins/withSanitizeInvalidChildren.ts
+++ b/src/MarkdownEditor/editor/plugins/withSanitizeInvalidChildren.ts
@@ -6,6 +6,19 @@ import { EditorUtils } from '../utils/editorUtils';
 const isValidChild = (child: unknown): child is Node =>
   child !== undefined && child !== null && Node.isNode(child);
 
+/**
+ * `Array.prototype.some` skips sparse holes; Slate still sees missing indices and
+ * can pass `undefined` as `leaf` into `renderLeaf`, which then throws in `Text.isText`.
+ */
+const childArrayHasInvalidEntries = (rawChildren: unknown[]): boolean => {
+  for (let i = 0; i < rawChildren.length; i += 1) {
+    if (!(i in rawChildren) || !isValidChild(rawChildren[i])) {
+      return true;
+    }
+  }
+  return false;
+};
+
 const getChildList = (node: Node): unknown[] => {
   if (!('children' in node)) {
     return [];
@@ -57,6 +70,26 @@ const rebuildOrDefaultBlock = (raw: unknown): Node => {
   return createDefaultBlock();
 };
 
+/** 压缩根级子节点：去掉空洞与 null/undefined；残缺元素对象则 rebuild，不凭空多插空段落。 */
+const compactEditorRootChildren = (raw: unknown[]): Node[] => {
+  const out: Node[] = [];
+  for (let i = 0; i < raw.length; i += 1) {
+    if (!(i in raw)) {
+      continue;
+    }
+    const c = raw[i];
+    if (isValidChild(c)) {
+      out.push(c);
+      continue;
+    }
+    if (c === undefined || c === null) {
+      continue;
+    }
+    out.push(rebuildOrDefaultBlock(c));
+  }
+  return out;
+};
+
 const repairBrokenChildArrays = (editor: Editor): boolean => {
   if (!Array.isArray(editor.children)) {
     /* eslint-disable no-param-reassign */
@@ -70,14 +103,16 @@ const repairBrokenChildArrays = (editor: Editor): boolean => {
     return true;
   }
 
-  for (let i = 0; i < editor.children.length; i++) {
-    const child = editor.children[i];
-    if (!isValidChild(child)) {
+  if (childArrayHasInvalidEntries(editor.children)) {
+    const fixedRoot = compactEditorRootChildren(editor.children);
+    if (fixedRoot.length === 0) {
+      EditorUtils.replaceEditorContent(editor, [createDefaultBlock()]);
+    } else {
       /* eslint-disable no-param-reassign */
-      editor.children[i] = rebuildOrDefaultBlock(child);
+      editor.children = fixedRoot;
       /* eslint-enable no-param-reassign */
-      return true;
     }
+    return true;
   }
 
   const fixBranch = (node: unknown): boolean => {
@@ -93,7 +128,7 @@ const repairBrokenChildArrays = (editor: Editor): boolean => {
       Object.assign(node as object, rebuildElement(node as Node));
       return true;
     }
-    if (rawChildren?.some((c) => !isValidChild(c))) {
+    if (childArrayHasInvalidEntries(rawChildren)) {
       const fixedChildren = rawChildren.filter(isValidChild) as Node[];
       (node as { children: Node[] }).children =
         fixedChildren.length === 0 ? [{ text: '' }] : fixedChildren;
@@ -143,14 +178,11 @@ export const withSanitizeInvalidChildren = (editor: Editor) => {
 
     if (Editor.isEditor(node) && path.length === 0) {
       const childList = getChildList(node);
-      const hasInvalid = childList.some((c) => !isValidChild(c));
+      const hasInvalid = childArrayHasInvalidEntries(childList);
       if (hasInvalid || childList.length === 0) {
+        const fixedTop = compactEditorRootChildren(childList);
         const nextNodes =
-          childList.length === 0
-            ? [createDefaultBlock()]
-            : (childList.map((c) =>
-                isValidChild(c) ? c : rebuildOrDefaultBlock(c),
-              ) as Node[]);
+          fixedTop.length === 0 ? [createDefaultBlock()] : fixedTop;
         EditorUtils.replaceEditorContent(editor, nextNodes);
         normalizeNode(entry);
         return;
@@ -172,7 +204,7 @@ export const withSanitizeInvalidChildren = (editor: Editor) => {
     //@ts-ignore
     if (Node.isElement(node)) {
       const childList = getChildList(node);
-      const hasInvalid = childList.some((c) => !isValidChild(c));
+      const hasInvalid = childArrayHasInvalidEntries(childList);
       if (hasInvalid) {
         const applyRebuild = () => {
           Editor.withoutNormalizing(editor, () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Slate-react 在渲染叶子时若 `children` 为**稀疏数组**（`length` 变大但存在空洞），`Array.prototype.some` 会跳过空洞，导致 `withSanitizeInvalidChildren` 误判为「合法」而不修复；随后 `renderLeaf` 可能收到 `undefined` 的 `leaf`，在 `Text.isText` 处抛出 `Cannot read properties of undefined (reading 'text')`。

## Changes

- 用按索引遍历的 `childArrayHasInvalidEntries` 检测空洞与非法项（替代仅靠 `some`）。
- 根级 `editor.children` 修复时通过 `compactEditorRootChildren`：**跳过空洞与 `null`/`undefined`**，避免把空洞误当成需插入的默认段落，从而不产生多余空块；仍对残缺元素对象走 `rebuildElement`。
- 补充单测：稀疏段落 `children`、稀疏根 `children`。

## Test plan

- `pnpm exec vitest run src/MarkdownEditor/editor/plugins/__tests__/withSanitizeInvalidChildren.test.ts`

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-513ec440-6aff-45a2-ab2b-c84e54cb9283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-513ec440-6aff-45a2-ab2b-c84e54cb9283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

