### PR TITLE
fix(bubble): stop mutating list items so streaming updates do not rerender all bubbles

### DIFF
--- a/docs/components/bubble.md
+++ b/docs/components/bubble.md
@@ -1567,6 +1567,9 @@ export default App;
    />
    ```
 
+4. **列表与 Bubble 的 memo 行为**  
+   `Bubble` 使用自定义 `memo` 比较，避免列表每次渲染因 `styles` / `avatar` 等新对象引用触发整表重绘。更新 `BubbleProps` 或 `originData` 时：对 `extra`、`meta` 等对象请**替换引用**（不可变更新），勿仅原地修改嵌套字段；`markdownRenderConfig` 等配置对象若每次 `render` 新建，请用 `useMemo` 稳定子对象引用。扩展 `BubbleProps` 时需在 `bubblePropsAreEqual` 中同步维护比较逻辑。
+
 ### 常见问题解决
 
 **Q: 如何实现消息流式更新？**

--- a/src/Bubble/Bubble.tsx
+++ b/src/Bubble/Bubble.tsx
@@ -3,6 +3,7 @@ import { memo, MutableRefObject, useMemo } from 'react';
 import React from 'react';
 import { debugInfo } from '../Utils/debugUtils';
 import { AIBubble } from './AIBubble';
+import { bubblePropsAreEqual } from './bubblePropsAreEqual';
 import { useSchemaEditorBridge } from './schema-editor';
 import type { BubbleProps } from './type';
 import { UserBubble } from './UserBubble';
@@ -113,5 +114,5 @@ const BubbleComponent: React.FC<
 
 BubbleComponent.displayName = 'Bubble';
 
-// 使用 React.memo 优化性能，避免不必要的重新渲染
-export const Bubble = memo(BubbleComponent);
+// 自定义比较：列表侧常传入新的 styles / avatar 对象引用，避免无数据变化时整表重绘
+export const Bubble = memo(BubbleComponent, bubblePropsAreEqual);

--- a/src/Bubble/Bubble.tsx
+++ b/src/Bubble/Bubble.tsx
@@ -114,5 +114,5 @@ const BubbleComponent: React.FC<
 
 BubbleComponent.displayName = 'Bubble';
 
-// 自定义比较：列表侧常传入新的 styles / avatar 对象引用，避免无数据变化时整表重绘
+// 自定义比较：列表侧常传入新的 styles / avatar 对象引用；扩展 props 时同步 bubblePropsAreEqual
 export const Bubble = memo(BubbleComponent, bubblePropsAreEqual);

--- a/src/Bubble/List/index.tsx
+++ b/src/Bubble/List/index.tsx
@@ -441,9 +441,11 @@ export const BubbleList: React.FC<BubbleListProps> = (props) => {
     return bubbleList.map((item, index) => {
       const isLast = bubbleList.length - 1 === index;
       const placement = item.role === 'user' ? 'right' : 'left';
-      // 保持向后兼容性，设置isLatest
-      (item as any).isLatest = isLast;
-      (item as any).isLast = isLast;
+      const originDataWithFlags = {
+        ...item,
+        isLatest: isLast,
+        isLast,
+      };
 
       let itemKey: string;
       if (item.id === LOADING_FLAT) {
@@ -468,51 +470,57 @@ export const BubbleList: React.FC<BubbleListProps> = (props) => {
       }
 
       const bubbleElement = (
-        <Bubble
+        <div
           key={itemKey}
-          data-id={item.id}
-          avatar={{
-            ...(item.role === 'user' ? userMeta : assistantMeta),
-            ...(item as any).meta,
-          }}
-          preMessage={bubbleList[index - 1]}
-          id={item.id}
-          style={{
-            ...styles?.bubbleListItemStyle,
-          }}
-          originData={item}
-          placement={placement}
-          time={item.updateAt || item.createAt}
-          deps={deps}
-          pure={props.pure}
-          bubbleListRef={bubbleListRef}
-          bubbleRenderConfig={bubbleRenderConfig}
-          classNames={classNames}
-          bubbleRef={props.bubbleRef}
-          markdownRenderConfig={markdownRenderConfig}
-          docListProps={props.docListProps}
-          styles={{
-            ...styles,
-            bubbleListItemContentStyle: {
-              ...styles?.bubbleListItemContentStyle,
-              ...(placement === 'right'
-                ? styles?.bubbleListRightItemContentStyle
-                : styles?.bubbleListLeftItemContentStyle),
-            },
-          }}
-          readonly={props.readonly}
-          onReply={props.onReply}
-          onDisLike={props.onDisLike}
-          onDislike={props.onDislike}
-          onLike={props.onLike}
-          onCancelLike={props.onCancelLike}
-          onLikeCancel={props.onLikeCancel}
-          onAvatarClick={props.onAvatarClick}
-          onDoubleClick={props.onDoubleClick}
-          customConfig={props?.bubbleRenderConfig?.customConfig}
-          shouldShowCopy={props.shouldShowCopy}
-          shouldShowVoice={props.shouldShowVoice}
-        />
+          style={{ display: 'contents' }}
+          data-bubble-list-item
+          data-is-last={isLast ? 'true' : 'false'}
+        >
+          <Bubble
+            data-id={item.id}
+            avatar={{
+              ...(item.role === 'user' ? userMeta : assistantMeta),
+              ...(item as any).meta,
+            }}
+            preMessage={bubbleList[index - 1]}
+            id={item.id}
+            style={{
+              ...styles?.bubbleListItemStyle,
+            }}
+            originData={originDataWithFlags}
+            placement={placement}
+            time={item.updateAt || item.createAt}
+            deps={deps}
+            pure={props.pure}
+            bubbleListRef={bubbleListRef}
+            bubbleRenderConfig={bubbleRenderConfig}
+            classNames={classNames}
+            bubbleRef={props.bubbleRef}
+            markdownRenderConfig={markdownRenderConfig}
+            docListProps={props.docListProps}
+            styles={{
+              ...styles,
+              bubbleListItemContentStyle: {
+                ...styles?.bubbleListItemContentStyle,
+                ...(placement === 'right'
+                  ? styles?.bubbleListRightItemContentStyle
+                  : styles?.bubbleListLeftItemContentStyle),
+              },
+            }}
+            readonly={props.readonly}
+            onReply={props.onReply}
+            onDisLike={props.onDisLike}
+            onDislike={props.onDislike}
+            onLike={props.onLike}
+            onCancelLike={props.onCancelLike}
+            onLikeCancel={props.onLikeCancel}
+            onAvatarClick={props.onAvatarClick}
+            onDoubleClick={props.onDoubleClick}
+            customConfig={props?.bubbleRenderConfig?.customConfig}
+            shouldShowCopy={props.shouldShowCopy}
+            shouldShowVoice={props.shouldShowVoice}
+          />
+        </div>
       );
 
       // 如果启用了懒加载，用 LazyElement 包裹

--- a/src/Bubble/List/index.tsx
+++ b/src/Bubble/List/index.tsx
@@ -17,6 +17,7 @@ import React from 'react';
 import { LazyElement } from '../../MarkdownEditor/editor/components/LazyElement';
 import { Bubble } from '../Bubble';
 import { BubbleConfigContext } from '../BubbleConfigProvide';
+import { shallowEqualRecord, shallowEqualStyles } from '../bubblePropsAreEqual';
 import { LOADING_FLAT } from '../MessagesContent';
 import { useStyle } from './style';
 
@@ -433,12 +434,20 @@ export const BubbleList: React.FC<BubbleListProps> = (props) => {
   const loadingKeyByIndexRef = useRef<Map<number, string>>(new Map());
   // 真实 id 映射到稳定 key（过渡后沿用），避免同一条消息因 id 变化导致 remount
   const realIdToStableKeyRef = useRef<Map<string, string>>(new Map());
+  /** 按列表行稳定 key 缓存合并后的 Bubble styles，避免每条消息每次父级渲染都换引用 */
+  const bubbleMergedStylesRef = useRef<Map<string, BubbleProps['styles']>>(
+    new Map(),
+  );
+  const bubbleMergedAvatarRef = useRef<Map<string, BubbleMetaData>>(
+    new Map(),
+  );
 
   const bubbleListDom = useMemo(() => {
     const isLazyEnabled = props.lazy?.enable;
     const totalCount = bubbleList.length;
+    const activeRowKeys = new Set<string>();
 
-    return bubbleList.map((item, index) => {
+    const rows = bubbleList.map((item, index) => {
       const isLast = bubbleList.length - 1 === index;
       const placement = item.role === 'user' ? 'right' : 'left';
       const originDataWithFlags = {
@@ -469,6 +478,33 @@ export const BubbleList: React.FC<BubbleListProps> = (props) => {
         }
       }
 
+      activeRowKeys.add(itemKey);
+
+      const candidateAvatar = {
+        ...(item.role === 'user' ? userMeta : assistantMeta),
+        ...(item as any).meta,
+      } as BubbleMetaData;
+      const prevAvatar = bubbleMergedAvatarRef.current.get(itemKey);
+      if (!prevAvatar || !shallowEqualRecord(prevAvatar as any, candidateAvatar as any)) {
+        bubbleMergedAvatarRef.current.set(itemKey, candidateAvatar);
+      }
+      const mergedAvatar = bubbleMergedAvatarRef.current.get(itemKey)!;
+
+      const candidateStyles: BubbleProps['styles'] = {
+        ...styles,
+        bubbleListItemContentStyle: {
+          ...styles?.bubbleListItemContentStyle,
+          ...(placement === 'right'
+            ? styles?.bubbleListRightItemContentStyle
+            : styles?.bubbleListLeftItemContentStyle),
+        },
+      };
+      const prevMergedStyles = bubbleMergedStylesRef.current.get(itemKey);
+      if (!prevMergedStyles || !shallowEqualStyles(prevMergedStyles, candidateStyles)) {
+        bubbleMergedStylesRef.current.set(itemKey, candidateStyles);
+      }
+      const mergedStyles = bubbleMergedStylesRef.current.get(itemKey)!;
+
       const bubbleElement = (
         <div
           key={itemKey}
@@ -478,10 +514,7 @@ export const BubbleList: React.FC<BubbleListProps> = (props) => {
         >
           <Bubble
             data-id={item.id}
-            avatar={{
-              ...(item.role === 'user' ? userMeta : assistantMeta),
-              ...(item as any).meta,
-            }}
+            avatar={mergedAvatar}
             preMessage={bubbleList[index - 1]}
             id={item.id}
             style={{
@@ -498,15 +531,7 @@ export const BubbleList: React.FC<BubbleListProps> = (props) => {
             bubbleRef={props.bubbleRef}
             markdownRenderConfig={markdownRenderConfig}
             docListProps={props.docListProps}
-            styles={{
-              ...styles,
-              bubbleListItemContentStyle: {
-                ...styles?.bubbleListItemContentStyle,
-                ...(placement === 'right'
-                  ? styles?.bubbleListRightItemContentStyle
-                  : styles?.bubbleListLeftItemContentStyle),
-              },
-            }}
+            styles={mergedStyles}
             readonly={props.readonly}
             onReply={props.onReply}
             onDisLike={props.onDisLike}
@@ -523,11 +548,34 @@ export const BubbleList: React.FC<BubbleListProps> = (props) => {
         </div>
       );
 
+      return { itemKey, bubbleElement, isLazyEnabled, index, item, totalCount };
+    });
+
+    for (const k of bubbleMergedStylesRef.current.keys()) {
+      if (!activeRowKeys.has(k)) {
+        bubbleMergedStylesRef.current.delete(k);
+      }
+    }
+    for (const k of bubbleMergedAvatarRef.current.keys()) {
+      if (!activeRowKeys.has(k)) {
+        bubbleMergedAvatarRef.current.delete(k);
+      }
+    }
+
+    return rows.map(
+      ({
+        itemKey,
+        bubbleElement,
+        isLazyEnabled: lazyOn,
+        index,
+        item,
+        totalCount: count,
+      }) => {
       // 如果启用了懒加载，用 LazyElement 包裹
-      if (isLazyEnabled) {
+      if (lazyOn) {
         // 检查是否应该对该消息启用懒加载
         const shouldLazyLoad =
-          props.lazy?.shouldLazyLoad?.(index, totalCount) ?? true;
+          props.lazy?.shouldLazyLoad?.(index, count) ?? true;
 
         // 如果不需要懒加载，直接返回元素
         if (!shouldLazyLoad) {
@@ -562,7 +610,7 @@ export const BubbleList: React.FC<BubbleListProps> = (props) => {
             elementInfo={{
               type: 'bubble',
               index,
-              total: totalCount,
+              total: count,
             }}
           >
             {bubbleElement}
@@ -572,7 +620,33 @@ export const BubbleList: React.FC<BubbleListProps> = (props) => {
 
       return bubbleElement;
     });
-  }, [bubbleList, props.style, props.lazy]);
+  }, [
+    bubbleList,
+    bubbleListRef,
+    bubbleRenderConfig,
+    classNames,
+    deps,
+    markdownRenderConfig,
+    props.bubbleRef,
+    props.docListProps,
+    props.lazy,
+    props.onAvatarClick,
+    props.onCancelLike,
+    props.onDisLike,
+    props.onDislike,
+    props.onDoubleClick,
+    props.onLike,
+    props.onLikeCancel,
+    props.onReply,
+    props.pure,
+    props.readonly,
+    props.shouldShowCopy,
+    props.shouldShowVoice,
+    props.style,
+    styles,
+    userMeta,
+    assistantMeta,
+  ]);
 
   if (loading)
     return wrapSSR(

--- a/src/Bubble/bubblePropsAreEqual.ts
+++ b/src/Bubble/bubblePropsAreEqual.ts
@@ -1,0 +1,195 @@
+import type { BubbleMetaData, BubbleProps, MessageBubbleData } from './type';
+
+export const shallowEqualRecord = (
+  a: Record<string, unknown> | undefined | null,
+  b: Record<string, unknown> | undefined | null,
+): boolean => {
+  if (a === b) return true;
+  if (!a || !b) return !a && !b;
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
+  if (keysA.length !== keysB.length) return false;
+  for (const k of keysA) {
+    if ((a as Record<string, unknown>)[k] !== (b as Record<string, unknown>)[k]) {
+      return false;
+    }
+  }
+  return true;
+};
+
+export const shallowEqualStyles = (
+  a: BubbleProps['styles'] | undefined,
+  b: BubbleProps['styles'] | undefined,
+): boolean => {
+  if (a === b) return true;
+  if (!a || !b) return !a && !b;
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  for (const k of keys) {
+    const va = (a as Record<string, unknown>)[k];
+    const vb = (b as Record<string, unknown>)[k];
+    if (va === vb) continue;
+    if (
+      va &&
+      vb &&
+      typeof va === 'object' &&
+      typeof vb === 'object' &&
+      !Array.isArray(va) &&
+      !Array.isArray(vb)
+    ) {
+      if (!shallowEqualRecord(va as Record<string, unknown>, vb as Record<string, unknown>)) {
+        return false;
+      }
+    } else {
+      return false;
+    }
+  }
+  return true;
+};
+
+const shallowEqualClassNames = (
+  a: BubbleProps['classNames'] | undefined,
+  b: BubbleProps['classNames'] | undefined,
+): boolean => {
+  if (a === b) return true;
+  if (!a || !b) return !a && !b;
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  for (const k of keys) {
+    if ((a as Record<string, unknown>)[k] !== (b as Record<string, unknown>)[k]) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const metaAffectsBubble = (m: BubbleMetaData | undefined): boolean =>
+  Boolean(m?.avatar || m?.title || m?.name || m?.description || m?.backgroundColor);
+
+const originDataEqualForMemo = (
+  a: MessageBubbleData | undefined,
+  b: MessageBubbleData | undefined,
+): boolean => {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  if (
+    a.id !== b.id ||
+    a.role !== b.role ||
+    a.content !== b.content ||
+    a.isFinished !== b.isFinished ||
+    a.isAborted !== b.isAborted ||
+    a.isLast !== b.isLast ||
+    a.isLatest !== b.isLatest ||
+    a.updateAt !== b.updateAt ||
+    a.createAt !== b.createAt ||
+    a.feedback !== b.feedback ||
+    a.originContent !== b.originContent ||
+    a.fileMap !== b.fileMap ||
+    a.extra !== b.extra ||
+    a.error !== b.error
+  ) {
+    return false;
+  }
+  if (a.meta === b.meta) return true;
+  if (!metaAffectsBubble(a.meta) && !metaAffectsBubble(b.meta)) return true;
+  return shallowEqualRecord(
+    (a.meta || {}) as Record<string, unknown>,
+    (b.meta || {}) as Record<string, unknown>,
+  );
+};
+
+const preMessageEqualForMemo = (
+  a: MessageBubbleData | undefined,
+  b: MessageBubbleData | undefined,
+): boolean => {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return a.id === b.id && a.role === b.role;
+};
+
+const depsArrayEqual = (a: unknown[] | undefined, b: unknown[] | undefined): boolean => {
+  if (a === b) return true;
+  if (!a || !b) return !a && !b;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+};
+
+/**
+ * Custom props comparator for Bubble memo.
+ * BubbleList (and callers) often pass fresh object references for styles / classNames / avatar
+ * while message data is unchanged; default shallow compare would still re-render every parent tick.
+ */
+export const bubblePropsAreEqual = (
+  prev: BubbleProps & { deps?: unknown[] },
+  next: BubbleProps & { deps?: unknown[] },
+): boolean => {
+  if (prev === next) return true;
+
+  if (prev.id !== next.id) return false;
+  if (prev.placement !== next.placement) return false;
+  if (prev.pure !== next.pure) return false;
+  if (prev.readonly !== next.readonly) return false;
+  if (prev.time !== next.time) return false;
+  if (prev.shouldShowVoice !== next.shouldShowVoice) return false;
+  if (prev.renderMode !== next.renderMode) return false;
+  if (prev.renderType !== next.renderType) return false;
+
+  if (prev.shouldShowCopy !== next.shouldShowCopy) return false;
+  if (typeof prev.shouldShowCopy === 'function' || typeof next.shouldShowCopy === 'function') {
+    if (prev.shouldShowCopy !== next.shouldShowCopy) return false;
+  }
+
+  if (!originDataEqualForMemo(prev.originData, next.originData)) return false;
+  if (!preMessageEqualForMemo(prev.preMessage, next.preMessage)) return false;
+
+  if (prev.markdownRenderConfig !== next.markdownRenderConfig) return false;
+  if (prev.bubbleRenderConfig !== next.bubbleRenderConfig) return false;
+  if (prev.docListProps !== next.docListProps) return false;
+  if (prev.customConfig !== next.customConfig) return false;
+  if (prev.bubbleListRef !== next.bubbleListRef) return false;
+  if (prev.bubbleRef !== next.bubbleRef) return false;
+
+  if (prev.avatar === next.avatar) {
+    // ok
+  } else if (!shallowEqualRecord(prev.avatar as any, next.avatar as any)) {
+    return false;
+  }
+
+  if (!shallowEqualStyles(prev.styles, next.styles)) return false;
+  if (!shallowEqualClassNames(prev.classNames, next.classNames)) return false;
+
+  if (prev.style !== next.style) {
+    if (
+      !shallowEqualRecord(
+        (prev.style || {}) as Record<string, unknown>,
+        (next.style || {}) as Record<string, unknown>,
+      )
+    ) {
+      return false;
+    }
+  }
+  if (prev.className !== next.className) return false;
+
+  if (prev.onReply !== next.onReply) return false;
+  if (prev.onDisLike !== next.onDisLike) return false;
+  if (prev.onDislike !== next.onDislike) return false;
+  if (prev.onLike !== next.onLike) return false;
+  if (prev.onCancelLike !== next.onCancelLike) return false;
+  if (prev.onLikeCancel !== next.onLikeCancel) return false;
+  if (prev.onAvatarClick !== next.onAvatarClick) return false;
+  if (prev.onDoubleClick !== next.onDoubleClick) return false;
+
+  if (prev.useSpeech !== next.useSpeech) return false;
+  if (prev.fileViewEvents !== next.fileViewEvents) return false;
+  if (prev.fileViewConfig !== next.fileViewConfig) return false;
+  if (prev.renderFileMoreAction !== next.renderFileMoreAction) return false;
+
+  if (prev.userBubbleProps !== next.userBubbleProps) return false;
+  if (prev.aiBubbleProps !== next.aiBubbleProps) return false;
+  if (prev.aIBubbleProps !== next.aIBubbleProps) return false;
+
+  if (!depsArrayEqual(prev.deps, next.deps)) return false;
+
+  return true;
+};

--- a/src/Bubble/bubblePropsAreEqual.ts
+++ b/src/Bubble/bubblePropsAreEqual.ts
@@ -1,3 +1,13 @@
+/**
+ * Bubble 自定义 memo 比较（见 Bubble.tsx）。
+ *
+ * 维护约定：
+ * - 在 BubbleProps 上新增「会影响渲染」的字段时，必须在此补充比较逻辑，否则可能漏更新。
+ * - `markdownRenderConfig` / `bubbleRenderConfig` / `docListProps` / `customConfig`：按**顶层键**浅比较；
+ *   顶层值为普通对象时再浅比较一层；数组与函数仍按引用比较。父组件用 `useMemo` 稳定子对象引用更佳。
+ * - `originData`：按列出的标量与引用字段比较；`meta` 顶层浅比较；`meta.metadata` 再浅比较一层。
+ *   对 `extra` 等对象请勿原地 mutate，应替换引用，否则可能与 `extra !==` 不一致（若仅改嵌套且未换引用会漏更新）。
+ */
 import type { BubbleMetaData, BubbleProps, MessageBubbleData } from './type';
 
 export const shallowEqualRecord = (
@@ -61,8 +71,60 @@ const shallowEqualClassNames = (
   return true;
 };
 
+/** 配置型 props：顶层浅比较；顶层值为非数组对象时再浅比较一层 */
+const shallowEqualConfigObject = (
+  a: object | undefined | null,
+  b: object | undefined | null,
+): boolean => {
+  if (a === b) return true;
+  if (!a || !b) return !a && !b;
+  const ra = a as Record<string, unknown>;
+  const rb = b as Record<string, unknown>;
+  const keys = new Set([...Object.keys(ra), ...Object.keys(rb)]);
+  for (const k of keys) {
+    if (!(k in ra) || !(k in rb)) return false;
+    const va = ra[k];
+    const vb = rb[k];
+    if (va === vb) continue;
+    if (
+      va &&
+      vb &&
+      typeof va === 'object' &&
+      typeof vb === 'object' &&
+      !Array.isArray(va) &&
+      !Array.isArray(vb)
+    ) {
+      if (!shallowEqualRecord(va as Record<string, unknown>, vb as Record<string, unknown>)) {
+        return false;
+      }
+    } else {
+      return false;
+    }
+  }
+  return true;
+};
+
 const metaAffectsBubble = (m: BubbleMetaData | undefined): boolean =>
-  Boolean(m?.avatar || m?.title || m?.name || m?.description || m?.backgroundColor);
+  Boolean(
+    m?.avatar ||
+      m?.title ||
+      m?.name ||
+      m?.description ||
+      m?.backgroundColor ||
+      (m?.metadata && Object.keys(m.metadata).length > 0),
+  );
+
+const metaEqualForMemo = (a: BubbleMetaData | undefined, b: BubbleMetaData | undefined): boolean => {
+  if (a === b) return true;
+  if (!shallowEqualRecord((a || {}) as Record<string, unknown>, (b || {}) as Record<string, unknown>)) {
+    return false;
+  }
+  const ma = a?.metadata;
+  const mb = b?.metadata;
+  if (ma === mb) return true;
+  if (!ma || !mb) return !ma && !mb;
+  return shallowEqualRecord(ma as Record<string, unknown>, mb as Record<string, unknown>);
+};
 
 const originDataEqualForMemo = (
   a: MessageBubbleData | undefined,
@@ -90,10 +152,7 @@ const originDataEqualForMemo = (
   }
   if (a.meta === b.meta) return true;
   if (!metaAffectsBubble(a.meta) && !metaAffectsBubble(b.meta)) return true;
-  return shallowEqualRecord(
-    (a.meta || {}) as Record<string, unknown>,
-    (b.meta || {}) as Record<string, unknown>,
-  );
+  return metaEqualForMemo(a.meta, b.meta);
 };
 
 const preMessageEqualForMemo = (
@@ -143,10 +202,28 @@ export const bubblePropsAreEqual = (
   if (!originDataEqualForMemo(prev.originData, next.originData)) return false;
   if (!preMessageEqualForMemo(prev.preMessage, next.preMessage)) return false;
 
-  if (prev.markdownRenderConfig !== next.markdownRenderConfig) return false;
-  if (prev.bubbleRenderConfig !== next.bubbleRenderConfig) return false;
-  if (prev.docListProps !== next.docListProps) return false;
-  if (prev.customConfig !== next.customConfig) return false;
+  if (
+    !shallowEqualConfigObject(
+      prev.markdownRenderConfig as object | undefined,
+      next.markdownRenderConfig as object | undefined,
+    )
+  ) {
+    return false;
+  }
+  if (
+    !shallowEqualConfigObject(
+      prev.bubbleRenderConfig as object | undefined,
+      next.bubbleRenderConfig as object | undefined,
+    )
+  ) {
+    return false;
+  }
+  if (!shallowEqualConfigObject(prev.docListProps as object | undefined, next.docListProps as object | undefined)) {
+    return false;
+  }
+  if (!shallowEqualConfigObject(prev.customConfig as object | undefined, next.customConfig as object | undefined)) {
+    return false;
+  }
   if (prev.bubbleListRef !== next.bubbleListRef) return false;
   if (prev.bubbleRef !== next.bubbleRef) return false;
 

--- a/src/Components/TypingAnimation/index.tsx
+++ b/src/Components/TypingAnimation/index.tsx
@@ -2,7 +2,14 @@ import { ConfigProvider } from 'antd';
 import classNames from 'clsx';
 import { motion, MotionProps, useInView } from 'framer-motion';
 import { isString } from 'lodash-es';
-import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  memo,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { resolveSegments } from '../TextAnimate';
 import { useTypingAnimationStyle } from './style';
 
@@ -23,7 +30,7 @@ export interface TypingAnimationProps extends MotionProps {
   cursorStyle?: 'line' | 'block' | 'underscore';
 }
 
-export function TypingAnimation({
+const TypingAnimationBase = ({
   children,
   words,
   className,
@@ -39,7 +46,7 @@ export function TypingAnimation({
   blinkCursor = true,
   cursorStyle = 'line',
   ...props
-}: TypingAnimationProps) {
+}: TypingAnimationProps) => {
   const MotionComponent = motion(Component, {
     forwardMotionProps: true,
   });
@@ -183,4 +190,8 @@ export function TypingAnimation({
       )}
     </MotionComponent>,
   );
-}
+};
+
+TypingAnimationBase.displayName = 'TypingAnimation';
+
+export const TypingAnimation = memo(TypingAnimationBase);

--- a/src/MarkdownRenderer/__tests__/useStreamingMarkdownReact.cache.test.tsx
+++ b/src/MarkdownRenderer/__tests__/useStreamingMarkdownReact.cache.test.tsx
@@ -1,0 +1,33 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as markdownReactShared from '../markdownReactShared';
+import { useStreamingMarkdownReact } from '../streaming/useStreamingMarkdownReact';
+
+describe('useStreamingMarkdownReact sealed subtree cache', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not call renderMarkdownBlock again for sealed blocks when only the tail block grows', () => {
+    const spy = vi.spyOn(markdownReactShared, 'renderMarkdownBlock');
+
+    const md1 = 'sealed\n\n\n';
+    const md2 = 'sealed\n\n\ntail';
+
+    const { rerender } = renderHook(
+      ({ content }: { content: string }) =>
+        useStreamingMarkdownReact(content, {
+          streaming: true,
+          contentRevisionSource: content,
+        }),
+      { initialProps: { content: md1 } },
+    );
+
+    const countAfterFirst = spy.mock.calls.length;
+    expect(countAfterFirst).toBeGreaterThan(0);
+
+    rerender({ content: md2 });
+
+    expect(spy.mock.calls.length - countAfterFirst).toBe(1);
+  });
+});

--- a/src/MarkdownRenderer/streaming/useStreamingMarkdownReact.tsx
+++ b/src/MarkdownRenderer/streaming/useStreamingMarkdownReact.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from 'react';
+import React, { memo, useEffect, useMemo, useRef } from 'react';
 import { Fragment, jsx, jsxs } from 'react/jsx-runtime';
 import {
   JINJA_DOLLAR_PLACEHOLDER,
@@ -8,12 +8,31 @@ import {
 import {
   buildEditorAlignedComponents,
   createHastProcessor,
+  renderMarkdownBlock,
   splitMarkdownBlocks,
   type UseMarkdownToReactOptions,
 } from '../markdownReactShared';
+import { StreamingAnimationContext } from '../StreamingAnimationContext';
 
 import { MarkdownBlockPiece } from './MarkdownBlockPiece';
 import { shouldResetRevisionProgress } from './revisionPolicy';
+
+interface SealedSubtreeProps {
+  children: React.ReactNode;
+}
+
+/** 已密封块：子树在 hook 层缓存，避免父 Fragment 重建时整段子树 reconcile */
+const SealedMarkdownSubtree = memo(function SealedMarkdownSubtree({
+  children,
+}: SealedSubtreeProps) {
+  return (
+    <StreamingAnimationContext.Provider value={{ animateBlock: false }}>
+      {children}
+    </StreamingAnimationContext.Provider>
+  );
+});
+
+SealedMarkdownSubtree.displayName = 'SealedMarkdownSubtree';
 
 /**
  * 流式优先的 Markdown → React：每块独立 memo 组件；tail 与 sealed 共用组件类型以便块晋升时复用实例。
@@ -29,6 +48,10 @@ export const useStreamingMarkdownReact = (
 
   const prevRevisionRef = useRef<string | undefined>(undefined);
   const revisionGenerationRef = useRef(0);
+  /** 修订代 + 块下标 → 已解析子树，供密封块跨父级 useMemo 周期复用同一 React 元素引用 */
+  const sealedSubtreeCacheRef = useRef<
+    Map<string, { source: string; node: React.ReactNode }>
+  >(new Map());
 
   const processor = useMemo(
     () => createHastProcessor(options?.remarkPlugins, options?.htmlConfig),
@@ -59,9 +82,14 @@ export const useStreamingMarkdownReact = (
     ],
   );
 
+  useEffect(() => {
+    sealedSubtreeCacheRef.current.clear();
+  }, [processor, components]);
+
   return useMemo(() => {
     if (!content) {
       prevRevisionRef.current = '';
+      sealedSubtreeCacheRef.current.clear();
       return null;
     }
 
@@ -71,6 +99,7 @@ export const useStreamingMarkdownReact = (
       shouldResetRevisionProgress(prevRev, revisionSource)
     ) {
       revisionGenerationRef.current += 1;
+      sealedSubtreeCacheRef.current.clear();
     }
     prevRevisionRef.current = revisionSource;
 
@@ -88,18 +117,43 @@ export const useStreamingMarkdownReact = (
         const isLast = index === blocks.length - 1;
         // 仅用修订代 + 块下标作 key，避免末块随文本增长导致 identity 变化而整段 remount
         const key = `b-${gen}-${index}`;
-        return jsx(
-          MarkdownBlockPiece,
-          {
-            variant: isLast ? 'tail' : 'sealed',
-            blockSource,
-            processor,
-            components,
-            streaming: !!(options?.streaming && isLast),
-          },
-          key,
-        );
+        if (isLast) {
+          return jsx(
+            MarkdownBlockPiece,
+            {
+              variant: 'tail',
+              blockSource,
+              processor,
+              components,
+              streaming: !!options?.streaming,
+            },
+            key,
+          );
+        }
+
+        const cacheKey = `${gen}:${index}`;
+        const cache = sealedSubtreeCacheRef.current;
+        const hit = cache.get(cacheKey);
+        const node =
+          hit && hit.source === blockSource
+            ? hit.node
+            : renderMarkdownBlock(blockSource, processor, components);
+        cache.set(cacheKey, { source: blockSource, node });
+
+        return jsx(SealedMarkdownSubtree, { children: node }, key);
       });
+
+      const maxSealedIndex = blocks.length - 2;
+      if (maxSealedIndex >= 0) {
+        const cachePrefix = `${gen}:`;
+        for (const k of [...sealedSubtreeCacheRef.current.keys()]) {
+          if (!k.startsWith(cachePrefix)) continue;
+          const idx = Number(k.slice(cachePrefix.length));
+          if (Number.isNaN(idx) || idx > maxSealedIndex) {
+            sealedSubtreeCacheRef.current.delete(k);
+          }
+        }
+      }
 
       return jsxs(Fragment, { children: elements });
     } catch (error) {

--- a/tests/Bubble/bubblePropsAreEqual.test.ts
+++ b/tests/Bubble/bubblePropsAreEqual.test.ts
@@ -37,4 +37,54 @@ describe('bubblePropsAreEqual', () => {
     };
     expect(bubblePropsAreEqual(a, b)).toBe(false);
   });
+
+  it('treats markdownRenderConfig as equal when top-level keys match with new object references', () => {
+    const a: BubbleProps = {
+      id: 'm1',
+      originData: baseOrigin(),
+      markdownRenderConfig: {
+        renderMode: 'markdown',
+        queueOptions: { animate: false },
+      },
+    };
+    const b: BubbleProps = {
+      ...a,
+      markdownRenderConfig: {
+        renderMode: 'markdown',
+        queueOptions: { animate: false },
+      },
+    };
+    expect(bubblePropsAreEqual(a, b)).toBe(true);
+  });
+
+  it('returns false when markdownRenderConfig top-level value changes', () => {
+    const a: BubbleProps = {
+      id: 'm1',
+      originData: baseOrigin(),
+      markdownRenderConfig: { renderMode: 'markdown' },
+    };
+    const b: BubbleProps = {
+      ...a,
+      markdownRenderConfig: { renderMode: 'slate' },
+    };
+    expect(bubblePropsAreEqual(a, b)).toBe(false);
+  });
+
+  it('detects originData.meta.metadata shallow changes', () => {
+    const a: BubbleProps = {
+      id: 'm1',
+      originData: {
+        ...baseOrigin(),
+        meta: { title: 't', metadata: { k: 1 } },
+      },
+    };
+    const b: BubbleProps = {
+      ...a,
+      originData: {
+        ...baseOrigin(),
+        meta: { title: 't', metadata: { k: 2 } },
+      },
+    };
+    expect(bubblePropsAreEqual(a, b)).toBe(false);
+  });
 });

--- a/tests/Bubble/bubblePropsAreEqual.test.ts
+++ b/tests/Bubble/bubblePropsAreEqual.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { bubblePropsAreEqual } from '../../src/Bubble/bubblePropsAreEqual';
+import type { BubbleProps, MessageBubbleData } from '../../src/Bubble/type';
+
+const baseOrigin = (): MessageBubbleData => ({
+  id: 'm1',
+  role: 'assistant',
+  content: 'hello',
+  createAt: 1,
+  updateAt: 1,
+  isFinished: true,
+  isLast: false,
+});
+
+describe('bubblePropsAreEqual', () => {
+  it('treats fresh style object references as equal when keys match', () => {
+    const a: BubbleProps = {
+      id: 'm1',
+      originData: baseOrigin(),
+      style: { padding: 8, margin: 0 },
+    };
+    const b: BubbleProps = {
+      ...a,
+      style: { padding: 8, margin: 0 },
+    };
+    expect(bubblePropsAreEqual(a, b)).toBe(true);
+  });
+
+  it('returns false when origin content changes', () => {
+    const a: BubbleProps = {
+      id: 'm1',
+      originData: baseOrigin(),
+    };
+    const b: BubbleProps = {
+      ...a,
+      originData: { ...baseOrigin(), content: 'world' },
+    };
+    expect(bubblePropsAreEqual(a, b)).toBe(false);
+  });
+});

--- a/tests/BubbleList.test.tsx
+++ b/tests/BubbleList.test.tsx
@@ -41,6 +41,19 @@ describe('BubbleList', () => {
     updateAt: Date.now(),
   });
 
+  const expectBubbleListItemIsLast = (
+    container: HTMLElement,
+    expected: boolean[],
+  ) => {
+    const rows = container.querySelectorAll('[data-bubble-list-item]');
+    expect(rows.length).toBe(expected.length);
+    expected.forEach((isLast, index) => {
+      expect(rows[index].getAttribute('data-is-last')).toBe(
+        isLast ? 'true' : 'false',
+      );
+    });
+  };
+
   describe('loading 状态', () => {
     it('loading 为 true 时应渲染加载骨架', () => {
       const bubbleList: MessageBubbleData[] = [
@@ -67,17 +80,18 @@ describe('BubbleList', () => {
         createMockBubbleData('4', 'assistant', 'Last message'),
       ];
 
-      render(
+      const { container } = render(
         <BubbleConfigProvide>
           <BubbleList bubbleList={bubbleList} />
         </BubbleConfigProvide>,
       );
 
-      // 验证只有最后一个消息的 isLast 为 true
-      expect((bubbleList[0] as any).isLast).toBe(false);
-      expect((bubbleList[1] as any).isLast).toBe(false);
-      expect((bubbleList[2] as any).isLast).toBe(false);
-      expect((bubbleList[3] as any).isLast).toBe(true);
+      expectBubbleListItemIsLast(container, [
+        false,
+        false,
+        false,
+        true,
+      ]);
     });
 
     it('should set isLast to true for single bubble in the list', () => {
@@ -85,14 +99,13 @@ describe('BubbleList', () => {
         createMockBubbleData('1', 'user', 'Only message'),
       ];
 
-      render(
+      const { container } = render(
         <BubbleConfigProvide>
           <BubbleList bubbleList={bubbleList} />
         </BubbleConfigProvide>,
       );
 
-      // 验证单个消息的 isLast 为 true
-      expect((bubbleList[0] as any).isLast).toBe(true);
+      expectBubbleListItemIsLast(container, [true]);
     });
 
     it('should update isLast when bubble list changes', () => {
@@ -101,15 +114,13 @@ describe('BubbleList', () => {
         createMockBubbleData('2', 'assistant', 'Second message'),
       ];
 
-      const { rerender } = render(
+      const { container, rerender } = render(
         <BubbleConfigProvide>
           <BubbleList bubbleList={initialBubbleList} />
         </BubbleConfigProvide>,
       );
 
-      // 验证初始状态
-      expect((initialBubbleList[0] as any).isLast).toBe(false);
-      expect((initialBubbleList[1] as any).isLast).toBe(true);
+      expectBubbleListItemIsLast(container, [false, true]);
 
       // 添加新的消息
       const updatedBubbleList: MessageBubbleData[] = [
@@ -123,10 +134,7 @@ describe('BubbleList', () => {
         </BubbleConfigProvide>,
       );
 
-      // 验证更新后的状态：之前的最后一个消息不再是最后一个
-      expect((updatedBubbleList[0] as any).isLast).toBe(false);
-      expect((updatedBubbleList[1] as any).isLast).toBe(false);
-      expect((updatedBubbleList[2] as any).isLast).toBe(true);
+      expectBubbleListItemIsLast(container, [false, false, true]);
     });
 
     it('should update isLast when removing the last bubble', () => {
@@ -136,16 +144,13 @@ describe('BubbleList', () => {
         createMockBubbleData('3', 'user', 'Third message'),
       ];
 
-      const { rerender } = render(
+      const { container, rerender } = render(
         <BubbleConfigProvide>
           <BubbleList bubbleList={initialBubbleList} />
         </BubbleConfigProvide>,
       );
 
-      // 验证初始状态
-      expect((initialBubbleList[0] as any).isLast).toBe(false);
-      expect((initialBubbleList[1] as any).isLast).toBe(false);
-      expect((initialBubbleList[2] as any).isLast).toBe(true);
+      expectBubbleListItemIsLast(container, [false, false, true]);
 
       // 移除最后一个消息
       const updatedBubbleList: MessageBubbleData[] = [
@@ -159,9 +164,7 @@ describe('BubbleList', () => {
         </BubbleConfigProvide>,
       );
 
-      // 验证更新后的状态：之前的倒数第二个消息现在成为最后一个
-      expect((updatedBubbleList[0] as any).isLast).toBe(false);
-      expect((updatedBubbleList[1] as any).isLast).toBe(true);
+      expectBubbleListItemIsLast(container, [false, true]);
     });
 
     it('should maintain isLast property for different roles', () => {
@@ -173,18 +176,19 @@ describe('BubbleList', () => {
         createMockBubbleData('5', 'user', 'User message 3'),
       ];
 
-      render(
+      const { container } = render(
         <BubbleConfigProvide>
           <BubbleList bubbleList={bubbleList} />
         </BubbleConfigProvide>,
       );
 
-      // 验证无论角色如何，只有最后一个消息的 isLast 为 true
-      expect((bubbleList[0] as any).isLast).toBe(false);
-      expect((bubbleList[1] as any).isLast).toBe(false);
-      expect((bubbleList[2] as any).isLast).toBe(false);
-      expect((bubbleList[3] as any).isLast).toBe(false);
-      expect((bubbleList[4] as any).isLast).toBe(true);
+      expectBubbleListItemIsLast(container, [
+        false,
+        false,
+        false,
+        false,
+        true,
+      ]);
     });
   });
 
@@ -197,17 +201,18 @@ describe('BubbleList', () => {
         createMockBubbleData('4', 'assistant', 'Last message'),
       ];
 
-      render(
+      const { container } = render(
         <BubbleConfigProvide>
           <BubbleList bubbleList={bubbleList} />
         </BubbleConfigProvide>,
       );
 
-      // 验证只有最后一个消息的 isLatest 为 true
-      expect(bubbleList[0].isLatest).toBe(false);
-      expect(bubbleList[1].isLatest).toBe(false);
-      expect(bubbleList[2].isLatest).toBe(false);
-      expect(bubbleList[3].isLatest).toBe(true);
+      expectBubbleListItemIsLast(container, [
+        false,
+        false,
+        false,
+        true,
+      ]);
     });
 
     it('should set isLatest to true for single bubble in the list', () => {
@@ -215,14 +220,13 @@ describe('BubbleList', () => {
         createMockBubbleData('1', 'user', 'Only message'),
       ];
 
-      render(
+      const { container } = render(
         <BubbleConfigProvide>
           <BubbleList bubbleList={bubbleList} />
         </BubbleConfigProvide>,
       );
 
-      // 验证单个消息的 isLatest 为 true
-      expect(bubbleList[0].isLatest).toBe(true);
+      expectBubbleListItemIsLast(container, [true]);
     });
 
     it('should handle empty bubble list', () => {
@@ -244,15 +248,13 @@ describe('BubbleList', () => {
         createMockBubbleData('2', 'assistant', 'Second message'),
       ];
 
-      const { rerender } = render(
+      const { container, rerender } = render(
         <BubbleConfigProvide>
           <BubbleList bubbleList={initialBubbleList} />
         </BubbleConfigProvide>,
       );
 
-      // 验证初始状态
-      expect(initialBubbleList[0].isLatest).toBe(false);
-      expect(initialBubbleList[1].isLatest).toBe(true);
+      expectBubbleListItemIsLast(container, [false, true]);
 
       // 添加新的消息
       const updatedBubbleList: MessageBubbleData[] = [
@@ -266,10 +268,7 @@ describe('BubbleList', () => {
         </BubbleConfigProvide>,
       );
 
-      // 验证更新后的状态
-      expect(updatedBubbleList[0].isLatest).toBe(false);
-      expect(updatedBubbleList[1].isLatest).toBe(false);
-      expect(updatedBubbleList[2].isLatest).toBe(true);
+      expectBubbleListItemIsLast(container, [false, false, true]);
     });
 
     it('should maintain isLatest property for different roles', () => {
@@ -281,18 +280,19 @@ describe('BubbleList', () => {
         createMockBubbleData('5', 'user', 'User message 3'),
       ];
 
-      render(
+      const { container } = render(
         <BubbleConfigProvide>
           <BubbleList bubbleList={bubbleList} />
         </BubbleConfigProvide>,
       );
 
-      // 验证无论角色如何，只有最后一个消息的 isLatest 为 true
-      expect(bubbleList[0].isLatest).toBe(false);
-      expect(bubbleList[1].isLatest).toBe(false);
-      expect(bubbleList[2].isLatest).toBe(false);
-      expect(bubbleList[3].isLatest).toBe(false);
-      expect(bubbleList[4].isLatest).toBe(true);
+      expectBubbleListItemIsLast(container, [
+        false,
+        false,
+        false,
+        false,
+        true,
+      ]);
     });
   });
 
@@ -851,15 +851,13 @@ describe('BubbleList', () => {
         createMockBubbleData('2', 'assistant', 'Second message'),
       ];
 
-      const { rerender } = render(
+      const { container, rerender } = render(
         <BubbleConfigProvide>
           <BubbleList bubbleList={initialBubbleList} />
         </BubbleConfigProvide>,
       );
 
-      // 验证初始状态
-      expect((initialBubbleList[0] as any).isLast).toBe(false);
-      expect((initialBubbleList[1] as any).isLast).toBe(true);
+      expectBubbleListItemIsLast(container, [false, true]);
 
       // 添加新的消息
       const updatedBubbleList: MessageBubbleData[] = [
@@ -873,10 +871,7 @@ describe('BubbleList', () => {
         </BubbleConfigProvide>,
       );
 
-      // 验证 isLast 值已更新：之前的最后一个消息不再是最后一个
-      expect((updatedBubbleList[0] as any).isLast).toBe(false);
-      expect((updatedBubbleList[1] as any).isLast).toBe(false);
-      expect((updatedBubbleList[2] as any).isLast).toBe(true);
+      expectBubbleListItemIsLast(container, [false, false, true]);
     });
 
     it('should update isLast correctly when multiple bubbles are added', () => {
@@ -884,14 +879,13 @@ describe('BubbleList', () => {
         createMockBubbleData('1', 'assistant', 'First message'),
       ];
 
-      const { rerender } = render(
+      const { container, rerender } = render(
         <BubbleConfigProvide>
           <BubbleList bubbleList={initialBubbleList} />
         </BubbleConfigProvide>,
       );
 
-      // 验证初始状态：单个消息时是最后一个
-      expect((initialBubbleList[0] as any).isLast).toBe(true);
+      expectBubbleListItemIsLast(container, [true]);
 
       // 添加两个新消息
       const updatedBubbleList: MessageBubbleData[] = [
@@ -906,10 +900,7 @@ describe('BubbleList', () => {
         </BubbleConfigProvide>,
       );
 
-      // 验证所有消息的 isLast 状态
-      expect((updatedBubbleList[0] as any).isLast).toBe(false);
-      expect((updatedBubbleList[1] as any).isLast).toBe(false);
-      expect((updatedBubbleList[2] as any).isLast).toBe(true);
+      expectBubbleListItemIsLast(container, [false, false, true]);
     });
 
     it('should correctly calculate isLast for each bubble in the list', () => {
@@ -919,21 +910,13 @@ describe('BubbleList', () => {
         createMockBubbleData('3', 'assistant', 'Message 3'),
       ];
 
-      render(
+      const { container } = render(
         <BubbleConfigProvide>
           <BubbleList bubbleList={bubbleList} />
         </BubbleConfigProvide>,
       );
 
-      // 验证每个消息的 isLast 状态
-      expect((bubbleList[0] as any).isLast).toBe(false);
-      expect((bubbleList[1] as any).isLast).toBe(false);
-      expect((bubbleList[2] as any).isLast).toBe(true);
-
-      // 验证 isLast 和 isLatest 保持一致
-      expect((bubbleList[0] as any).isLast).toBe(bubbleList[0].isLatest);
-      expect((bubbleList[1] as any).isLast).toBe(bubbleList[1].isLatest);
-      expect((bubbleList[2] as any).isLast).toBe(bubbleList[2].isLatest);
+      expectBubbleListItemIsLast(container, [false, false, true]);
     });
 
     it('should handle empty bubble list gracefully', () => {
@@ -955,16 +938,13 @@ describe('BubbleList', () => {
         createMockBubbleData('3', 'assistant', 'Message 3'),
       ];
 
-      const { rerender } = render(
+      const { container, rerender } = render(
         <BubbleConfigProvide>
           <BubbleList bubbleList={initialBubbleList} />
         </BubbleConfigProvide>,
       );
 
-      // 验证初始状态
-      expect((initialBubbleList[0] as any).isLast).toBe(false);
-      expect((initialBubbleList[1] as any).isLast).toBe(false);
-      expect((initialBubbleList[2] as any).isLast).toBe(true);
+      expectBubbleListItemIsLast(container, [false, false, true]);
 
       // 移除最后一个消息
       const updatedBubbleList: MessageBubbleData[] = [
@@ -978,9 +958,7 @@ describe('BubbleList', () => {
         </BubbleConfigProvide>,
       );
 
-      // 验证更新后的状态
-      expect((updatedBubbleList[0] as any).isLast).toBe(false);
-      expect((updatedBubbleList[1] as any).isLast).toBe(true);
+      expectBubbleListItemIsLast(container, [false, true]);
     });
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Follow-up (post-review)

- **`bubblePropsAreEqual`**: file-level maintainer notes; `markdownRenderConfig` / `bubbleRenderConfig` / `docListProps` / `customConfig` shallow-compared at top level with one nested object level; `meta.metadata` shallow-compared when meta is compared.
- **Tests**: `bubblePropsAreEqual.test.ts` covers config object reference stability, `renderMode` change, and `metadata` change.
- **Docs**: `docs/components/bubble.md` — performance best practice #4 documents memo / immutability expectations.
- **`Bubble.tsx`**: comment reminds to update `bubblePropsAreEqual` when extending props.

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1abfd04f-7680-477c-b8f5-bc1eca7b6715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1abfd04f-7680-477c-b8f5-bc1eca7b6715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

