### PR TITLE
fix: normalize redacted_thinking alias so nested JSON stays in think block

### DIFF
--- a/src/MarkdownEditor/editor/parser/__tests__/parserMarkdownToSlateNode.test.ts
+++ b/src/MarkdownEditor/editor/parser/__tests__/parserMarkdownToSlateNode.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { handleDefinition } from '../parse/parseElements';
 import { handleMath, shouldTreatInlineMathAsText } from '../parse/parseMath';
 import { handleAttachmentLink, handleImage } from '../parse/parseMedia';
+import { normalizeThinkTagAliases } from '../parse/parseHtml';
 import {
   clearParseCache,
   parserMarkdownToSlateNode,
@@ -1158,6 +1159,12 @@ console.log('测试代码');
       const value = codeNode.value as string;
       expect(value).toContain('【CODE_BLOCK:think】');
       expect(value).toContain('这是嵌套的 think 代码块');
+    });
+
+    it('should not alter markdown when alias open tag appears without closing pair', () => {
+      const aliasOpen = '<' + 'redacted_' + 'thinking' + '>';
+      const md = `正文里出现 ${aliasOpen} 但不闭合`;
+      expect(normalizeThinkTagAliases(md)).toBe(md);
     });
 
     it('should fold nested ```json inside <think> into one think code node', () => {

--- a/src/MarkdownEditor/editor/parser/__tests__/parserMarkdownToSlateNode.test.ts
+++ b/src/MarkdownEditor/editor/parser/__tests__/parserMarkdownToSlateNode.test.ts
@@ -1159,6 +1159,23 @@ console.log('测试代码');
       expect(value).toContain('【CODE_BLOCK:think】');
       expect(value).toContain('这是嵌套的 think 代码块');
     });
