### PR TITLE
fix(i18n): wire DeepThink and MarkdownRenderer think labels to locale

### DIFF
--- a/src/I18n/locales.ts
+++ b/src/I18n/locales.ts
@@ -90,6 +90,8 @@ export const cnLabels = {
   // ThinkBlock 组件相关
   'think.deepThinking': '深度思考',
   'think.deepThinkingInProgress': '深度思考...',
+  /** DeepThink 无 output 且未完成时，加载行文案（与标题「深度思考...」区分） */
+  'think.deepThinkingLoading': '正在深度思考中',
   switchLanguage: '切换语言',
   welcome: '欢迎使用多语言支持',
   insertLink: '插入链接',
@@ -495,6 +497,7 @@ export const enLabels: typeof cnLabels = {
   // ThinkBlock component related
   'think.deepThinking': 'Deep Thinking',
   'think.deepThinkingInProgress': 'Deep Thinking...',
+  'think.deepThinkingLoading': 'Deep thinking in progress',
   bold: 'Bold',
   italic: 'Italic',
   strikethrough: 'Strikethrough',

--- a/src/MarkdownRenderer/__tests__/MarkdownRenderer.test.tsx
+++ b/src/MarkdownRenderer/__tests__/MarkdownRenderer.test.tsx
@@ -1,6 +1,7 @@
 import { act, render } from '@testing-library/react';
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cnLabels, enLabels, I18nProvide } from '../../I18n';
 import { MarkdownRenderer } from '../index';
 
 vi.mock('mermaid', () => ({
@@ -374,6 +375,25 @@ describe('MarkdownRenderer', () => {
     );
     expect(thinkBlock).toBeTruthy();
     expect(container.textContent).toContain('最终回答');
+  });
+
+  it('应将 <think> 标题随 I18n 语言切换', () => {
+    const thinkMarkdown =
+      '<think>\n一段内容\n</think>\n\n正文';
+    const { container, unmount } = render(
+      <I18nProvide key="zh" defaultLanguage="zh-CN" autoDetect={false}>
+        <MarkdownRenderer content={thinkMarkdown} />
+      </I18nProvide>,
+    );
+    expect(container.textContent).toContain(cnLabels['think.deepThinking']);
+    unmount();
+
+    const { container: enContainer } = render(
+      <I18nProvide key="en" defaultLanguage="en-US" autoDetect={false}>
+        <MarkdownRenderer content={thinkMarkdown} />
+      </I18nProvide>,
+    );
+    expect(enContainer.textContent).toContain(enLabels['think.deepThinking']);
   });
 
   it('应将 HTML 注释 + 表格组合渲染为图表', () => {

--- a/src/MarkdownRenderer/markdownReactShared.ts
+++ b/src/MarkdownRenderer/markdownReactShared.ts
@@ -25,6 +25,7 @@ import {
   type MarkdownToHtmlConfig,
 } from '../MarkdownEditor/editor/utils/markdownToHtml';
 import type { MarkdownEditorProps } from '../MarkdownEditor/types';
+import { cnLabels, I18nContext } from '../I18n';
 import { parseChineseCurrencyToNumber } from '../Plugins/chart/utils';
 import { ToolUseBarThink } from '../ToolUseBarThink';
 import AnimationText from './AnimationText';
@@ -306,22 +307,29 @@ const extractChildrenText = (children: React.ReactNode): string => {
   return '';
 };
 
+const THINK_BLOCK_RENDERER_ROOT_STYLES = {
+  root: {
+    boxSizing: 'border-box' as const,
+    maxWidth: '680px',
+    marginTop: 8,
+  },
+};
+
 /** <think> 标签 → ToolUseBarThink（MarkdownRenderer 无 Slate 上下文，直接渲染） */
 const ThinkBlockRendererComponent = (props: any) => {
   const { children } = props;
+  const { locale } = useContext(I18nContext);
   const content = extractChildrenText(children);
   const isLoading = content.endsWith('...');
+  const toolName = isLoading
+    ? locale?.['think.deepThinkingInProgress'] ??
+      cnLabels['think.deepThinkingInProgress']
+    : locale?.['think.deepThinking'] ?? cnLabels['think.deepThinking'];
 
   return React.createElement(ToolUseBarThink, {
     testId: 'think-block-renderer',
-    styles: {
-      root: {
-        boxSizing: 'border-box',
-        maxWidth: '680px',
-        marginTop: 8,
-      },
-    },
-    toolName: isLoading ? '深度思考...' : '深度思考',
+    styles: THINK_BLOCK_RENDERER_ROOT_STYLES,
+    toolName,
     thinkContent: content,
     status: isLoading ? 'loading' : 'success',
   });

--- a/src/Plugins/code/components/ThinkBlock.tsx
+++ b/src/Plugins/code/components/ThinkBlock.tsx
@@ -12,7 +12,7 @@ import React, {
   useRef,
 } from 'react';
 import { MessagesContext } from '../../../Bubble/MessagesContent/BubbleContext';
-import { I18nContext } from '../../../I18n';
+import { cnLabels, I18nContext } from '../../../I18n';
 import {
   EditorStoreContext,
   useEditorStore,
@@ -179,8 +179,9 @@ export function ThinkBlock(props: ThinkBlockProps) {
   // 判断是否正在加载：内容以...结尾 或者 bubble 还未完成
   const isLoading = content.endsWith('...');
   const toolNameText = isLoading
-    ? locale?.['think.deepThinkingInProgress'] || '深度思考...'
-    : locale?.['think.deepThinking'] || '深度思考';
+    ? locale?.['think.deepThinkingInProgress'] ??
+      cnLabels['think.deepThinkingInProgress']
+    : locale?.['think.deepThinking'] ?? cnLabels['think.deepThinking'];
 
   return (
     <ToolUseBarThink

--- a/src/ThoughtChainList/DeepThink.tsx
+++ b/src/ThoughtChainList/DeepThink.tsx
@@ -2,7 +2,7 @@ import { CloseCircleFilled } from '@ant-design/icons';
 import { Typography } from 'antd';
 import React, { useContext, useMemo } from 'react';
 import { LoadingSpinnerIcon } from '../Components/icons/LoadingSpinnerIcon';
-import { I18nContext } from '../I18n';
+import { cnLabels, I18nContext } from '../I18n';
 import { MarkdownEditorProps } from '../MarkdownEditor/types';
 import { DotLoading } from './DotAni';
 import { MarkdownEditorUpdate } from './MarkdownEditor';
@@ -113,7 +113,8 @@ export const DeepThink = (
               }}
             >
               <LoadingSpinnerIcon size={24} />
-              {i18n?.locale?.deepThinkingInProgress || '正在深度思考中'}
+              {i18n?.locale?.['think.deepThinkingLoading'] ??
+                cnLabels['think.deepThinkingLoading']}
               <DotLoading />
             </div>
           ) : null}
@@ -197,8 +198,8 @@ export const DeepThink = (
                     }}
                   />
                   <Typography.Text>
-                    {i18n?.locale?.taskExecutionFailed ||
-                      '任务执行失败，需要修改'}
+                    {i18n?.locale?.taskExecutionFailed ??
+                      cnLabels.taskExecutionFailed}
                   </Typography.Text>
                 </div>
                 <Typography
@@ -216,5 +217,13 @@ export const DeepThink = (
         </div>
       </>
     );
-  }, [props.category, JSON.stringify(props.output), props.costMillis]);
+  }, [
+    props.category,
+    props.isFinished,
+    JSON.stringify(props.output),
+    props.costMillis,
+    i18n?.locale?.['think.deepThinkingLoading'],
+    i18n?.locale?.taskExecutionFailed,
+    props.markdownRenderProps,
+  ]);
 };

