### PR TITLE
fix(mermaid): 剥离误传入的 Markdown 围栏，修复流程图空白

### DIFF
--- a/src/Plugins/mermaid/useMermaidRender.ts
+++ b/src/Plugins/mermaid/useMermaidRender.ts
@@ -7,6 +7,7 @@ import {
   createMermaidThemeConfig,
   loadMermaid,
   renderSvgToContainer,
+  stripMermaidMarkdownFence,
 } from './utils';
 
 /**
@@ -75,7 +76,7 @@ export const useMermaidRender = (
           appliedThemeCacheKeyRef.current = themeConfig.cacheKey;
         }
 
-        const trimmedCode = code.trim();
+        const trimmedCode = stripMermaidMarkdownFence(code).trim();
         if (!trimmedCode) {
           renderedSignatureRef.current = '';
           setRenderedCode('');
@@ -87,10 +88,7 @@ export const useMermaidRender = (
           return;
         }
 
-        const { svg } = await api.render(
-          id,
-          trimmedCode.endsWith('```') ? trimmedCode : trimmedCode,
-        );
+        const { svg } = await api.render(id, trimmedCode);
 
         if (latestRenderSignatureRef.current !== currentSignature) {
           timer.current = null;

--- a/src/Plugins/mermaid/utils.ts
+++ b/src/Plugins/mermaid/utils.ts
@@ -242,6 +242,33 @@ export const loadMermaid = async (): Promise<MermaidApi> => {
 };
 
 /**
+ * 若整段文本误带了 Markdown 围栏（常见于从 ```mermaid 块复制），去掉首尾围栏再交给 Mermaid。
+ */
+export const stripMermaidMarkdownFence = (raw: string): string => {
+  let text = raw.trim();
+  if (!text.startsWith('```')) {
+    return raw;
+  }
+
+  const firstNewline = text.indexOf('\n');
+  const openLine =
+    firstNewline === -1 ? text.slice(3).trim() : text.slice(3, firstNewline).trim();
+  const openLower = openLine.toLowerCase();
+  if (openLower !== 'mermaid' && !openLower.startsWith('mermaid ')) {
+    return raw;
+  }
+
+  const bodyStart = firstNewline === -1 ? text.length : firstNewline + 1;
+  let body = text.slice(bodyStart);
+  const closeIdx = body.lastIndexOf('```');
+  if (closeIdx !== -1) {
+    body = body.slice(0, closeIdx);
+  }
+
+  return body.trimEnd();
+};
+
+/**
  * 渲染 SVG 到容器
  */
 export const renderSvgToContainer = (

--- a/tests/plugins/mermaid/useMermaidRender.test.tsx
+++ b/tests/plugins/mermaid/useMermaidRender.test.tsx
@@ -156,6 +156,26 @@ describe('useMermaidRender', () => {
       expect(result.current.renderedCode).toBe('graph TD');
     });
 
+    it('应在整段为 ```mermaid 围栏时把内文传给 mermaid.render', async () => {
+      const mockRender = vi.fn().mockResolvedValue({ svg: '<svg></svg>' });
+      mockLoadMermaid.mockResolvedValue({ render: mockRender });
+
+      const fenced =
+        '```mermaid\nflowchart LR\n  A[政策] --> B[装机]\n```';
+
+      renderHook(() => useMermaidRender(fenced, divRef, 'test-id', true));
+
+      await act(async () => {
+        vi.advanceTimersByTime(200);
+        await vi.runAllTimersAsync();
+      });
+
+      expect(mockRender).toHaveBeenCalledWith(
+        'test-id',
+        'flowchart LR\n  A[政策] --> B[装机]',
+      );
+    });
+
     it('应该处理空代码（trim 后为空）', async () => {
       const { result } = renderHook(() =>
         useMermaidRender('   ', divRef, 'test-id', true),

--- a/tests/plugins/mermaid/utils.test.ts
+++ b/tests/plugins/mermaid/utils.test.ts
@@ -7,6 +7,7 @@ import {
   cleanupTempElement,
   loadMermaid,
   renderSvgToContainer,
+  stripMermaidMarkdownFence,
 } from '../../../src/Plugins/mermaid/utils';
 
 // Mock mermaid module
@@ -87,6 +88,22 @@ describe('Mermaid utils', () => {
       // 但我们可以验证 API 的基本结构
       const api = await loadMermaid();
       expect(api).toBeDefined();
+    });
+  });
+
+  describe('stripMermaidMarkdownFence', () => {
+    it('应去掉 ```mermaid 围栏，保留正文', () => {
+      const raw = '```mermaid\nflowchart LR\n  A --> B\n```';
+      expect(stripMermaidMarkdownFence(raw)).toBe('flowchart LR\n  A --> B');
+    });
+
+    it('非 mermaid 围栏或普通文本应原样返回', () => {
+      expect(stripMermaidMarkdownFence('```js\nconst x = 1\n```')).toBe(
+        '```js\nconst x = 1\n```',
+      );
+      expect(stripMermaidMarkdownFence('flowchart LR\nA --> B')).toBe(
+        'flowchart LR\nA --> B',
+      );
     });
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When the Mermaid code passed to `mermaid.render` accidentally includes a full Markdown fence (for example the entire block was pasted as `` ```mermaid ... ``` ``), Mermaid treats it as invalid diagram text. The UI can end up showing an empty diagram area instead of the expected flowchart.

## Solution

- Add `stripMermaidMarkdownFence` in `src/Plugins/mermaid/utils.ts` to detect a leading `` ```mermaid `` (or `` ```mermaid ... ``) fence and strip the opening line plus the trailing `` ``` `` before rendering.
- `useMermaidRender` now trims via this helper so both the editor path and Markdown renderer path benefit.
- Unit tests cover the helper and the hook calling `render` with the stripped body.

## Notes

- Non-mermaid fenced blocks and plain diagram text are left unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45093fe1-ef8e-4fbc-bb3c-9e9fe48faf8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45093fe1-ef8e-4fbc-bb3c-9e9fe48faf8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

