### PR TITLE
fix: reduce DeepThink rerenders during thought chain streaming

### DIFF
--- a/src/Plugins/code/components/ThinkBlock.tsx
+++ b/src/Plugins/code/components/ThinkBlock.tsx
@@ -182,16 +182,21 @@ export function ThinkBlock(props: ThinkBlockProps) {
     ? locale?.['think.deepThinkingInProgress'] || '深度思考...'
     : locale?.['think.deepThinking'] || '深度思考';
 
+  const thinkBlockRootStyles = useMemo(
+    () => ({
+      root: {
+        boxSizing: 'border-box' as const,
+        maxWidth: '680px',
+        marginTop: 8,
+      },
+    }),
+    [],
+  );
+
   return (
     <ToolUseBarThink
       testId="think-block"
-      styles={{
-        root: {
-          boxSizing: 'border-box',
-          maxWidth: '680px',
-          marginTop: 8,
-        },
-      }}
+      styles={thinkBlockRootStyles}
       expanded={expanded}
       onExpandedChange={setExpanded}
       toolName={toolNameText}

--- a/src/ThoughtChainList/index.tsx
+++ b/src/ThoughtChainList/index.tsx
@@ -31,6 +31,14 @@ import {
 
 const COLLAPSE_ANIMATION_DURATION_MS = 160;
 
+/** 流式更新时复用同一引用，避免列表项 props 每次变引用导致 DeepThink 整树重渲染 */
+const THOUGHT_CHAIN_LOADING_ICON = <Loader />;
+const THOUGHT_CHAIN_SUCCESS_ICON = <CircleCheckBig />;
+const THOUGHT_CHAIN_ERROR_ICON_STYLE: React.CSSProperties = { color: 'red' };
+const THOUGHT_CHAIN_ERROR_ICON = (
+  <CloseCircleFilled style={THOUGHT_CHAIN_ERROR_ICON_STYLE} />
+);
+
 // Initialize dayjs plugins
 try {
   dayjs.extend(duration);
@@ -210,7 +218,7 @@ const ThoughtChainContent = React.memo<
 
       return thoughtChainList.map((item, index) => {
         let info = item.info;
-        let icon = <Loader />;
+        let icon: React.ReactNode = THOUGHT_CHAIN_LOADING_ICON;
         let isFinished = false;
 
         if (
@@ -219,17 +227,11 @@ const ThoughtChainContent = React.memo<
           item.output?.type !== 'RUNNING'
         ) {
           isFinished = true;
-          icon = <CircleCheckBig />;
+          icon = THOUGHT_CHAIN_SUCCESS_ICON;
         }
 
         if (item.output?.errorMsg) {
-          icon = (
-            <CloseCircleFilled
-              style={{
-                color: 'red',
-              }}
-            />
-          );
+          icon = THOUGHT_CHAIN_ERROR_ICON;
         }
 
         return {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Streaming updates rebuild the thought chain list on every chunk. `ThoughtChainContent` was creating new `<Loader />` / `<CircleCheckBig />` / error icon elements on each `processedItems` pass, so `thoughtChainListItem` always had a new `icon` reference. That defeated `React.memo` on `ThoughtChainListItem` and caused the DeepThink subtree (including `MarkdownEditorUpdate`) to re-render far more often than necessary.

`ThinkBlock` also passed a fresh inline `styles` object to `ToolUseBarThink` on every Slate update, which broke that component's `memo` shallow compare.

## Changes

- Reuse stable module-level icon elements for loading, success, and error states in `ThoughtChainList`.
- Memoize `ThinkBlock` root `styles` passed to `ToolUseBarThink`.

## Testing

- `pnpm test -- src/ThoughtChainList tests/ThoughtChainList.test.tsx tests/plugins/code/components/ThinkBlock.test.tsx`

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6caae507-d824-4f45-a652-e5d2d79bac01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6caae507-d824-4f45-a652-e5d2d79bac01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

