### PR TITLE
fix(ToolUseBarThink): 提升 light 在 success 下的样式优先级

### DIFF
--- a/src/ToolUseBarThink/style.ts
+++ b/src/ToolUseBarThink/style.ts
@@ -63,22 +63,6 @@ const genStyle: GenerateStyle<ChatTokenType> = (token) => {
           boxShadow: 'var(--shadow-border-base)',
         },
       },
-      '&-light': {
-        boxShadow: 'none',
-        border: 'none',
-        borderRadius: '14px',
-        padding: 4,
-        background: LIGHT_MODE_BACKGROUND,
-        backdropFilter: LIGHT_MODE_BACKDROP_FILTER,
-        WebkitBackdropFilter: LIGHT_MODE_BACKDROP_FILTER,
-        '&:hover': {
-          background: 'none',
-          boxShadow: 'none',
-          [`${token.componentCls}-header-left-icon-light`]: {
-            color: 'var(--color-gray-text-secondary)',
-          },
-        },
-      },
       '&-loading': {
         background: 'var(--color-gray-bg-card-white)',
         boxSizing: 'border-box',
@@ -95,6 +79,23 @@ const genStyle: GenerateStyle<ChatTokenType> = (token) => {
         borderRadius: 'var(--radius-card-base)',
         background: 'var(--color-gray-bg-card-light)',
         boxShadow: 'inset 0px 0px 1px 0px rgba(0, 19, 41, 0.15)',
+      },
+      // Placed after &-success so light mode wins when both classes apply (success + light).
+      '&-light': {
+        boxShadow: 'none',
+        border: 'none',
+        borderRadius: '14px',
+        padding: 4,
+        background: LIGHT_MODE_BACKGROUND,
+        backdropFilter: LIGHT_MODE_BACKDROP_FILTER,
+        WebkitBackdropFilter: LIGHT_MODE_BACKDROP_FILTER,
+        '&:hover': {
+          background: 'none',
+          boxShadow: 'none',
+          [`${token.componentCls}-header-left-icon-light`]: {
+            color: 'var(--color-gray-text-secondary)',
+          },
+        },
       },
       '&-bar': {
         borderRadius: 'var(--radius-card-base)',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

当 `ToolUseBarThink` 根节点同时应用 `…-success` 与 `…-light`（`light` + `status="success"`）时，两者选择器特异性相同。此前 `&-light` 在样式表中排在 `&-success` 之前，导致 `success` 的 `background`、`box-shadow` 等覆盖 `light` 的磨砂与圆角。

## 修改

- 在 `src/ToolUseBarThink/style.ts` 中将 `&-light` 规则块整体移到 `&-success` 之后，使在注入顺序上 `light` 后于 `success`，双类并存时以 light 为准。

## 测试

- `pnpm vitest --run tests/ToolUseBarThink.test.tsx` 通过。

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e5dbcb7-6c8a-48f2-99e8-8a357a8d4ffa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e5dbcb7-6c8a-48f2-99e8-8a357a8d4ffa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

