### PR TITLE
fix(MarkdownEditor): show paragraphs that wrap void/block children

### DIFF
--- a/src/MarkdownEditor/editor/elements/Paragraph/ReadonlyParagraph.tsx
+++ b/src/MarkdownEditor/editor/elements/Paragraph/ReadonlyParagraph.tsx
@@ -1,6 +1,6 @@
 import classNames from 'clsx';
 import React from 'react';
-import { Node } from 'slate';
+import { Descendant, Element, Node } from 'slate';
 import { ElementProps, ParagraphNode } from '../../../el';
 
 /**
@@ -39,6 +39,9 @@ export const ReadonlyParagraph: React.FC<ElementProps<ParagraphNode>> =
   React.memo((props) => {
     const str = Node.string(props.element).trim();
     const align = props.element.align ?? props.element.otherProps?.align;
+    const hasNestedElement = props.element.children.some((child: Descendant) =>
+      Element.isElement(child),
+    );
 
     return (
       <div
@@ -47,7 +50,7 @@ export const ReadonlyParagraph: React.FC<ElementProps<ParagraphNode>> =
         className={classNames({})}
         data-align={align}
         style={{
-          display: !!str || !!props.children?.at(0).type ? undefined : 'none',
+          display: str || hasNestedElement ? undefined : 'none',
           textAlign: align,
         }}
       >

--- a/src/MarkdownEditor/editor/elements/Paragraph/index.tsx
+++ b/src/MarkdownEditor/editor/elements/Paragraph/index.tsx
@@ -1,6 +1,6 @@
 import classNames from 'clsx';
 import React, { useContext } from 'react';
-import { Node } from 'slate';
+import { Descendant, Element, Node } from 'slate';
 import { I18nContext } from '../../../../I18n';
 import { debugInfo } from '../../../../Utils/debugUtils';
 import { ElementProps, ParagraphNode } from '../../../el';
@@ -36,6 +36,9 @@ export const Paragraph = (props: ElementProps<ParagraphNode>) => {
     const hasOnlyTextNodes = props.element?.children?.every?.(
       (child: any) => !child.type && !child.code && !child.tag,
     );
+    const hasNestedElement = props.element.children.some((child: Descendant) =>
+      Element.isElement(child),
+    );
     // 组合输入进行中时，Slate 模型尚未更新（字符还在 IME 候选区），
     // 此时强制视为非空以隐藏占位符，避免用户输入时占位符仍然可见。
     const isEmpty =
@@ -66,7 +69,7 @@ export const Paragraph = (props: ElementProps<ParagraphNode>) => {
         }}
         data-empty={isEmpty}
         style={{
-          display: !!str || !!props.children?.at(0).type ? undefined : 'none',
+          display: str || hasNestedElement ? undefined : 'none',
           textAlign: align,
         }}
       >
@@ -74,6 +77,7 @@ export const Paragraph = (props: ElementProps<ParagraphNode>) => {
       </div>
     );
   }, [
+    props.element,
     props.element.children,
     align,
     readonly,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Paragraph visibility used `props.children?.at(0).type` to decide whether to apply `display: none`. Slate often passes `children` as a single wrapper element without a `type` property, so paragraphs that actually contained nested blocks (for example mermaid or other inline/void content) were incorrectly hidden. That matched reports of empty chart areas and raw diagram source showing without the rendered layer.

## Changes

- Derive visibility from the Slate model: if `Node.string` is non-empty **or** any child in `element.children` is an element (`Element.isElement`), keep `display` visible.
- Apply the same logic to `ReadonlyParagraph`.
- Include `props.element` in the `Paragraph` `useMemo` dependency list so nested structure updates recompute visibility.

## Testing

- `pnpm tsc`
- `pnpm exec vitest run src/MarkdownEditor/editor/__tests__/Editor.test.tsx`

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb63bafe-b32d-49fe-a0f3-e4c101cb9946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb63bafe-b32d-49fe-a0f3-e4c101cb9946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

