### PR TITLE
fix(MarkdownInputField): send button contrast for light/dark themes

### DIFF
--- a/src/MarkdownInputField/SendButton/index.tsx
+++ b/src/MarkdownInputField/SendButton/index.tsx
@@ -1,7 +1,7 @@
-import { ConfigProvider, Tooltip } from 'antd';
+import { ConfigProvider, Tooltip, theme as antdTheme } from 'antd';
 import classNames from 'clsx';
 import { motion } from 'framer-motion';
-import React, { useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useMemo } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import {
   STOP_ICON_DISK_FILL,
@@ -10,6 +10,11 @@ import {
 } from '../../AgentRunBar/icons';
 import { I18nContext } from '../../I18n';
 import type { FileUploadManagerReturn } from '../FileUploadManager';
+import {
+  getSendButtonPalette,
+  resolveSendButtonDisplayColors,
+  type SendButtonResolvedColors,
+} from './sendButtonPalette';
 import { useStyle } from './style';
 
 /**
@@ -45,23 +50,17 @@ export function resolveSendDisabled(
   return sendButtonProps?.disabled ?? fileUploadStatus === 'uploading';
 }
 
-/** 未传入 `colors` 时使用 CSS 语义变量（与原先全局 SVG 覆盖一致） */
-const SEND_BUTTON_THEME_COLORS = {
-  icon: 'var(--color-gray-bg-card-white, #ffffff)',
-  iconHover: 'var(--color-gray-bg-card-white, #ffffff)',
-  background: 'var(--color-primary-control-fill-primary, #1677ff)',
-  backgroundHover: 'var(--color-primary-control-fill-primary, #1677ff)',
-};
-
 function SendIcon(
   props: React.SVGProps<SVGSVGElement> & {
-    hover?: boolean;
+    /** 可发送且非禁用 */
+    isActive: boolean;
+    /** 业务禁用（仍渲染弱态，与 !isActive 一致） */
     disabled?: boolean;
     typing?: boolean;
-    colors?: SendButtonColors;
+    displayColors: SendButtonResolvedColors;
   },
 ) {
-  const { hover, typing, colors, ...rest } = props;
+  const { isActive, disabled, typing, displayColors, ...rest } = props;
 
   if (typing) {
     return (
@@ -73,13 +72,13 @@ function SendIcon(
     );
   }
 
-  const currentColors = {
-    icon: colors?.icon ?? SEND_BUTTON_THEME_COLORS.icon,
-    iconHover: colors?.iconHover ?? SEND_BUTTON_THEME_COLORS.iconHover,
-    background: colors?.background ?? SEND_BUTTON_THEME_COLORS.background,
-    backgroundHover:
-      colors?.backgroundHover ?? SEND_BUTTON_THEME_COLORS.backgroundHover,
-  };
+  const useActive = isActive && !disabled;
+  const circleFill = useActive
+    ? displayColors.backgroundActive
+    : displayColors.backgroundMuted;
+  const arrowFill = useActive
+    ? displayColors.iconActive
+    : displayColors.iconMuted;
 
   return (
     <svg
@@ -96,10 +95,8 @@ function SendIcon(
         r="0.5em"
         initial={false}
         animate={{
-          fill: hover
-            ? currentColors.backgroundHover
-            : currentColors.background,
-          fillOpacity: hover ? 1 : 0.03530000150203705,
+          fill: circleFill,
+          fillOpacity: 1,
         }}
         transition={{
           duration: 0.6,
@@ -112,8 +109,8 @@ function SendIcon(
           fillRule="evenodd"
           initial={false}
           animate={{
-            fill: hover ? currentColors.iconHover : currentColors.icon,
-            fillOpacity: hover ? 1 : 0.24709999561309814,
+            fill: arrowFill,
+            fillOpacity: 1,
           }}
           transition={{
             duration: 0.2,
@@ -192,7 +189,7 @@ type SendButtonProps = {
  * @component
  * @description 发送按钮组件，支持多种状态和动画效果
  * @param {SendButtonProps} props - 组件属性
- * @param {boolean} props.isHover - 指示鼠标是否悬停在按钮上
+ * @param {boolean} props.isSendable - 是否处于可发送状态
  * @param {boolean} props.disabled - 指示按钮是否禁用
  * @param {boolean} props.typing - 指示是否处于输入状态
  * @param {() => void} props.onClick - 点击按钮时的回调函数
@@ -204,7 +201,7 @@ type SendButtonProps = {
  * @example
  * ```tsx
  * <SendButton
- *   isHover={false}
+ *   isSendable
  *   disabled={false}
  *   typing={false}
  *   onClick={() => console.log('发送消息')}
@@ -242,10 +239,43 @@ export const SendButton: React.FC<SendButtonProps> = (props) => {
     // 仅在挂载时触发一次，避免引用变化导致重复打点
     // eslint-disable-next-line react-hooks/exhaustive-deps -- onInit intentionally once on mount
   }, []);
+  const { token } = antdTheme.useToken();
   const { getPrefixCls } = useContext(ConfigProvider.ConfigContext);
   const { locale } = useContext(I18nContext);
   const baseCls = getPrefixCls('agentic-md-input-field-send-button');
   const { wrapSSR, hashId } = useStyle(baseCls);
+
+  const displayColors = useMemo(
+    () =>
+      resolveSendButtonDisplayColors(
+        getSendButtonPalette({
+          colorPrimary: token.colorPrimary,
+          colorBgContainer: token.colorBgContainer,
+          colorTextLightSolid: token.colorTextLightSolid,
+          colorTextTertiary: token.colorTextTertiary,
+          colorFillTertiary: token.colorFillTertiary,
+          colorText: token.colorText,
+        }),
+        colors,
+        {
+          colorPrimary: token.colorPrimary,
+          colorBgContainer: token.colorBgContainer,
+          colorTextLightSolid: token.colorTextLightSolid,
+          colorTextTertiary: token.colorTextTertiary,
+          colorFillTertiary: token.colorFillTertiary,
+          colorText: token.colorText,
+        },
+      ),
+    [
+      colors,
+      token.colorBgContainer,
+      token.colorFillTertiary,
+      token.colorPrimary,
+      token.colorText,
+      token.colorTextLightSolid,
+      token.colorTextTertiary,
+    ],
+  );
 
   if (
     typeof window === 'undefined' ||
@@ -314,10 +344,10 @@ export const SendButton: React.FC<SendButtonProps> = (props) => {
       >
         <ErrorBoundary fallback={<div />}>
           <SendIcon
-            hover={isSendable && !disabled}
+            isActive={isSendable}
             disabled={disabled}
             typing={typing}
-            colors={colors}
+            displayColors={displayColors}
           />
         </ErrorBoundary>
       </div>

--- a/src/MarkdownInputField/SendButton/sendButtonPalette.ts
+++ b/src/MarkdownInputField/SendButton/sendButtonPalette.ts
@@ -1,0 +1,300 @@
+/**
+ * 发送按钮默认色板：用 Ant Design token 的实色保证相对 colorBgContainer 的对比度，
+ * 随亮色 / 暗色主题切换。半透明 token 先与 colorBgContainer 叠算再比对比度、再混合。
+ */
+
+export interface SendButtonPaletteToken {
+  colorPrimary: string;
+  colorBgContainer: string;
+  colorTextLightSolid: string;
+  colorTextTertiary: string;
+  colorFillTertiary: string;
+  colorText?: string;
+}
+
+const SHORT_HEX = /^#([0-9a-f]{3})$/i;
+const LONG_HEX6 = /^#([0-9a-f]{6})$/i;
+const LONG_HEX8 = /^#([0-9a-f]{8})$/i;
+const RGBA =
+  /^rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})(?:\s*[,/]\s*([\d.]+))?\s*\)/i;
+
+const clamp = (n: number, min: number, max: number) =>
+  Math.min(max, Math.max(min, n));
+
+type Rgb = { r: number; g: number; b: number };
+
+const compositeOn = (
+  fr: number,
+  fg: number,
+  fb: number,
+  a: number,
+  br: number,
+  bg: number,
+  bb: number,
+): Rgb => {
+  const u = clamp(a, 0, 1);
+  return {
+    r: Math.round(fr * u + br * (1 - u)),
+    g: Math.round(fg * u + bg * (1 - u)),
+    b: Math.round(fb * u + bb * (1 - u)),
+  };
+};
+
+/**
+ * 不透明色：#rgb #rrggbb、rgb(,,) 无 alpha
+ */
+const parseOpaqueRgb = (color: string): Rgb | null => {
+  const t = color.trim();
+  const shortM = t.match(SHORT_HEX);
+  if (shortM) {
+    const [a, b, c] = shortM[1].split('');
+    return {
+      r: parseInt(a + a, 16),
+      g: parseInt(b + b, 16),
+      b: parseInt(c + c, 16),
+    };
+  }
+  const long6 = t.match(LONG_HEX6);
+  if (long6) {
+    return {
+      r: parseInt(long6[1].slice(0, 2), 16),
+      g: parseInt(long6[1].slice(2, 4), 16),
+      b: parseInt(long6[1].slice(4, 6), 16),
+    };
+  }
+  const m = t.match(/^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)/i);
+  if (m) {
+    return { r: Number(m[1]), g: Number(m[2]), b: Number(m[3]) };
+  }
+  return null;
+};
+
+/**
+ * 任意色值在 `onBackground` 上呈现的有效 sRGB（含 rgba / 8 位 hex 叠色）
+ */
+const toRgbOnBackground = (color: string, onBackground: string): Rgb | null => {
+  const t = color.trim();
+  const bg = parseOpaqueRgb(onBackground);
+  if (!bg) {
+    return null;
+  }
+  const long8 = t.match(LONG_HEX8);
+  if (long8) {
+    const r = parseInt(long8[1].slice(0, 2), 16);
+    const g = parseInt(long8[1].slice(2, 4), 16);
+    const b = parseInt(long8[1].slice(4, 6), 16);
+    const a = parseInt(long8[1].slice(6, 8), 16) / 255;
+    return compositeOn(r, g, b, a, bg.r, bg.g, bg.b);
+  }
+  const rgbaM = t.match(RGBA);
+  if (rgbaM) {
+    const r = Number(rgbaM[1]);
+    const g = Number(rgbaM[2]);
+    const b = Number(rgbaM[3]);
+    const a = rgbaM[4] === undefined ? 1 : Number(rgbaM[4]);
+    if (a >= 1 - 1e-6) {
+      return { r, g, b };
+    }
+    return compositeOn(r, g, b, a, bg.r, bg.g, bg.b);
+  }
+  return parseOpaqueRgb(t);
+};
+
+const toRgbString = (rgb: Rgb) => `rgb(${rgb.r},${rgb.g},${rgb.b})`;
+
+const relativeLuminance = (r: number, g: number, b: number) => {
+  const [rs, gs, bs] = [r, g, b].map((c) => {
+    const s = c / 255;
+    return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * rs + 0.7152 * gs + 0.0722 * bs;
+};
+
+const contrastRatio = (c1: string, c2: string): number | null => {
+  const a = toRgbOnBackground(c1, c2);
+  const b = toRgbOnBackground(c2, c2);
+  if (!a || !b) {
+    return null;
+  }
+  const l1 = relativeLuminance(a.r, a.g, a.b);
+  const l2 = relativeLuminance(b.r, b.g, b.b);
+  const L1 = Math.max(l1, l2);
+  const L2 = Math.min(l1, l2);
+  return (L1 + 0.05) / (L2 + 0.05);
+};
+
+/**
+ * 线性 sRGB 混合两色（先相对 `mixBase` 还原为实色），输出不透明 rgb()
+ */
+const mixSrgb = (
+  fg: string,
+  bg: string,
+  t: number,
+  mixBase: string,
+): string => {
+  const a = toRgbOnBackground(fg, mixBase);
+  const b = toRgbOnBackground(bg, mixBase);
+  if (!a || !b) {
+    return fg;
+  }
+  const u = clamp(t, 0, 1);
+  const m = (x: number, y: number) => Math.round(x * u + y * (1 - u));
+  return toRgbString({
+    r: m(a.r, b.r),
+    g: m(a.g, b.g),
+    b: m(a.b, b.b),
+  });
+};
+
+const MIN_MUTED_ICON_CONTRAST = 2.4;
+const MIN_MUTED_FILL_CONTRAST = 1.4;
+
+const DEFAULT_LIGHT_SOLID = '#ffffff';
+
+/**
+ * 基于当前主题 token 生成默认可发送 / 未激活填充与图标色
+ */
+export function getSendButtonPalette(token: SendButtonPaletteToken) {
+  const { colorBgContainer, colorPrimary, colorTextLightSolid } = token;
+  const textTertiary = token.colorTextTertiary;
+  const fillTertiary = token.colorFillTertiary;
+
+  const lightSolid = colorTextLightSolid || DEFAULT_LIGHT_SOLID;
+
+  let fillMuted: string = fillTertiary;
+  let cFill = contrastRatio(fillMuted, colorBgContainer);
+  for (
+    let i = 0;
+    i < 6 && cFill !== null && cFill < MIN_MUTED_FILL_CONTRAST;
+    i += 1
+  ) {
+    fillMuted = mixSrgb(
+      colorPrimary,
+      colorBgContainer,
+      0.1 + i * 0.06,
+      colorBgContainer,
+    );
+    cFill = contrastRatio(fillMuted, colorBgContainer);
+  }
+  if (cFill === null) {
+    fillMuted = mixSrgb(colorPrimary, colorBgContainer, 0.1, colorBgContainer);
+  }
+
+  let iconMuted: string = textTertiary;
+  let cIcon = contrastRatio(iconMuted, colorBgContainer);
+  for (
+    let j = 0;
+    j < 6 && cIcon !== null && cIcon < MIN_MUTED_ICON_CONTRAST;
+    j += 1
+  ) {
+    const mixT = 0.55 - j * 0.08;
+    iconMuted = mixSrgb(
+      colorPrimary,
+      colorBgContainer,
+      Math.max(0, mixT),
+      colorBgContainer,
+    );
+    cIcon = contrastRatio(iconMuted, colorBgContainer);
+  }
+  if (cIcon === null) {
+    iconMuted = mixSrgb(colorPrimary, colorBgContainer, 0.45, colorBgContainer);
+  }
+
+  const fillFinal = toRgbOnBackground(fillMuted, colorBgContainer);
+  const iconFinal = toRgbOnBackground(iconMuted, colorBgContainer);
+
+  return {
+    backgroundActive: colorPrimary,
+    backgroundMuted: fillFinal ? toRgbString(fillFinal) : fillMuted,
+    iconActive: lightSolid,
+    iconMuted: iconFinal ? toRgbString(iconFinal) : iconMuted,
+  } as const;
+}
+
+export type SendButtonResolvedColors = {
+  backgroundActive: string;
+  backgroundMuted: string;
+  iconActive: string;
+  iconMuted: string;
+};
+
+const tuneFillTowardContainer = (
+  source: string,
+  colorBgContainer: string,
+  hintPrimary: string,
+) => {
+  let fill = mixSrgb(source, colorBgContainer, 0.1, colorBgContainer);
+  let c = contrastRatio(fill, colorBgContainer);
+  for (let i = 0; i < 6 && c !== null && c < MIN_MUTED_FILL_CONTRAST; i += 1) {
+    fill = mixSrgb(
+      i % 2 === 0 ? hintPrimary : source,
+      colorBgContainer,
+      0.12 + i * 0.05,
+      colorBgContainer,
+    );
+    c = contrastRatio(fill, colorBgContainer);
+  }
+  const rgb = toRgbOnBackground(fill, colorBgContainer);
+  return rgb ? toRgbString(rgb) : fill;
+};
+
+const tuneIconTowardContainer = (
+  source: string,
+  colorBgContainer: string,
+  hintPrimary: string,
+) => {
+  let icon = mixSrgb(source, colorBgContainer, 0.4, colorBgContainer);
+  let c = contrastRatio(icon, colorBgContainer);
+  for (let j = 0; j < 6 && c !== null && c < MIN_MUTED_ICON_CONTRAST; j += 1) {
+    icon = mixSrgb(
+      j % 2 === 0 ? hintPrimary : source,
+      colorBgContainer,
+      0.5 - j * 0.07,
+      colorBgContainer,
+    );
+    c = contrastRatio(icon, colorBgContainer);
+  }
+  const rgb = toRgbOnBackground(icon, colorBgContainer);
+  return rgb ? toRgbString(rgb) : icon;
+};
+
+/**
+ * 合并默认色板与用户 `colors`；与原先 background/backgroundHover、icon/iconHover 语义一致
+ */
+export function resolveSendButtonDisplayColors(
+  basePalette: SendButtonResolvedColors,
+  colors:
+    | {
+        icon?: string;
+        iconHover?: string;
+        background?: string;
+        backgroundHover?: string;
+      }
+    | undefined,
+  token: SendButtonPaletteToken,
+): SendButtonResolvedColors {
+  if (!colors) {
+    return basePalette;
+  }
+
+  const { colorBgContainer, colorPrimary } = token;
+
+  const backgroundActive =
+    colors.backgroundHover ?? colors.background ?? basePalette.backgroundActive;
+  const iconActive = colors.iconHover ?? colors.icon ?? basePalette.iconActive;
+
+  return {
+    backgroundActive,
+    backgroundMuted: colors.background
+      ? tuneFillTowardContainer(
+          colors.background,
+          colorBgContainer,
+          colorPrimary,
+        )
+      : basePalette.backgroundMuted,
+    iconActive,
+    iconMuted: colors.icon
+      ? tuneIconTowardContainer(colors.icon, colorBgContainer, colorPrimary)
+      : basePalette.iconMuted,
+  };
+}

--- a/src/MarkdownInputField/SendButton/style.ts
+++ b/src/MarkdownInputField/SendButton/style.ts
@@ -39,9 +39,9 @@ const genStyle: GenerateStyle<ChatTokenType> = (token) => {
     // 使用完整 modifier 类名，避免嵌套 `&&-disabled` 与 BEM 类名拼接不一致导致 cursor 等未生效
     [`${token.componentCls}-disabled`]: {
       cursor: 'not-allowed',
-      // 发送图标圆形 fill 使用 var(--color-primary-control-fill-primary)，禁用时改为灰色语义
-      '--color-primary-control-fill-primary': '#8c8c8c',
-      '--color-gray-bg-card-white': 'black',
+      // StopIcon 等仍读语义变量：用 antd token 随亮色/暗色一致
+      '--color-primary-control-fill-primary': token.colorTextQuaternary,
+      '--color-gray-bg-card-white': token.colorBgContainer,
     },
   };
 };

--- a/tests/SendButtonPalette.test.ts
+++ b/tests/SendButtonPalette.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getSendButtonPalette,
+  resolveSendButtonDisplayColors,
+} from '../src/MarkdownInputField/SendButton/sendButtonPalette';
+
+const lightToken = {
+  colorPrimary: '#1677ff',
+  colorBgContainer: '#ffffff',
+  colorTextLightSolid: '#ffffff',
+  colorTextTertiary: 'rgba(0,0,0,0.45)',
+  colorFillTertiary: 'rgba(0,0,0,0.04)',
+};
+
+const darkToken = {
+  colorPrimary: '#1668dc',
+  colorBgContainer: '#141414',
+  colorTextLightSolid: '#ffffff',
+  colorTextTertiary: 'rgba(255,255,255,0.45)',
+  colorFillTertiary: 'rgba(255,255,255,0.12)',
+};
+
+describe('getSendButtonPalette', () => {
+  it('returns opaque hex/rgb fills for light container', () => {
+    const p = getSendButtonPalette(lightToken);
+    expect(p.backgroundActive).toBe('#1677ff');
+    expect(p.iconActive).toBe('#ffffff');
+    expect(p.backgroundMuted).toMatch(/^rgb\(/);
+    expect(p.iconMuted).toMatch(/^rgb\(/);
+    expect(p.backgroundMuted).not.toContain('rgba(0,0,0,0.04)');
+  });
+
+  it('returns distinct muted colors for dark container', () => {
+    const p = getSendButtonPalette(darkToken);
+    expect(p.backgroundActive).toBe('#1668dc');
+    expect(p.iconActive).toBe('#ffffff');
+    expect(p.backgroundMuted).not.toBe(p.backgroundActive);
+    expect(p.iconMuted).not.toBe(p.iconActive);
+  });
+});
+
+describe('resolveSendButtonDisplayColors', () => {
+  it('uses custom active colors and tunes muted from custom background/icon', () => {
+    const base = getSendButtonPalette(lightToken);
+    const resolved = resolveSendButtonDisplayColors(
+      base,
+      {
+        background: '#e6f4ff',
+        backgroundHover: '#0958d9',
+        icon: '#0958d9',
+        iconHover: '#ffffff',
+      },
+      {
+        ...lightToken,
+        colorPrimary: lightToken.colorPrimary,
+        colorBgContainer: lightToken.colorBgContainer,
+        colorTextLightSolid: lightToken.colorTextLightSolid,
+        colorTextTertiary: lightToken.colorTextTertiary,
+        colorFillTertiary: lightToken.colorFillTertiary,
+      },
+    );
+    expect(resolved.backgroundActive).toBe('#0958d9');
+    expect(resolved.iconActive).toBe('#ffffff');
+    expect(resolved.backgroundMuted).toMatch(/^rgb\(/);
+    expect(resolved.iconMuted).toMatch(/^rgb\(/);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Improves MarkdownInputField send button contrast in both light and dark themes by deriving opaque `rgb()` colors from Ant Design `theme.useToken()` instead of stacking low `fillOpacity` on primary over the page background.

## Changes
- New `sendButtonPalette.ts`: builds muted fill/icon from `colorFillTertiary` / `colorTextTertiary` with WCAG-style contrast checks against `colorBgContainer`, blends with `colorPrimary` when below thresholds, and normalizes output to solid `rgb()`.
- `SendButton`: `useToken()` + `useMemo` to resolve `displayColors`; `SendIcon` uses `isActive` and `fillOpacity: 1` (animation only transitions fill colors).
- `SendButton/style` disabled state: sets `--color-primary-control-fill-primary` to `token.colorTextQuaternary` and `--color-gray-bg-card-white` to `token.colorBgContainer` for StopIcon theming.
- Tests: `tests/SendButtonPalette.test.ts` for light/dark token fixtures.

## Notes
- Custom `sendButtonProps.colors` still maps to previous semantics; muted variants are tuned from custom `background` / `icon` when provided.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b26b5ce-23de-40d5-bdd1-fd8cf5e94362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b26b5ce-23de-40d5-bdd1-fd8cf5e94362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