+
+    it('should fold nested ```json inside <think> into one think code node', () => {
+      const markdown = `<think>
+\`\`\`json
+{"file_type":"docx"}
+\`\`\`
+</think>`;
+      const result = parserMarkdownToSlateNode(markdown);
+
+      expect(result.schema).toHaveLength(1);
+      expect(result.schema[0]).toMatchObject({
+        type: 'code',
+        language: 'think',
+      });
+      const codeNode = result.schema[0] as { value?: string };
+      expect(codeNode.value).toContain('【CODE_BLOCK:json】');
+    });
   });
 
   describe('handleCustomHtmlTags', () => {

--- a/src/MarkdownEditor/editor/parser/parse/parseHtml.ts
+++ b/src/MarkdownEditor/editor/parser/parse/parseHtml.ts
@@ -3,6 +3,33 @@ import { htmlToFragmentList } from '../../plugins/insertParsedHtmlNodes';
 import { EditorUtils } from '../../utils';
 import partialJsonParse from '../json-parse';
 
+/** 与 `preprocessSpecialTags(..., 'think')`、序列化输出一致：`<think>`…`</think>` */
+const THINK_TAG_CANONICAL_OPEN = '<think>';
+const THINK_TAG_CANONICAL_CLOSE = '</think>';
+
+/** 部分模型会输出该别名；拼接避免与规范 `<think>` 在源码中混淆 */
+const REDACTED_THINKING_ALIAS_OPEN =
+  '<' + 'redacted_' + 'thinking' + '>';
+const REDACTED_THINKING_ALIAS_CLOSE =
+  '</' + 'redacted_' + 'thinking' + '>';
+
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * 将 `<think>`…`</think>` 归一成 `<think>`…`</think>`。
+ * 否则 `preprocessThinkTags` 无法把思考区内的 ```json 换成 【CODE_BLOCK】，JSON 会变成顶层独立 code 节点，DOM 分裂。
+ */
+export function normalizeThinkTagAliases(markdown: string): string {
+  if (!markdown) return markdown;
+  const openRe = new RegExp(escapeRegExp(REDACTED_THINKING_ALIAS_OPEN), 'gi');
+  const closeRe = new RegExp(escapeRegExp(REDACTED_THINKING_ALIAS_CLOSE), 'gi');
+  return markdown
+    .replace(openRe, THINK_TAG_CANONICAL_OPEN)
+    .replace(closeRe, THINK_TAG_CANONICAL_CLOSE);
+}
+
+
 /**
  * 解码 URI 组件，处理错误情况
  */
@@ -22,8 +49,19 @@ export const decodeURIComponentUrl = (url: string) => {
  */
 const findThinkElement = (str: string) => {
   try {
-    // 匹配 <think>内容</think> 格式
-    const thinkMatch = str.match(/^\s*<think>([\s\S]*?)<\/think>\s*$/);
+    const canonicalRe = new RegExp(
+      `^\\s*${escapeRegExp(THINK_TAG_CANONICAL_OPEN)}([\\s\\S]*?)${escapeRegExp(
+        THINK_TAG_CANONICAL_CLOSE,
+      )}\\s*$`,
+      'i',
+    );
+    const aliasRe = new RegExp(
+      `^\\s*${escapeRegExp(REDACTED_THINKING_ALIAS_OPEN)}([\\s\\S]*?)${escapeRegExp(
+        REDACTED_THINKING_ALIAS_CLOSE,
+      )}\\s*$`,
+      'i',
+    );
+    const thinkMatch = str.match(canonicalRe) || str.match(aliasRe);
     if (thinkMatch) {
       return {
         content: thinkMatch[1].trim(),
@@ -818,7 +856,7 @@ export function preprocessSpecialTags(
  * @returns 处理后的 Markdown 字符串
  */
 export function preprocessThinkTags(markdown: string): string {
-  return preprocessSpecialTags(markdown, 'think');
+  return preprocessSpecialTags(normalizeThinkTagAliases(markdown), 'think');
 }
 
 /**

--- a/src/MarkdownEditor/editor/parser/parse/parseHtml.ts
+++ b/src/MarkdownEditor/editor/parser/parse/parseHtml.ts
@@ -3,11 +3,14 @@ import { htmlToFragmentList } from '../../plugins/insertParsedHtmlNodes';
 import { EditorUtils } from '../../utils';
 import partialJsonParse from '../json-parse';
 
-/** 与 `preprocessSpecialTags(..., 'think')`、序列化输出一致：`<think>`…`</think>` */
+/**
+ * 规范标签名必须与 `preprocessSpecialTags(markdown, 'think')` 一致：该函数用 `<${tagName}>` / `</${tagName}>`，
+ * 即字面量 `<think>`…`</think>`，再包成 `` ```think ``。若此处改名须同步改 `parserSlateNodeToMarkdown` 里 think 序列化。
+ */
 const THINK_TAG_CANONICAL_OPEN = '<think>';
 const THINK_TAG_CANONICAL_CLOSE = '</think>';
 
-/** 部分模型会输出该别名；拼接避免与规范 `<think>` 在源码中混淆 */
+/** 部分模型输出的外壳别名；拼接避免与规范标签在源码中混淆 */
 const REDACTED_THINKING_ALIAS_OPEN =
   '<' + 'redacted_' + 'thinking' + '>';
 const REDACTED_THINKING_ALIAS_CLOSE =
@@ -16,17 +19,41 @@ const REDACTED_THINKING_ALIAS_CLOSE =
 const escapeRegExp = (value: string) =>
   value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
+/** 仅替换「成对」别名标签，避免正文里偶然出现的孤立字面量被误换 */
+const REDACTED_THINKING_ALIAS_PAIR_REGEX = new RegExp(
+  `${escapeRegExp(REDACTED_THINKING_ALIAS_OPEN)}([\\s\\S]*?)${escapeRegExp(
+    REDACTED_THINKING_ALIAS_CLOSE,
+  )}`,
+  'gi',
+);
+
+const FIND_THINK_CANONICAL_BLOCK_RE = new RegExp(
+  `^\\s*${escapeRegExp(THINK_TAG_CANONICAL_OPEN)}([\\s\\S]*?)${escapeRegExp(
+    THINK_TAG_CANONICAL_CLOSE,
+  )}\\s*$`,
+  'i',
+);
+
+const FIND_THINK_ALIAS_BLOCK_RE = new RegExp(
+  `^\\s*${escapeRegExp(REDACTED_THINKING_ALIAS_OPEN)}([\\s\\S]*?)${escapeRegExp(
+    REDACTED_THINKING_ALIAS_CLOSE,
+  )}\\s*$`,
+  'i',
+);
+
 /**
- * 将 `<think>`…`</think>` 归一成 `<think>`…`</think>`。
- * 否则 `preprocessThinkTags` 无法把思考区内的 ```json 换成 【CODE_BLOCK】，JSON 会变成顶层独立 code 节点，DOM 分裂。
+ * 将成对的别名标签 `<think>`…`</think>` 归一为与 `preprocessSpecialTags(..., 'think')` 契约一致的规范标签。
+ * 否则 `preprocessThinkTags` 无法把思考区内的 ``` 围栏换成 【CODE_BLOCK】，内层 JSON 会变成顶层独立 code 节点。
  */
 export function normalizeThinkTagAliases(markdown: string): string {
-  if (!markdown) return markdown;
-  const openRe = new RegExp(escapeRegExp(REDACTED_THINKING_ALIAS_OPEN), 'gi');
-  const closeRe = new RegExp(escapeRegExp(REDACTED_THINKING_ALIAS_CLOSE), 'gi');
-  return markdown
-    .replace(openRe, THINK_TAG_CANONICAL_OPEN)
-    .replace(closeRe, THINK_TAG_CANONICAL_CLOSE);
+  if (!markdown || markdown.indexOf(REDACTED_THINKING_ALIAS_OPEN) === -1) {
+    return markdown;
+  }
+  return markdown.replace(
+    REDACTED_THINKING_ALIAS_PAIR_REGEX,
+    (_match, inner: string) =>
+      `${THINK_TAG_CANONICAL_OPEN}${inner}${THINK_TAG_CANONICAL_CLOSE}`,
+  );
 }
 
 
@@ -49,19 +76,9 @@ export const decodeURIComponentUrl = (url: string) => {
  */
 const findThinkElement = (str: string) => {
   try {
-    const canonicalRe = new RegExp(
-      `^\\s*${escapeRegExp(THINK_TAG_CANONICAL_OPEN)}([\\s\\S]*?)${escapeRegExp(
-        THINK_TAG_CANONICAL_CLOSE,
-      )}\\s*$`,
-      'i',
-    );
-    const aliasRe = new RegExp(
-      `^\\s*${escapeRegExp(REDACTED_THINKING_ALIAS_OPEN)}([\\s\\S]*?)${escapeRegExp(
-        REDACTED_THINKING_ALIAS_CLOSE,
-      )}\\s*$`,
-      'i',
-    );
-    const thinkMatch = str.match(canonicalRe) || str.match(aliasRe);
+    const thinkMatch =
+      str.match(FIND_THINK_CANONICAL_BLOCK_RE) ||
+      str.match(FIND_THINK_ALIAS_BLOCK_RE);
     if (thinkMatch) {
       return {
         content: thinkMatch[1].trim(),
@@ -69,6 +86,9 @@ const findThinkElement = (str: string) => {
     }
     return null;
   } catch (e) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn('[parseHtml] findThinkElement failed', e);
+    }
     return null;
   }
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Follow-up (code review)

- **A — 性能**：`REDACTED_THINKING_ALIAS_PAIR_REGEX`、`FIND_THINK_CANONICAL_BLOCK_RE`、`FIND_THINK_ALIAS_BLOCK_RE` 提升为模块级预编译；`normalizeThinkTagAliases` 无别名开标签时早退。
- **B — 注释**：在 `THINK_TAG_CANONICAL_*` 上明确与 `preprocessSpecialTags(markdown, 'think')` 的 `<think>` / `think` 契约一致，并提示与 `parserSlateNodeToMarkdown` think 序列化联动。
- **C — 边界**：别名替换改为「成对」整块替换（非全文单独替换开/闭标签），降低正文孤立字面量误替换概率；新增单测覆盖「仅有别名开标签、未闭合」时不改写。
- **D — 可观测性**：`findThinkElement` 在 `NODE_ENV !== 'production'` 时对异常 `console.warn`。

> Submitted by Cursor

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1909b92b-e4cc-4915-b443-75b9dd591dca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1909b92b-e4cc-4915-b443-75b9dd591dca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

