### PR TITLE
fix: Bubble 代码块选择器与 SendButton 无障碍改进

### DIFF
--- a/src/Bubble/style.ts
+++ b/src/Bubble/style.ts
@@ -133,7 +133,7 @@ const genStyle = (
           borderRadius: '12px',
           overflow: 'auto',
         },
-        [`div['data-be=code']`]: {
+        [`& ${token.antCls}-agentic-md-editor-content div[data-be="code"]`]: {
           borderRadius: '12px',
           overflow: 'auto',
         },

--- a/src/I18n/locales.ts
+++ b/src/I18n/locales.ts
@@ -347,6 +347,8 @@ export const cnLabels = {
   'input.sendButtonTooltip.newline': '按 Shift+Enter 键换行',
   'input.sendButtonTooltip.send.mod': '按 Cmd/Ctrl+Enter 键发送',
   'input.sendButtonTooltip.newline.mod': '按 Enter 键换行',
+  'input.sendButtonAriaLabel.send': '发送消息',
+  'input.sendButtonAriaLabel.stop': '停止生成',
   'input.typing.hint': 'AI 正在回复中，请稍候...',
   // Other translations
   'common.name': '名称',
@@ -814,6 +816,8 @@ export const enLabels: typeof cnLabels = {
   'input.sendButtonTooltip.newline': 'Press Shift+Enter for new line',
   'input.sendButtonTooltip.send.mod': 'Press Cmd/Ctrl+Enter to send',
   'input.sendButtonTooltip.newline.mod': 'Press Enter for new line',
+  'input.sendButtonAriaLabel.send': 'Send message',
+  'input.sendButtonAriaLabel.stop': 'Stop generating',
   'input.typing.hint': 'AI is replying, please wait...',
   // Other translations
   'common.name': 'Name',

--- a/src/MarkdownInputField/SendButton/index.tsx
+++ b/src/MarkdownInputField/SendButton/index.tsx
@@ -58,15 +58,10 @@ function SendIcon(
     hover?: boolean;
     disabled?: boolean;
     typing?: boolean;
-    onInit?: () => void;
     colors?: SendButtonColors;
   },
 ) {
-  const { hover, typing, onInit, colors, ...rest } = props;
-
-  useEffect(() => {
-    onInit?.();
-  }, []);
+  const { hover, typing, colors, ...rest } = props;
 
   if (typing) {
     return (
@@ -244,6 +239,8 @@ export const SendButton: React.FC<SendButtonProps> = (props) => {
   } = props;
   useEffect(() => {
     props.onInit?.();
+    // 仅在挂载时触发一次，避免引用变化导致重复打点
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- onInit intentionally once on mount
   }, []);
   const { getPrefixCls } = useContext(ConfigProvider.ConfigContext);
   const { locale } = useContext(I18nContext);
@@ -282,10 +279,18 @@ export const SendButton: React.FC<SendButtonProps> = (props) => {
     </div>
   );
 
+  const ariaLabelSend =
+    locale?.['input.sendButtonAriaLabel.send'] ?? '发送消息';
+  const ariaLabelStop =
+    locale?.['input.sendButtonAriaLabel.stop'] ?? '停止生成';
+  const sendButtonAriaLabel = typing ? ariaLabelStop : ariaLabelSend;
+
   return wrapSSR(
     <Tooltip arrow={false} title={tooltipTitle} mouseEnterDelay={0.5}>
       <div
         data-testid="send-button"
+        aria-label={sendButtonAriaLabel}
+        aria-disabled={disabled ? true : undefined}
         onClick={() => {
           if (!disabled) {
             onClick();

--- a/tests/SendButton.test.tsx
+++ b/tests/SendButton.test.tsx
@@ -46,6 +46,17 @@ describe('SendButton', () => {
         '.ant-agentic-md-input-field-send-button',
       );
       expect(button).toBeInTheDocument();
+      expect(button).toHaveAttribute('aria-label', '发送消息');
+    });
+
+    it('typing 时应使用停止生成的无障碍标签', () => {
+      const { container } = render(
+        <SendButton isSendable={true} typing={true} onClick={vi.fn()} />,
+      );
+      const button = container.querySelector(
+        '.ant-agentic-md-input-field-send-button',
+      );
+      expect(button).toHaveAttribute('aria-label', '停止生成');
     });
 
     it('should call onInit when initialized', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

落实上次代码评审中的可落地改动：修正 Bubble 内无效的 CSS 选择器，并为发送按钮补充无障碍标签与国际化键。

## 变更说明

- **Bubble**：将 `div['data-be=code']` 改为在编辑器内容根下匹配 `div[data-be="code"]`，使代码块圆角等样式能正确命中 DOM。
- **SendButton**：为可聚焦容器增加 `aria-label`（发送 / 停止，随 `typing` 切换）、禁用时 `aria-disabled`；新增 `input.sendButtonAriaLabel.send` / `input.sendButtonAriaLabel.stop` 中英文案。
- **SendIcon**：移除与父组件重复的 `onInit` `useEffect`，避免 `onInit` 被调用两次；父层单次 `onInit` 保留并补充 `exhaustive-deps` 注释。
- **测试**：为 `aria-label` 行为增加断言。

## 验证

- `pnpm exec vitest run tests/SendButton.test.tsx`
- `pnpm exec eslint`（变更文件）

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-555f914f-6ad5-4d05-a701-8c1e3469f0d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-555f914f-6ad5-4d05-a701-8c1e3469f0d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

