### PR TITLE
fix(MarkdownInputField): align tools row when using toolsRender

### DIFF
--- a/src/MarkdownInputField/style.ts
+++ b/src/MarkdownInputField/style.ts
@@ -239,7 +239,9 @@ const genStyle: GenerateStyle<
         borderRadius: 0,
       },
       '&-tools-wrapper': {
-        height: '32px',
+        // 使用 minHeight，避免在 border-box 下固定 height 与 paddingBottom
+        // 争用导致内容区 < 32px、Toggle 工具与发送区纵向错位
+        minHeight: '32px',
         backgroundColor: 'var(--color-gray-bg-card-white, #ffffff)',
         display: 'flex',
         boxSizing: 'border-box',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The bottom tools strip (`ant-agentic-md-input-field-tools-wrapper`) used a fixed `height: 32px` with `box-sizing: border-box` and `padding-bottom: var(--padding-3x)` (12px). That left only 20px for the flex content, while `ToggleButton` is 32px tall, so the two toggle pills and the send area were vertically misaligned.

## Change

- Replaced `height: 32px` with `minHeight: 32px` on `&-tools-wrapper` so padding and 32px controls no longer fight for the same space.

## Testing

- `pnpm test -- src/MarkdownInputField --run` (passes; vitest also ran full project match for that filter in this environment)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb4f1278-9712-441b-b15e-ce6ec328eb5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb4f1278-9712-441b-b15e-ce6ec328eb5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

