### PR TITLE
fix(MarkdownInputField): prevent markdownProps.readonly from locking input

### DIFF
--- a/src/MarkdownEditor/editor/plugins/__tests__/withSanitizeInvalidChildren.test.ts
+++ b/src/MarkdownEditor/editor/plugins/__tests__/withSanitizeInvalidChildren.test.ts
@@ -1,4 +1,6 @@
 import { createEditor, Editor, Node } from 'slate';
+import { withReact } from 'slate-react';
+import { withMarkdown } from '../withMarkdown';
 import { withSanitizeInvalidChildren } from '../withSanitizeInvalidChildren';
 
 describe('withSanitizeInvalidChildren', () => {
@@ -94,5 +96,22 @@ describe('withSanitizeInvalidChildren', () => {
     expect(() =>
       editor.normalizeNode([{ text: 'hi' }, [0, 0]] as any),
     ).not.toThrow();
+  });
+
+  it('wraps bare text at editor root into a paragraph (fixes duplicate DOM / broken delete)', () => {
+    const editor = withSanitizeInvalidChildren(withMarkdown(withReact(createEditor())));
+    editor.children = [
+      { text: '山西' },
+      { type: 'paragraph', children: [{ text: '山西' }] },
+    ] as any;
+
+    Editor.normalize(editor, { force: true });
+
+    expect(editor.children).toEqual([
+      {
+        type: 'paragraph',
+        children: [{ text: '山西' }],
+      },
+    ]);
   });
 });

--- a/src/MarkdownEditor/editor/plugins/useKeyboard.ts
+++ b/src/MarkdownEditor/editor/plugins/useKeyboard.ts
@@ -92,6 +92,7 @@ export const useKeyboard = (
     setJinjaAnchorPath,
     jinjaTemplatePanelEnabled,
     editorProps,
+    readonly,
   } = useEditorStore();
   // 从 editorProps.jinja 读取（BaseMarkdownEditor 已写入 effectiveJinja），支持插件配置的 trigger
   const effectiveJinja = editorProps?.jinja;
