### PR TITLE
fix: restore MarkdownInputField placeholder by avoiding duplicate empty paragraphs

### DIFF
--- a/src/MarkdownEditor/BaseMarkdownEditor.tsx
+++ b/src/MarkdownEditor/BaseMarkdownEditor.tsx
@@ -198,8 +198,9 @@ export const BaseMarkdownEditor: React.FC<MarkdownEditorProps> = (props) => {
     const parseResult = parserMdToSchema(initValue || '', props.plugins);
     let list = parseResult?.schema || [];
 
-    // 如果不是只读模式，添加一个空段落以便编辑
-    if (!props.readonly) {
+    // 非只读时保证末尾有可编辑块：解析结果常已含空段落（如空 initValue），
+    // 再追加会导致 Slate 根下两个空段，Paragraph 的占位符依赖 children.length===1 而失效
+    if (!props.readonly && list.length === 0) {
       list = [...list, EditorUtils.p];
     }
 

--- a/tests/BaseMarkdownEditor.test.tsx
+++ b/tests/BaseMarkdownEditor.test.tsx
@@ -418,6 +418,17 @@ describe('BaseMarkdownEditor', () => {
   });
 
   describe('initSchemaValue 过滤', () => {
+    it('initValue 为空字符串时不应追加重复空段落（保证占位符等单块逻辑）', async () => {
+      render(
+        <BaseMarkdownEditor initValue="" readonly={false} onChange={vi.fn()} />,
+      );
+      await waitFor(() => {
+        expect(capturedInitSchemaValue?.length).toBeGreaterThan(0);
+      });
+      expect(capturedInitSchemaValue.length).toBe(1);
+      expect(capturedInitSchemaValue[0].type).toBe('paragraph');
+    });
+
     it('应过滤掉空 paragraph、空 list、空 listItem、空 heading', async () => {
       const schemaWithEmpties = [
         { type: 'paragraph', children: [] },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`BaseMarkdownEditor` always appended an empty paragraph in edit mode after parsing `initValue`. For an empty string, the markdown parser already yields one empty paragraph, so the document ended up with two top-level blocks.

`Paragraph` only treats the editor as empty (and sets `data-slate-placeholder`) when `markdownEditorRef.current.children.length === 1`, so the placeholder never appeared. The extra block also matches the "two divs" symptom inside the editable surface.

## Changes

- Only append `EditorUtils.p` when the parsed schema is empty (readonly unchanged).
- Add a regression test asserting a single block for `initValue=""`.

## Testing

- `pnpm exec vitest run tests/BaseMarkdownEditor.test.tsx`
- `pnpm tsc`

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef2084cd-4737-4257-a4c4-0fb19e4cfbb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef2084cd-4737-4257-a4c4-0fb19e4cfbb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

