### PR TITLE
fix(demos): stabilize rerender bubble demo list keys and memoize props

### DIFF
--- a/docs/demos/bubble/rerender-bubble-demo.tsx
+++ b/docs/demos/bubble/rerender-bubble-demo.tsx
@@ -7,7 +7,7 @@ import {
   ReloadOutlined,
 } from '@ant-design/icons';
 import { Button, Radio, Space } from 'antd';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { RERENDER_CARD_APPENDIX } from '../shared/rerenderCardAppendix';
 
 const rerenderDemoMarkdown = `> 用户再次要求基于中国 10 年的 GDP 数据，用 markdown 语法绘制图表展示 2020-2026 年 GDP 增长情况。这个请求我已经回答过很多次了，我应该提供一致的回复。
@@ -105,6 +105,25 @@ const splitBlocks = (text: string): string[] => {
   return blocks;
 };
 
+const STATIC_INTRO_AVATAR =
+  'https://mdn.alipayobjects.com/huamei_re70wt/afts/img/A*ed7ZTbwtgIQAAAAAQOAAAAgAemuEAQ/original';
+
+/** 与流式气泡 id 必须不同，否则 BubbleList 内 React key 冲突会导致整列表异常重挂载 */
+const STATIC_INTRO_BUBBLE: MessageBubbleData = {
+  id: 'rerender-bubble-intro',
+  role: 'assistant',
+  content:
+    '下面模拟 **流式追加**：未完成前保持 `isFinished: false`，结束时再置为 `true` 以配合队列与动画策略。',
+  createAt: 1,
+  updateAt: 1,
+  isFinished: false,
+  meta: {
+    avatar: STATIC_INTRO_AVATAR,
+    title: 'MarkdownRenderer · Bubble',
+    description: 'MarkdownRenderer · 流式',
+  },
+};
+
 const createInitialMessage = (): MessageBubbleData => ({
   id: 'rerender-bubble-stream',
   role: 'assistant',
@@ -113,8 +132,7 @@ const createInitialMessage = (): MessageBubbleData => ({
   updateAt: Date.now(),
   isFinished: false,
   meta: {
-    avatar:
-      'https://mdn.alipayobjects.com/huamei_re70wt/afts/img/A*ed7ZTbwtgIQAAAAAQOAAAAgAemuEAQ/original',
+    avatar: STATIC_INTRO_AVATAR,
     title: 'MarkdownRenderer · Bubble',
     description: '流式演示',
   },
@@ -257,6 +275,20 @@ const RerenderBubbleDemo = () => {
     };
   }, [restartKey]);
 
+  const markdownRenderConfig = useMemo(
+    () => ({
+      renderMode: 'markdown' as const,
+      queueOptions: { animate: false },
+      streamingParagraphAnimation: false,
+    }),
+    [],
+  );
+
+  const bubbleListData = useMemo(
+    () => [{ ...STATIC_INTRO_BUBBLE }, message],
+    [message],
+  );
+
   return (
     <div
       style={{
@@ -307,30 +339,8 @@ const RerenderBubbleDemo = () => {
 
       <div style={{ background: '#fff', borderRadius: 8, padding: 16 }}>
         <BubbleList
-          bubbleList={[
-            {
-              id: 'rerender-bubble-stream',
-              role: 'assistant',
-              content:
-                '下面模拟 **流式追加**：未完成前保持 `isFinished: false`，结束时再置为 `true` 以配合队列与动画策略。',
-              createAt: Date.now(),
-              updateAt: Date.now(),
-              isFinished: false,
-              meta: {
-                avatar:
-                  'https://mdn.alipayobjects.com/huamei_re70wt/afts/img/A*ed7ZTbwtgIQAAAAAQOAAAAgAemuEAQ/original',
-                title: 'MarkdownRenderer · Bubble',
-                description: 'MarkdownRenderer · 流式',
-              },
-            },
-            message,
-          ]}
-          markdownRenderConfig={{
-            renderMode: 'markdown',
-            queueOptions: { animate: false },
-            // 与旧版一致：未传时曾无末段段落淡入；若需关闭请显式 false
-            streamingParagraphAnimation: false,
-          }}
+          bubbleList={bubbleListData}
+          markdownRenderConfig={markdownRenderConfig}
           shouldShowCopy={false}
         />
       </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In `docs/demos/bubble/rerender-bubble-demo.tsx`, both bubbles used the same `id: 'rerender-bubble-stream'`. `BubbleList` uses `item.id` as the React `key` when stable loading keys do not apply, so **duplicate keys** caused incorrect reconciliation: the whole list could remount or behave as if “the whole page” re-rendered during streaming.

The intro bubble also used `Date.now()` for `createAt`/`updateAt` on every parent render, producing a **new object identity** each tick even when only the streaming bubble changed.

## Fix

- Give the static intro bubble a distinct id (`rerender-bubble-intro`) vs the streaming one (`rerender-bubble-stream`).
- Hoist intro copy/meta to a module constant; pass `[{ ...STATIC_INTRO_BUBBLE }, message]` from `useMemo` so the intro row is a fresh shallow copy (BubbleList mutates `isLatest`/`isLast` on items) without rebuilding unrelated fields each frame.
- Memoize `markdownRenderConfig` so `BubbleList`’s memo deps stay stable.

## Testing

Docs-only change; ESLint passed via pre-commit hook.

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8010a64-fd78-4752-8d8a-4087ed325459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8010a64-fd78-4752-8d8a-4087ed325459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