@@ -115,8 +116,8 @@ export const useKeyboard = (
     const backspace = new BackspaceKey(markdownEditorRef.current);
     const enter = new EnterKey(store, backspace);
     return (e: React.KeyboardEvent) => {
-      // 只读模式下跳过所有键盘处理，提升性能
-      if (props.readonly) return;
+      // 只读模式下跳过所有键盘处理，提升性能（以 EditorStoreContext 为准，避免 props 闭包陈旧）
+      if (readonly) return;
 
       // 处理表格键盘事件
       if (NativeTableKeyboard.shouldHandle(markdownEditorRef.current)) {
@@ -323,7 +324,7 @@ export const useKeyboard = (
     };
   }, [
     markdownEditorRef.current,
-    props?.readonly,
+    readonly,
     openInsertCompletion,
     insertCompletionText$,
     setOpenInsertCompletion,

--- a/src/MarkdownEditor/editor/plugins/withSanitizeInvalidChildren.ts
+++ b/src/MarkdownEditor/editor/plugins/withSanitizeInvalidChildren.ts
@@ -32,6 +32,82 @@ const createDefaultBlock = () => ({
   children: [{ text: '' }],
 });
 
+/**
+ * Slate 要求 editor 根下只能是块级节点；若出现裸 Text 或根级 inline，
+ * 会导致 DOM 异常（如文本与块并列）、重复显示与 Backspace 失效。
+ * 将连续的「非块」根子节点合并为一个段落包裹。
+ */
+const isSingletonTextParagraph = (node: Node): node is Element & { children: [Text] } => {
+  if (!Element.isElement(node) || (node as { type?: string }).type !== 'paragraph') {
+    return false;
+  }
+  const ch = (node as { children?: unknown }).children;
+  if (!Array.isArray(ch) || ch.length !== 1 || !Text.isText(ch[0])) {
+    return false;
+  }
+  return true;
+};
+
+/**
+ * 裸 Text 与紧随其后的「同文单段」常来自非法根结构的双份展示；保留块节点、丢弃缓冲重复。
+ */
+const bufferMatchesFollowingSingletonParagraph = (
+  buffer: Node[],
+  block: Node,
+): boolean => {
+  if (buffer.length !== 1 || !Text.isText(buffer[0])) return false;
+  if (!isSingletonTextParagraph(block)) return false;
+  return buffer[0].text === Node.string(block);
+};
+
+const ensureRootOnlyBlockChildren = (editor: Editor, nodes: Node[]): Node[] => {
+  const out: Node[] = [];
+  let nonBlockBuffer: Node[] = [];
+
+  const flushNonBlocks = () => {
+    if (nonBlockBuffer.length === 0) return;
+    out.push({
+      type: 'paragraph',
+      children: nonBlockBuffer,
+    } as Node);
+    nonBlockBuffer = [];
+  };
+
+  for (const child of nodes) {
+    if (!isValidChild(child)) continue;
+    if (Text.isText(child)) {
+      nonBlockBuffer.push(child);
+      continue;
+    }
+    if (Element.isElement(child) && Editor.isBlock(editor, child)) {
+      if (bufferMatchesFollowingSingletonParagraph(nonBlockBuffer, child)) {
+        nonBlockBuffer = [];
+        out.push(child);
+        continue;
+      }
+      flushNonBlocks();
+      out.push(child);
+      continue;
+    }
+    nonBlockBuffer.push(child);
+  }
+  flushNonBlocks();
+  return out.length > 0 ? out : [createDefaultBlock()];
+};
+
+const rootHasNonBlockChild = (editor: Editor, childList: unknown[]): boolean => {
+  for (let i = 0; i < childList.length; i += 1) {
+    if (!(i in childList)) continue;
+    const c = childList[i];
+    if (!isValidChild(c)) continue;
+    if (Text.isText(c as Node)) return true;
+    if (Element.isElement(c as Node) && !Editor.isBlock(editor, c as Node)) {
+      return true;
+    }
+  }
+  return false;
+};
+
 const rebuildElement = (node: Node): Node => {
   let children = getChildList(node).filter(isValidChild) as Node[];
   if (
@@ -192,7 +268,17 @@ export const withSanitizeInvalidChildren = (editor: Editor) => {
         const fixedTop = compactEditorRootChildren(childList);
         const nextNodes =
           fixedTop.length === 0 ? [createDefaultBlock()] : fixedTop;
-        EditorUtils.replaceEditorContent(editor, nextNodes);
+        const wrapped = ensureRootOnlyBlockChildren(editor, nextNodes);
+        EditorUtils.replaceEditorContent(editor, wrapped);
+        normalizeNode(entry);
+        return;
+      }
+      if (rootHasNonBlockChild(editor, childList)) {
+        const wrapped = ensureRootOnlyBlockChildren(
+          editor,
+          childList.filter(isValidChild) as Node[],
+        );
+        EditorUtils.replaceEditorContent(editor, wrapped);
         normalizeNode(entry);
         return;
       }

--- a/src/MarkdownInputField/MarkdownInputField.tsx
+++ b/src/MarkdownInputField/MarkdownInputField.tsx
@@ -1,6 +1,6 @@
 import { ConfigProvider } from 'antd';
 import classNames from 'clsx';
-import React, { memo, useContext, useState } from 'react';
+import React, { memo, useContext, useMemo, useState } from 'react';
 import { TextLoading } from '../Components/lotties/TextLoading';
 import { useLocale } from '../I18n';
 import { BaseMarkdownEditor } from '../MarkdownEditor';
@@ -246,6 +246,12 @@ const MarkdownInputFieldComponent: React.FC<MarkdownInputFieldProps> = ({
     isLoading,
   });
 
+  const markdownEditorPassThroughProps = useMemo(() => {
+    if (!markdownProps) return undefined;
+    const { readonly: _readonlyFromMarkdownProps, ...rest } = markdownProps;
+    return rest;
+  }, [markdownProps]);
+
   const editorReadonly = isLoading || !!props.typing;
 
   const sendActionsNode = useSendActionsNode({
@@ -407,7 +413,6 @@ const MarkdownInputFieldComponent: React.FC<MarkdownInputFieldProps> = ({
                 floatBar={{
                   enable: false,
                 }}
-                readonly={editorReadonly}
                 contentStyle={{
                   alignItems: 'flex-start',
                   padding: 'var(--padding-3x)',
@@ -468,7 +473,8 @@ const MarkdownInputFieldComponent: React.FC<MarkdownInputFieldProps> = ({
                   plainTextOnly: true,
                   ...props.pasteConfig,
                 }}
-                {...markdownProps}
+                {...markdownEditorPassThroughProps}
+                readonly={editorReadonly}
               >
                 {props?.quickActionRender ||
                 props.refinePrompt?.enable ||

--- a/src/MarkdownInputField/MarkdownInputField.tsx
+++ b/src/MarkdownInputField/MarkdownInputField.tsx
@@ -246,11 +246,24 @@ const MarkdownInputFieldComponent: React.FC<MarkdownInputFieldProps> = ({
     isLoading,
   });
 
-  const markdownEditorPassThroughProps = useMemo(() => {
-    if (!markdownProps) return undefined;
-    const { readonly: _readonlyFromMarkdownProps, ...rest } = markdownProps;
-    return rest;
-  }, [markdownProps]);
+  const { markdownEditorRestProps, markdownPropsEditorOnChange } =
+    useMemo(() => {
+      if (!markdownProps) {
+        return {
+          markdownEditorRestProps: undefined,
+          markdownPropsEditorOnChange: undefined,
+        };
+      }
+      const {
+        readonly: _readonlyFromMarkdownProps,
+        onChange: mdEditorOnChange,
+        ...rest
+      } = markdownProps;
+      return {
+        markdownEditorRestProps: rest,
+        markdownPropsEditorOnChange: mdEditorOnChange,
+      };
+    }, [markdownProps]);
 
   const editorReadonly = isLoading || !!props.typing;
 
@@ -428,7 +441,7 @@ const MarkdownInputFieldComponent: React.FC<MarkdownInputFieldProps> = ({
                   ...tagInputProps,
                 }}
                 initValue={props.value}
-                onChange={(value) => {
+                onChange={(value, schema) => {
                   // 检查并限制字符数
                   if (props.maxLength !== undefined) {
                     if (value.length > props.maxLength) {
@@ -437,6 +450,7 @@ const MarkdownInputFieldComponent: React.FC<MarkdownInputFieldProps> = ({
                       setValue(truncatedValue);
                       props.onChange?.(truncatedValue);
                       props.onMaxLengthExceeded?.(value);
+                      markdownPropsEditorOnChange?.(truncatedValue, schema);
                       // 更新编辑器内容以反映截断后的值
                       markdownEditorRef.current?.store?.setMDContent(
                         truncatedValue,
@@ -450,6 +464,7 @@ const MarkdownInputFieldComponent: React.FC<MarkdownInputFieldProps> = ({
                   onEditorChange(value);
                   setValue(value);
                   props.onChange?.(value);
+                  markdownPropsEditorOnChange?.(value, schema);
                 }}
                 onFocus={(value, schema, e) => {
                   onFocus?.(value, schema, e);
@@ -473,7 +488,7 @@ const MarkdownInputFieldComponent: React.FC<MarkdownInputFieldProps> = ({
                   plainTextOnly: true,
                   ...props.pasteConfig,
                 }}
-                {...markdownEditorPassThroughProps}
+                {...markdownEditorRestProps}
                 readonly={editorReadonly}
               >
                 {props?.quickActionRender ||

--- a/src/MarkdownInputField/__tests__/MarkdownInputField.markdownPropsOnChange.test.tsx
+++ b/src/MarkdownInputField/__tests__/MarkdownInputField.markdownPropsOnChange.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../MarkdownEditor', () => ({
+  BaseMarkdownEditor: vi.fn(({ onChange }) => (
+    <button
+      type="button"
+      data-testid="mock-markdown-editor"
+      onClick={() => onChange?.('synced', [])}
+    >
+      trigger-change
+    </button>
+  )),
+}));
+
+import { MarkdownInputField } from '../MarkdownInputField';
+
+describe('MarkdownInputField — markdownProps.onChange', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('merges markdownProps.onChange with the field handler (no spread override)', () => {
+    const fieldOnChange = vi.fn();
+    const markdownPropsOnChange = vi.fn();
+
+    render(
+      <MarkdownInputField
+        onChange={fieldOnChange}
+        markdownProps={{ onChange: markdownPropsOnChange }}
+      />,
+    );
+
+    screen.getByTestId('mock-markdown-editor').click();
+
+    expect(fieldOnChange).toHaveBeenCalledTimes(1);
+    expect(markdownPropsOnChange).toHaveBeenCalledTimes(1);
+    expect(fieldOnChange).toHaveBeenCalledWith('synced');
+    expect(markdownPropsOnChange).toHaveBeenCalledWith('synced', []);
+  });
+});

--- a/src/MarkdownInputField/__tests__/MarkdownInputField.test.tsx
+++ b/src/MarkdownInputField/__tests__/MarkdownInputField.test.tsx
@@ -1,6 +1,7 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
+import type { MarkdownEditorProps } from '../../MarkdownEditor';
 import { MarkdownInputField } from '../MarkdownInputField';
 import { CreateRecognizer } from '../VoiceInput';
 
@@ -421,6 +422,23 @@ describe('MarkdownInputField - click to focus', () => {
         '[class*="markdown-editor"][class*="readonly"]',
       ),
     ).toBeTruthy();
+  });
+
+  it('should ignore markdownProps.readonly so the field stays editable', async () => {
+    render(
+      <MarkdownInputField
+        markdownProps={{ readonly: true } satisfies MarkdownEditorProps}
+      />,
+    );
+    const editorContent = screen.getByTestId(
+      'markdown-input-field-editor-content',
+    );
+    await waitFor(() => {
+      const editable = editorContent.querySelector(
+        '[contenteditable="true"]',
+      );
+      expect(editable).toBeTruthy();
+    });
   });
 
   it('should allow clicking on the editor area', () => {

--- a/tests/editor/useKeyboard.test.tsx
+++ b/tests/editor/useKeyboard.test.tsx
@@ -61,6 +61,7 @@ const mockStoreState = {
   openInsertCompletion: false,
   insertCompletionText$: mockInsertCompletionText$,
   setOpenInsertCompletion: mockSetOpenInsertCompletion,
+  readonly: false,
 };
 
 vi.mock('../../src/MarkdownEditor/editor/store', () => ({
@@ -120,6 +121,7 @@ describe('useKeyboard Hook Tests', () => {
     store = { editor } as EditorStore;
     mockProps = {} as MarkdownEditorProps;
     mockStoreState.openInsertCompletion = false;
+    mockStoreState.readonly = false;
     mockNativeTableShouldHandle.mockReturnValue(false);
     mockNativeTableHandleKeyDown.mockReturnValue(false);
   });
@@ -142,6 +144,7 @@ describe('useKeyboard Hook Tests', () => {
     });
 
     it('readonly 时跳过所有键盘处理 (84)', () => {
+      mockStoreState.readonly = true;
       const propsReadonly = { ...mockProps, readonly: true };
       const { result } = renderHook(() =>
         useKeyboard(store, editorRef, propsReadonly),
@@ -152,6 +155,22 @@ describe('useKeyboard Hook Tests', () => {
         keyboardHandler(tabEvent);
       });
       expect(tabEvent.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('以 EditorStoreContext.readonly 为准：props.readonly 陈旧为 true 时仍可处理快捷键', () => {
+      mockStoreState.readonly = false;
+      const staleProps = { ...mockProps, readonly: true };
+      const { result } = renderHook(() =>
+        useKeyboard(store, editorRef, staleProps),
+      );
+      const keyboardHandler = result.current;
+      const modDown = createKeyboardEvent('ArrowDown', {
+        metaKey: true,
+      } as Partial<KeyboardEvent>);
+      act(() => {
+        keyboardHandler(modDown);
+      });
+      expect(modDown.preventDefault).toHaveBeenCalled();
     });
 
     it('NativeTableKeyboard.shouldHandle 且 handleKeyDown 返回 true 时直接 return (88,94)', () => {
@@ -588,6 +607,7 @@ describe('useKeyboard Hook Tests', () => {
       setOpenJinjaTemplate: mockSetOpenJinjaTemplate,
       setJinjaAnchorPath: mockSetJinjaAnchorPath,
       jinjaTemplatePanelEnabled: false,
+      readonly: false,
     } as any;
 
     beforeEach(() => {
@@ -610,6 +630,7 @@ describe('useKeyboard Hook Tests', () => {
         setOpenJinjaTemplate: mockSetOpenJinjaTemplate,
         setJinjaAnchorPath: mockSetJinjaAnchorPath,
         jinjaTemplatePanelEnabled: true,
+        readonly: false,
       } as any);
 
       editor.children = [{ type: 'paragraph', children: [{ text: '{' }] }];
@@ -644,6 +665,7 @@ describe('useKeyboard Hook Tests', () => {
         setOpenJinjaTemplate: mockSetOpenJinjaTemplate,
         setJinjaAnchorPath: mockSetJinjaAnchorPath,
         jinjaTemplatePanelEnabled: true,
+        readonly: false,
       } as any);
 
       editor.children = [
@@ -678,6 +700,7 @@ describe('useKeyboard Hook Tests', () => {
         setOpenJinjaTemplate: mockSetOpenJinjaTemplate,
         setJinjaAnchorPath: mockSetJinjaAnchorPath,
         jinjaTemplatePanelEnabled: false,
+        readonly: false,
       } as any);
 
       editor.children = [{ type: 'paragraph', children: [{ text: '{' }] }];
@@ -709,6 +732,7 @@ describe('useKeyboard Hook Tests', () => {
         setOpenJinjaTemplate: mockSetOpenJinjaTemplate,
         setJinjaAnchorPath: mockSetJinjaAnchorPath,
         jinjaTemplatePanelEnabled: true,
+        readonly: false,
       } as any);
 
       editor.children = [{ type: 'paragraph', children: [{ text: 'ab' }] }];
@@ -740,6 +764,7 @@ describe('useKeyboard Hook Tests', () => {
         setOpenJinjaTemplate: mockSetOpenJinjaTemplate,
         setJinjaAnchorPath: mockSetJinjaAnchorPath,
         jinjaTemplatePanelEnabled: true,
+        readonly: true,
       } as any);
 
       editor.children = [{ type: 'paragraph', children: [{ text: '{' }] }];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
 
## Summary

### 1. `markdownProps.readonly` 覆盖输入区只读

`{...markdownProps}` 在显式 `readonly` 之后会覆盖。剥离 `readonly` 并最后传入 `editorReadonly`。

### 2. 删除键失效（`useKeyboard` 闭包陈旧）

`useKeyboard` 曾用 `props.readonly` 早退；`markdownProps.readonly` 剥离后 props 闭包可能仍为 `true`。改为使用 `EditorStoreContext.readonly`。

### 3. 一次输入触发两次 / 双字符（`markdownProps.onChange` 覆盖）

`{...markdownProps}` 在显式 `onChange` **之后** 展开时，会**覆盖** `MarkdownInputField` 内部的 `onChange`。Slate 仍通过 `useOnchange` 调用 `rest.onChange`（透传的旧链），而 `MarkdownInputField` 的 `setValue` / `props.onChange` 若通过其它路径也会跑，易造成**同一按键两次业务更新**或状态不同步。

**Fix:** 从 `markdownProps` 中剥离 `onChange`，在内部 `onChange` 里先跑字段逻辑再调用 `markdownProps.onChange`。

### 4. 根级非法 Slate 树：裸文本 + 段落并列（重复显示、无法删除）

Slate 要求 `editor` 根下只能是**块级**节点。若出现根级裸 `Text`（你提供的 DOM 里 `contenteditable` 下先有「山西」文本节点、再有段落），属于非法结构，会导致浏览器里看起来像**同一内容出现两次**，且 Backspace 行为异常。

**Fix:** 在 `withSanitizeInvalidChildren` 的根 `normalizeNode` 中：将连续的根级非块节点包进段落；若缓冲里只有一段裸文本且紧随其后的块是**同字符串的单段段落**，则丢弃缓冲（避免「山西」+「山西」叠成重复）。

## Testing

- `pnpm exec vitest run src/MarkdownInputField/__tests__/MarkdownInputField.markdownPropsOnChange.test.tsx`
- `pnpm exec vitest run tests/editor/useKeyboard.test.tsx`
- `pnpm exec vitest run src/MarkdownInputField/__tests__/MarkdownInputField.test.tsx`
- `pnpm exec vitest run src/MarkdownEditor/editor/plugins/__tests__/withSanitizeInvalidChildren.test.ts`

> Submitted by Cursor
 

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-393e28f2-60d3-42fc-9b36-0509fa50031a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-393e28f2-60d3-42fc-9b36-0509fa50031a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

