### PR TITLE
fix(Mermaid): correct SVG sizing so fit-to-viewport keeps Chinese labels readable

### DIFF
--- a/src/Plugins/mermaid/style.ts
+++ b/src/Plugins/mermaid/style.ts
@@ -103,9 +103,11 @@ const genStyle: GenerateStyle<ChatTokenType> = (token) => {
       },
 
       '& [data-mermaid-svg="true"]': {
-        maxWidth: '100%',
+        display: 'block',
+        maxWidth: 'none',
+        width: 'auto',
         height: 'auto',
-        overflow: 'hidden',
+        overflow: 'visible',
       },
 
       '&-error': {

--- a/src/Plugins/mermaid/utils.ts
+++ b/src/Plugins/mermaid/utils.ts
@@ -259,8 +259,10 @@ export const renderSvgToContainer = (
 
   if (svgElement) {
     const existingStyle = svgElement.getAttribute('style') || '';
+    // Do not set max-width: 100% — it shrinks the SVG in the DOM and breaks
+    // fit-to-viewport math (viewBox vs clientWidth). Pan/zoom uses transform scale.
     const newStyle =
-      `${existingStyle}; max-width: 100%; height: auto; overflow: hidden;`.trim();
+      `${existingStyle}; display: block; max-width: none; width: auto; height: auto; overflow: visible;`.trim();
     svgElement.setAttribute('style', newStyle);
     svgElement.setAttribute('data-mermaid-svg', 'true');
     svgElement.setAttribute(
@@ -283,7 +285,7 @@ export const renderSvgToContainer = (
     if (extractedSvg) {
       extractedSvg.setAttribute(
         'style',
-        'max-width: 100%; height: auto; overflow: hidden;',
+        'display: block; max-width: none; width: auto; height: auto; overflow: visible;',
       );
       extractedSvg.setAttribute('data-mermaid-svg', 'true');
       wrapper.appendChild(extractedSvg);

--- a/tests/plugins/mermaid/utils.test.ts
+++ b/tests/plugins/mermaid/utils.test.ts
@@ -171,7 +171,7 @@ describe('Mermaid utils', () => {
 
       const svgEl = container.querySelector('svg[data-mermaid-svg]');
       expect(svgEl).toBeTruthy();
-      expect(svgEl?.getAttribute('style')).toContain('max-width: 100%');
+      expect(svgEl?.getAttribute('style')).toContain('max-width: none');
 
       global.DOMParser = OriginalParser;
     });
@@ -185,7 +185,7 @@ describe('Mermaid utils', () => {
       await new Promise((resolve) => requestAnimationFrame(resolve));
 
       const svgElement = container.querySelector('svg');
-      expect(svgElement?.getAttribute('style')).toContain('max-width: 100%');
+      expect(svgElement?.getAttribute('style')).toContain('max-width: none');
       expect(svgElement?.getAttribute('class')).toContain('mermaid-isolated');
       expect(svgElement?.getAttribute('data-mermaid-svg')).toBe('true');
     });

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,5 @@
+# 任务记录
+
+- [x] 定位 Mermaid 适配画布时尺寸与文字过小原因
+- [x] 移除 SVG 上 `max-width: 100%` 与冲突样式，修正 `renderSvgToContainer` 与 `style.ts`
+- [x] 更新相关单测并通过 `vitest run` 指定文件


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Mermaid flowcharts (e.g. `flowchart LR` with long Chinese node labels) appeared too small because the rendered SVG had `max-width: 100%` while `handleFitToScreen` already scales using `viewBox` natural dimensions. The CSS constraint shrank the DOM size again, so the effective scale was wrong and text was hard to read.

## Changes

- Stop injecting `max-width: 100%` on the Mermaid SVG in `renderSvgToContainer`; use intrinsic width with pan/zoom transform instead.
- Align `[data-mermaid-svg]` styles in the plugin stylesheet with the same approach.
- Update unit test expectations in `tests/plugins/mermaid/utils.test.ts`.

## Testing

`pnpm exec vitest run tests/plugins/mermaid/utils.test.ts src/Plugins/mermaid/__tests__/utils.test.ts tests/plugins/mermaid/MermaidRendererImpl.test.tsx`

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8010a64-fd78-4752-8d8a-4087ed325459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8010a64-fd78-4752-8d8a-4087ed325459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

