### PR TITLE
fix: prevent Ace JSON code block flicker during streaming

### DIFF
--- a/src/Plugins/code/components/AceEditor.tsx
+++ b/src/Plugins/code/components/AceEditor.tsx
@@ -252,7 +252,9 @@ export function AceEditor({
     const codeProps = editorProps.codeProps || {};
 
     let value = element.value || '';
-    if (element.language === 'json') {
+    const shouldFormatJsonInAce =
+      element.language === 'json' && element.otherProps?.finished !== false;
+    if (shouldFormatJsonInAce) {
       try {
         value = JSON.stringify(partialParse(value), null, 2);
       } catch (e) {}
@@ -333,7 +335,11 @@ export function AceEditor({
   useEffect(() => {
     let value = element.value || '';
 
-    if (element.language === 'json') {
+    // 流式 JSON：partialParse + JSON.stringify 会随不完整结构变化而整块改写，
+    // 与 Slate 原文的 startsWith 关系断裂，反复 setValue 造成闪动；闭合后再格式化。
+    const shouldFormatJsonInAce =
+      element.language === 'json' && element.otherProps?.finished !== false;
+    if (shouldFormatJsonInAce) {
       try {
         value = JSON.stringify(partialParse(value), null, 2);
       } catch (e) {}
@@ -360,7 +366,7 @@ export function AceEditor({
       editor.setValue(value);
       editor.clearSelection();
     }
-  }, [element.value]);
+  }, [element.value, element.language, element.otherProps?.finished]);
 
   // 监听主题变化
   useEffect(() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a `json` fenced code block is streamed into the Markdown editor, `AceEditor` was running `JSON.stringify(partialParse(value), null, 2)` on every update. Partial JSON parses to different object shapes as tokens arrive, so the formatted string often no longer starts with the previous buffer. That broke the append-only optimization (`value.startsWith(prev)`), forcing repeated `setValue` and visible flicker.

## Changes

- Skip JSON pretty-printing in Ace while the code block is still streaming (`otherProps.finished === false`).
- After the block is finished (or when `finished` is unset), keep the existing pretty-print behavior.
- Re-run the external-value effect when `finished` flips so the editor can format once when streaming completes.

## Testing

- `pnpm tsc --noEmit`
- `pnpm test -- tests/plugins/code/components/AceEditor.test.tsx` (Vitest suite ran full file resolution in this environment; all tests passed)

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1909b92b-e4cc-4915-b443-75b9dd591dca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1909b92b-e4cc-4915-b443-75b9dd591dca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

