### PR TITLE
fix(bubble): lazy 列表项避免 display:contents 导致 LazyElement 不渲染

### DIFF
--- a/src/Bubble/List/index.tsx
+++ b/src/Bubble/List/index.tsx
@@ -505,10 +505,16 @@ export const BubbleList: React.FC<BubbleListProps> = (props) => {
       }
       const mergedStyles = bubbleMergedStylesRef.current.get(itemKey)!;
 
+      // LazyElement 依赖被观察元素的几何尺寸；display:contents 不产生盒子，会导致
+      // IntersectionObserver 在部分环境下永不触发，气泡永远不渲染。
+      const useLazyWrapper =
+        !!isLazyEnabled &&
+        (props.lazy?.shouldLazyLoad?.(index, totalCount) ?? true);
+
       const bubbleElement = (
         <div
           key={itemKey}
-          style={{ display: 'contents' }}
+          style={useLazyWrapper ? { minWidth: 0, width: '100%' } : { display: 'contents' }}
           data-bubble-list-item
           data-is-last={isLast ? 'true' : 'false'}
         >
@@ -548,7 +554,15 @@ export const BubbleList: React.FC<BubbleListProps> = (props) => {
         </div>
       );
 
-      return { itemKey, bubbleElement, isLazyEnabled, index, item, totalCount };
+      return {
+        itemKey,
+        bubbleElement,
+        isLazyEnabled,
+        index,
+        item,
+        totalCount,
+        useLazyWrapper,
+      };
     });
 
     for (const k of bubbleMergedStylesRef.current.keys()) {
@@ -570,15 +584,12 @@ export const BubbleList: React.FC<BubbleListProps> = (props) => {
         index,
         item,
         totalCount: count,
+        useLazyWrapper,
       }) => {
       // 如果启用了懒加载，用 LazyElement 包裹
       if (lazyOn) {
-        // 检查是否应该对该消息启用懒加载
-        const shouldLazyLoad =
-          props.lazy?.shouldLazyLoad?.(index, count) ?? true;
-
         // 如果不需要懒加载，直接返回元素
-        if (!shouldLazyLoad) {
+        if (!useLazyWrapper) {
           return bubbleElement;
         }
 

--- a/tests/BubbleList.test.tsx
+++ b/tests/BubbleList.test.tsx
@@ -1101,6 +1101,45 @@ describe('BubbleList', () => {
       expect(observeSpy).toHaveBeenCalled();
     });
 
+    it('lazy 模式下列表行不应使用 display:contents，以便 LazyElement 能观测到几何尺寸', () => {
+      const bubbleList: MessageBubbleData[] = [
+        createMockBubbleData('1', 'user', 'Test message'),
+      ];
+
+      global.IntersectionObserver = class {
+        constructor(public callback: IntersectionObserverCallback) {}
+        observe = (el: Element) => {
+          this.callback(
+            [
+              {
+                isIntersecting: true,
+                target: el,
+              } as IntersectionObserverEntry,
+            ],
+            this as unknown as IntersectionObserver,
+          );
+        };
+        unobserve = vi.fn();
+        disconnect = vi.fn();
+        takeRecords = vi.fn(() => []);
+        root = null;
+        rootMargin = '';
+        thresholds = [];
+      } as any;
+
+      const { container } = render(
+        <BubbleConfigProvide>
+          <BubbleList bubbleList={bubbleList} lazy={{ enable: true }} />
+        </BubbleConfigProvide>,
+      );
+
+      const row = container.querySelector('[data-bubble-list-item]');
+      expect(row).toBeTruthy();
+      const inlineStyle = row?.getAttribute('style') || '';
+      expect(inlineStyle).not.toMatch(/display:\s*contents/);
+      expect(inlineStyle).toMatch(/min-width:\s*0/);
+    });
+
     it('should use default placeholderHeight when not provided', () => {
       const bubbleList: MessageBubbleData[] = [
         createMockBubbleData('1', 'user', 'Test message'),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`BubbleList` 在启用 `lazy` 时，列表行外层使用了 `display: contents`。`LazyElement` 的 `IntersectionObserver` 需要被观察元素有布局盒子；`display: contents` 不产生盒子，在部分环境下相交检测永远不触发，气泡内容会一直停留在占位阶段，表现为空白。

## Changes

- 对需要被 `LazyElement` 包裹的行使用普通块级容器（`minWidth: 0`, `width: 100%`），不再使用 `display: contents`。
- `shouldLazyLoad` 为 false 的行仍使用 `display: contents`，保持与原先非懒加载列表的布局一致。
- 增加单测：懒加载模式下 `[data-bubble-list-item]` 的内联样式不含 `display: contents`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45093fe1-ef8e-4fbc-bb3c-9e9fe48faf8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45093fe1-ef8e-4fbc-bb3c-9e9fe48faf8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

