### PR TITLE
fix(MarkdownRenderer): stabilize streaming pipe tables and block promotion

### DIFF
--- a/src/MarkdownRenderer/__tests__/markdownReactShared.test.ts
+++ b/src/MarkdownRenderer/__tests__/markdownReactShared.test.ts
@@ -48,6 +48,30 @@ describe('splitMarkdownBlocks', () => {
     const result = splitMarkdownBlocks(md);
     expect(result.length).toBe(3);
   });
+
+  it('splits a completed pipe table from following content on a single blank line', () => {
+    const table =
+      '| a | b |\n|:-:|:-:|\n| 1 | 2 |';
+    const md = `${table}\n\n### Next`;
+    const result = splitMarkdownBlocks(md);
+    expect(result.length).toBe(2);
+    expect(result[0]).toBe(table);
+    expect(result[1]).toBe('\n\n### Next');
+  });
+
+  it('keeps prose and fenced block in one chunk without double blank between them', () => {
+    const md = 'Intro\n```mermaid\nx\n```\n\nAfter';
+    const result = splitMarkdownBlocks(md);
+    expect(result).toEqual([md]);
+  });
+
+  it('does not split pipe table until the table is complete', () => {
+    const partial =
+      '| a | b |\n|:-:|:-:|\n| 1 |';
+    const result = splitMarkdownBlocks(`${partial}\n\nMore`);
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(`${partial}\n\nMore`);
+  });
 });
 
 describe('createHastProcessor', () => {

--- a/src/MarkdownRenderer/__tests__/useStreamingMarkdownReact.cache.test.tsx
+++ b/src/MarkdownRenderer/__tests__/useStreamingMarkdownReact.cache.test.tsx
@@ -1,7 +1,18 @@
-import { renderHook } from '@testing-library/react';
+import { render } from '@testing-library/react';
+import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as markdownReactShared from '../markdownReactShared';
 import { useStreamingMarkdownReact } from '../streaming/useStreamingMarkdownReact';
+
+const StreamingMarkdownHarness: React.FC<{
+  content: string;
+}> = ({ content }) => {
+  const node = useStreamingMarkdownReact(content, {
+    streaming: true,
+    contentRevisionSource: content,
+  });
+  return <div data-testid="streaming-md-root">{node}</div>;
+};
 
 describe('useStreamingMarkdownReact sealed subtree cache', () => {
   beforeEach(() => {
@@ -14,19 +25,30 @@ describe('useStreamingMarkdownReact sealed subtree cache', () => {
     const md1 = 'sealed\n\n\n';
     const md2 = 'sealed\n\n\ntail';
 
-    const { rerender } = renderHook(
-      ({ content }: { content: string }) =>
-        useStreamingMarkdownReact(content, {
-          streaming: true,
-          contentRevisionSource: content,
-        }),
-      { initialProps: { content: md1 } },
-    );
+    const { rerender } = render(<StreamingMarkdownHarness content={md1} />);
 
     const countAfterFirst = spy.mock.calls.length;
     expect(countAfterFirst).toBeGreaterThan(0);
 
-    rerender({ content: md2 });
+    rerender(<StreamingMarkdownHarness content={md2} />);
+
+    expect(spy.mock.calls.length - countAfterFirst).toBe(1);
+  });
+
+  it('does not re-parse a sealed pipe table when only content after the table grows', () => {
+    const spy = vi.spyOn(markdownReactShared, 'renderMarkdownBlock');
+
+    const table = '| a | b |\n|:-:|:-:|\n| 1 | 2 |';
+    const md1 = `${table}\n\n### `;
+    // 末块节流：纯字母增量可能跳过 parse；换行触发边界以稳定断言「仅 tail 再算一次」
+    const md2 = `${table}\n\n### Sec\n`;
+
+    const { rerender } = render(<StreamingMarkdownHarness content={md1} />);
+
+    const countAfterFirst = spy.mock.calls.length;
+    expect(countAfterFirst).toBeGreaterThan(0);
+
+    rerender(<StreamingMarkdownHarness content={md2} />);
 
     expect(spy.mock.calls.length - countAfterFirst).toBe(1);
   });

--- a/src/MarkdownRenderer/markdownReactShared.ts
+++ b/src/MarkdownRenderer/markdownReactShared.ts
@@ -1013,7 +1013,99 @@ const renderMarkdownBlock = (
   }
 };
 
-/** 按双换行拆块，尊重代码围栏边界 */
+const isPipeTableRowLine = (line: string): boolean =>
+  line.trimStart().startsWith('|');
+
+const parsePipeRowCellsForSplit = (line: string): string[] | null => {
+  const trimmedLine = line.trim();
+  if (!trimmedLine.startsWith('|') || !trimmedLine.endsWith('|')) {
+    return null;
+  }
+  const cells = trimmedLine
+    .split('|')
+    .slice(1, -1)
+    .map((cell) => cell.trim());
+  if (!cells.length) return null;
+  return cells;
+};
+
+/** GFM 对齐行单元格：`:---`、`:--:`、`---:` 等，中间至少 1 个 `-` */
+const isTableSeparatorCellForSplit = (cell: string): boolean =>
+  /^:?-{1,}:?$/.test(cell);
+
+/**
+ * 连续管道行是否构成完整 GFM 表格（不含表后空行）。
+ * 用于拆块：表完成后可密封，避免与后续段落同处 tail 反复 parse。
+ */
+const isCompleteGfmPipeTableLines = (tableLines: string[]): boolean => {
+  if (tableLines.length < 3) return false;
+  const [header, separator, ...dataRows] = tableLines;
+  const headerCells = parsePipeRowCellsForSplit(header);
+  if (!headerCells) return false;
+  const separatorCells = parsePipeRowCellsForSplit(separator);
+  if (
+    !separatorCells ||
+    separatorCells.length !== headerCells.length ||
+    !separatorCells.every(isTableSeparatorCellForSplit)
+  ) {
+    return false;
+  }
+  for (const row of dataRows) {
+    const cells = parsePipeRowCellsForSplit(row);
+    if (!cells || cells.length !== headerCells.length) return false;
+  }
+  return true;
+};
+
+/**
+ * 若缓冲区以「完整 GFM 管道表 +（可选空行）+ 非管道续行」结尾，则拆出表为独立块。
+ * tail 保留表后的空行与续行，以便流式末块继续增长且与单块解析字符串一致。
+ */
+const maybeSplitTrailingCompletedTable = (
+  current: string[],
+  blocks: string[],
+): void => {
+  if (current.length < 4) return;
+  const ls = current;
+
+  let lastNonEmpty = ls.length - 1;
+  while (lastNonEmpty >= 0 && ls[lastNonEmpty].trim() === '') {
+    lastNonEmpty -= 1;
+  }
+  if (lastNonEmpty < 0) return;
+  // 末尾仍是管道行：仍在扩表或仅表后空白，勿拆（避免 table+\n 时误封）
+  if (isPipeTableRowLine(ls[lastNonEmpty])) return;
+
+  let end = lastNonEmpty - 1;
+  while (end >= 0 && ls[end].trim() === '') end -= 1;
+  if (end < 0 || !isPipeTableRowLine(ls[end])) return;
+
+  let i = end;
+  while (i >= 0 && isPipeTableRowLine(ls[i])) i -= 1;
+  const tableLines = ls.slice(i + 1, end + 1);
+  if (tableLines.length < 3 || !isCompleteGfmPipeTableLines(tableLines)) {
+    return;
+  }
+
+  const prefixLines = ls.slice(0, i + 1);
+  const prefixJoined = prefixLines.join('\n');
+  const tableJoined = tableLines.join('\n');
+  const tailLines = ls.slice(end + 1);
+
+  if (prefixJoined) {
+    blocks.push(prefixJoined);
+  }
+  blocks.push(tableJoined);
+
+  current.length = 0;
+  // 保留「表末行之后」的首个换行：仅用 slice 会丢掉行分隔符，导致 tail 与原文前缀不一致
+  const tailStr = tailLines.length ? `\n${tailLines.join('\n')}` : '';
+  if (tailStr) {
+    current.push(...tailStr.split('\n'));
+  }
+};
+
+/** 按双换行拆块，尊重代码围栏边界；完整管道表结束后拆块（利于流式缓存） */
 const splitMarkdownBlocks = (content: string): string[] => {
   const lines = content.split('\n');
   const blocks: string[] = [];
@@ -1022,20 +1114,32 @@ const splitMarkdownBlocks = (content: string): string[] => {
 
   for (const line of lines) {
     const trimmed = line.trimStart();
-    if (trimmed.startsWith('```') || trimmed.startsWith('~~~')) {
-      inFence = !inFence;
-    }
-    if (!inFence && line === '' && current.length > 0) {
+    const isFenceLine =
+      trimmed.startsWith('```') || trimmed.startsWith('~~~');
+
+    if (!inFence && !isFenceLine && line === '' && current.length > 0) {
       const prev = current[current.length - 1];
       if (prev === '') {
         // 触发分割的是「第二个连续空行」，不应并入上一块末尾，否则与单块解析结果字符串不一致、缓存失效
         const withoutTrailingBlank = current.slice(0, -1);
-        blocks.push(withoutTrailingBlank.join('\n'));
+        const flushed = withoutTrailingBlank.join('\n');
+        if (flushed) {
+          blocks.push(flushed);
+        }
         current = [];
         continue;
       }
     }
+
+    if (isFenceLine) {
+      inFence = !inFence;
+    }
+
     current.push(line);
+
+    if (!inFence) {
+      maybeSplitTrailingCompletedTable(current, blocks);
+    }
   }
   if (current.length > 0) {
     blocks.push(current.join('\n'));

--- a/src/MarkdownRenderer/streaming/useStreamingMarkdownReact.tsx
+++ b/src/MarkdownRenderer/streaming/useStreamingMarkdownReact.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useEffect, useMemo, useRef } from 'react';
+import React, { useMemo, useRef } from 'react';
 import { Fragment, jsx, jsxs } from 'react/jsx-runtime';
 import {
   JINJA_DOLLAR_PLACEHOLDER,
@@ -8,34 +8,15 @@ import {
 import {
   buildEditorAlignedComponents,
   createHastProcessor,
-  renderMarkdownBlock,
   splitMarkdownBlocks,
   type UseMarkdownToReactOptions,
 } from '../markdownReactShared';
-import { StreamingAnimationContext } from '../StreamingAnimationContext';
 
 import { MarkdownBlockPiece } from './MarkdownBlockPiece';
 import { shouldResetRevisionProgress } from './revisionPolicy';
 
-interface SealedSubtreeProps {
-  children: React.ReactNode;
-}
-
-/** 已密封块：子树在 hook 层缓存，避免父 Fragment 重建时整段子树 reconcile */
-const SealedMarkdownSubtree = memo(function SealedMarkdownSubtree({
-  children,
-}: SealedSubtreeProps) {
-  return (
-    <StreamingAnimationContext.Provider value={{ animateBlock: false }}>
-      {children}
-    </StreamingAnimationContext.Provider>
-  );
-});
-
-SealedMarkdownSubtree.displayName = 'SealedMarkdownSubtree';
-
 /**
- * 流式优先的 Markdown → React：每块独立 memo 组件；tail 与 sealed 共用组件类型以便块晋升时复用实例。
+ * 流式优先的 Markdown → React：每块独立 memo 组件；tail 与 sealed 共用 MarkdownBlockPiece，块数从 1→N 时首块不因宿主类型切换而 remount。
  */
 export const useStreamingMarkdownReact = (
   content: string,
@@ -48,10 +29,6 @@ export const useStreamingMarkdownReact = (
 
   const prevRevisionRef = useRef<string | undefined>(undefined);
   const revisionGenerationRef = useRef(0);
-  /** 修订代 + 块下标 → 已解析子树，供密封块跨父级 useMemo 周期复用同一 React 元素引用 */
-  const sealedSubtreeCacheRef = useRef<
-    Map<string, { source: string; node: React.ReactNode }>
-  >(new Map());
 
   const processor = useMemo(
     () => createHastProcessor(options?.remarkPlugins, options?.htmlConfig),
@@ -82,14 +59,9 @@ export const useStreamingMarkdownReact = (
     ],
   );
 
-  useEffect(() => {
-    sealedSubtreeCacheRef.current.clear();
-  }, [processor, components]);
-
   return useMemo(() => {
     if (!content) {
       prevRevisionRef.current = '';
-      sealedSubtreeCacheRef.current.clear();
       return null;
     }
 
@@ -99,7 +71,6 @@ export const useStreamingMarkdownReact = (
       shouldResetRevisionProgress(prevRev, revisionSource)
     ) {
       revisionGenerationRef.current += 1;
-      sealedSubtreeCacheRef.current.clear();
     }
     prevRevisionRef.current = revisionSource;
 
@@ -117,43 +88,18 @@ export const useStreamingMarkdownReact = (
         const isLast = index === blocks.length - 1;
         // 仅用修订代 + 块下标作 key，避免末块随文本增长导致 identity 变化而整段 remount
         const key = `b-${gen}-${index}`;
-        if (isLast) {
-          return jsx(
-            MarkdownBlockPiece,
-            {
-              variant: 'tail',
-              blockSource,
-              processor,
-              components,
-              streaming: !!options?.streaming,
-            },
-            key,
-          );
-        }
-
-        const cacheKey = `${gen}:${index}`;
-        const cache = sealedSubtreeCacheRef.current;
-        const hit = cache.get(cacheKey);
-        const node =
-          hit && hit.source === blockSource
-            ? hit.node
-            : renderMarkdownBlock(blockSource, processor, components);
-        cache.set(cacheKey, { source: blockSource, node });
-
-        return jsx(SealedMarkdownSubtree, { children: node }, key);
+        return jsx(
+          MarkdownBlockPiece,
+          {
+            variant: isLast ? 'tail' : 'sealed',
+            blockSource,
+            processor,
+            components,
+            streaming: !!options?.streaming,
+          },
+          key,
+        );
       });
-
-      const maxSealedIndex = blocks.length - 2;
-      if (maxSealedIndex >= 0) {
-        const cachePrefix = `${gen}:`;
-        for (const k of [...sealedSubtreeCacheRef.current.keys()]) {
-          if (!k.startsWith(cachePrefix)) continue;
-          const idx = Number(k.slice(cachePrefix.length));
-          if (Number.isNaN(idx) || idx > maxSealedIndex) {
-            sealedSubtreeCacheRef.current.delete(k);
-          }
-        }
-      }
 
       return jsxs(Fragment, { children: elements });
     } catch (error) {

--- a/src/MarkdownRenderer/useStreaming.ts
+++ b/src/MarkdownRenderer/useStreaming.ts
@@ -68,7 +68,7 @@ const parsePipeRowCells = (line: string): string[] | null => {
 };
 
 const isTableSeparatorCell = (cell: string): boolean => {
-  return /^:?-{3,}:?$/.test(cell);
+  return /^:?-{1,}:?$/.test(cell);
 };
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Streaming markdown in Bubble demos re-parsed pipe tables and heavy blocks (e.g. Mermaid) on every small tail update because:

1. **Block splitting** only broke on double blank lines, so a completed GFM pipe table often stayed in the same tail block as the following heading/fence.
2. **Separator detection** required three hyphens per cell, so `|:-:|:-:|` was not treated as a complete table for split/cache purposes (out of sync with `useStreaming`).
3. When block count grew from 1 to N, the first block switched host type (`MarkdownBlockPiece` → `SealedMarkdownSubtree`), causing a remount even when the source was unchanged.

## Changes

- `splitMarkdownBlocks`: after a complete pipe table, split once real non-pipe continuation exists; preserve leading newlines in the tail buffer; skip pushing empty chunks on double-blank flush.
- `useStreaming`: align separator cell regex with split logic (`:-:`, etc.).
- `useStreamingMarkdownReact`: render sealed blocks with `MarkdownBlockPiece` (`variant: 'sealed'`) so promotion from single-block tail to multi-block does not remount the first subtree.
- Tests: table split expectations, harness-based cache tests, document single-blank prose+fence behavior.

## Verification

- `pnpm tsc --noEmit`
- `pnpm exec vitest run` on affected MarkdownRenderer test files (streaming stability, chart/card stability, splitMarkdownBlocks, useStreaming, cache tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5436b25f-88d2-456a-b362-7a5eac77ba3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5436b25f-88d2-456a-b362-7a5eac77ba3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