--- a/tests/ThoughtChainList/DeepThink.test.tsx
+++ b/tests/ThoughtChainList/DeepThink.test.tsx
@@ -20,7 +20,7 @@ vi.mock('../../src/ThoughtChainList/DotAni', () => ({
 }));
 
 const locale = {
-  deepThinkingInProgress: '正在深度思考中',
+  'think.deepThinkingLoading': '正在深度思考中',
   taskExecutionFailed: '任务执行失败',
 };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Deep thinking UI had several Chinese-only fallbacks or mismatched locale keys:

- `MarkdownRenderer` `<think>` used hard-coded `深度思考` / `深度思考...` for `ToolUseBarThink`.
- `DeepThink` loading row used `deepThinkingInProgress` as fallback, which duplicated the bar title semantics and did not match the intended “in progress” line copy.
- `ThinkBlock` fallbacks were Chinese strings instead of `cnLabels`.

## Changes

- Add `think.deepThinkingLoading` to `cnLabels` / `enLabels`.
- `DeepThink`: use `think.deepThinkingLoading` with `cnLabels` fallback; align `taskExecutionFailed` fallback with `cnLabels`; extend `useMemo` deps for `isFinished` / locale / `markdownRenderProps`.
- `markdownReactShared` think renderer: read `I18nContext` and use `think.deepThinking` / `think.deepThinkingInProgress` with `cnLabels` fallback; stable root `styles` object.
- `ThinkBlock`: same title keys with `cnLabels` fallback.
- Tests: `DeepThink` mock locale key update; `MarkdownRenderer` i18n switch test (requires `VITEST_FULL_SUITE=1` because this file is excluded from the default vitest set).

## Testing

- `pnpm tsc --noEmit`
- `pnpm exec vitest run tests/ThoughtChainList/DeepThink.test.tsx tests/plugins/code/components/ThinkBlock.i18n.test.tsx`
- `VITEST_FULL_SUITE=1 pnpm exec vitest run src/MarkdownRenderer/__tests__/MarkdownRenderer.test.tsx -t "标题随 I18n"`

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6caae507-d824-4f45-a652-e5d2d79bac01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6caae507-d824-4f45-a652-e5d2d79bac01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

