### PR TITLE
Trim default Vitest suite to ~5000 tests

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config';
 
 /**
  * 默认排除「非单元」或「纯覆盖率补洞」测试，降低 `pnpm test` 用例数量与耗时。
- * CI 全量：`VITEST_FULL_SUITE=1 pnpm test` 或 `pnpm run test:full`
+ * 目标约 5000 条用例；CI 全量：`VITEST_FULL_SUITE=1 pnpm test` 或 `pnpm run test:full`
  */
 const defaultTestExcludes = [
   '**/node_modules/**',
@@ -39,6 +39,18 @@ const defaultTestExcludes = [
   '**/*missing-coverage.test.tsx',
   /** Workspace 子系统用例体量大，与 E2E 重叠多；改 Workspace 时用 `pnpm test tests/Workspace` 或 `pnpm run test:full` */
   '**/tests/Workspace/**',
+  /** 体量大的集成区：默认套件外跑，见 `pnpm run test:full` 或按目录单跑 */
+  '**/tests/plugins/**',
+  '**/tests/MarkdownEditor/editor/**',
+  '**/tests/Bubble/**',
+  '**/tests/Bubble*.tsx',
+  '**/tests/schema/**',
+  '**/tests/MarkdownInputField/**',
+  '**/tests/History/**',
+  '**/src/MarkdownRenderer/**',
+  '**/src/MarkdownInputField/**',
+  '**/tests/editor/utils/editorUtils.test.ts',
+  '**/tests/utils/language.test.ts',
 ];
 
 const testExclude =


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The default `pnpm test` run was executing about 8640 Vitest cases. This change extends `vitest.config.ts` default `exclude` patterns so the default suite runs approximately **4980** tests (~5000 target), shortening local and CI default runs.

## What is excluded in the default suite (not in full suite)

- `tests/plugins/**` (non-chart plugins were still heavy in the default set)
- `tests/MarkdownEditor/editor/**` (duplicates much of `src/MarkdownEditor` coverage)
- Bubble integration tests under `tests/Bubble/**` and top-level `tests/Bubble*.tsx`
- `tests/schema/**`, `tests/MarkdownInputField/**`, `tests/History/**`
- `src/MarkdownRenderer/**` and `src/MarkdownInputField/**` unit tests
- Two very large editor utility files: `tests/editor/utils/editorUtils.test.ts`, `tests/utils/language.test.ts`

## Full suite

Unchanged: `VITEST_FULL_SUITE=1 pnpm test` or `pnpm run test:full` still uses the reduced exclude list and runs the complete suite.

## Verification

- `pnpm test` — 266 files, **4980** tests passed locally.

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54a1889d-9396-4886-b6e3-d8cfb1714b16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54a1889d-9396-4886-b6e3-d8cfb1714b16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

