### PR TITLE
feat: touch/mobile adaptive tooltips and attachment Popover

### DIFF
--- a/src/Bubble/MessagesContent/index.tsx
+++ b/src/Bubble/MessagesContent/index.tsx
@@ -3,6 +3,7 @@ import { ConfigProvider, Popover, Tooltip, Typography } from 'antd';
 import classNames from 'clsx';
 import React, { useContext, useMemo } from 'react';
 import { ActionIconBox } from '../../Components/ActionIconBox';
+import { useAdaptiveTooltipProps } from '../../Hooks/useAdaptiveTooltipProps';
 import { useRefFunction } from '../../Hooks/useRefFunction';
 import { I18nContext } from '../../I18n';
 import { MarkdownEditor } from '../../MarkdownEditor';
@@ -84,6 +85,8 @@ export const BubbleMessageDisplay: React.FC<
   const chatCls = getPrefixCls('agentic-ui');
   const baseChatCls = `${chatCls}-display`;
   const { hashId, wrapSSR } = useMessagesContentStyle(baseChatCls);
+
+  const docTagTooltipProps = useAdaptiveTooltipProps('informational');
 
   const funRender = useRefFunction((props: { identifier?: any }) => {
     const node = nodeList.find((item) => item.placeholder === props.identifier);
@@ -214,6 +217,7 @@ export const BubbleMessageDisplay: React.FC<
                       {item.docId}
                     </Typography.Text>
                   }
+                  {...docTagTooltipProps}
                 >
                   <div
                     className={classNames(

--- a/src/Components/ActionIconBox/index.tsx
+++ b/src/Components/ActionIconBox/index.tsx
@@ -4,6 +4,7 @@ import classNames from 'clsx';
 import { isFunction } from 'lodash-es';
 import { useMergedState } from 'rc-util';
 import React, { useContext, useEffect, useMemo, useState } from 'react';
+import { useNativeTitleTooltipFallback } from '../../Hooks/useNativeTitleTooltipFallback';
 import { useStyle } from './style';
 
 export interface ActionIconBoxProps {
@@ -151,6 +152,7 @@ export const ActionIconBox: React.FC<ActionIconBoxProps> = (props) => {
     onChange: onLoadingChange,
   });
   const [isHovered, setIsHovered] = useState(false);
+  const keepNativeTitleFallback = useNativeTitleTooltipFallback();
   const { getPrefixCls } = useContext(ConfigProvider.ConfigContext);
   const prefixCls = getPrefixCls('agentic-md-editor-action-icon-box');
   const { wrapSSR, hashId } = useStyle(prefixCls);
@@ -220,7 +222,13 @@ export const ActionIconBox: React.FC<ActionIconBoxProps> = (props) => {
       role="button"
       tabIndex={0}
       aria-label={titleText}
-      title={extraProps ? undefined : titleText}
+      title={
+        titleText === undefined
+          ? undefined
+          : extraProps && !keepNativeTitleFallback
+            ? undefined
+            : titleText
+      }
       className={rootClassName}
       onClick={handleClick}
       onKeyDown={handleKeyDown}

--- a/src/Components/SuggestionList/index.tsx
+++ b/src/Components/SuggestionList/index.tsx
@@ -9,6 +9,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { useAdaptiveTooltipProps } from '../../Hooks/useAdaptiveTooltipProps';
 import { useRefFunction } from '../../Hooks/useRefFunction';
 import { I18nContext } from '../../I18n';
 import { useStyle } from './style';
@@ -67,6 +68,7 @@ const OverflowTooltip: React.FC<OverflowTooltipProps> = memo(
   ({ children, title, prefixCls, hashId, forceShow = false }) => {
     const textRef = useRef<HTMLSpanElement>(null);
     const [isOverflowing, setIsOverflowing] = useState(false);
+    const adaptiveTooltip = useAdaptiveTooltipProps('informational');
 
     const checkOverflow = useRefFunction(() => {
       const node = textRef.current;
@@ -118,7 +120,12 @@ const OverflowTooltip: React.FC<OverflowTooltipProps> = memo(
     }
 
     return (
-      <Tooltip mouseEnterDelay={0.3} title={title} placement="top">
+      <Tooltip
+        mouseEnterDelay={0.3}
+        title={title}
+        placement="top"
+        {...adaptiveTooltip}
+      >
         <span
           ref={textRef}
           className={classNames(`${prefixCls}-label`, hashId)}

--- a/src/Components/__tests__/ActionIconBox.test.tsx
+++ b/src/Components/__tests__/ActionIconBox.test.tsx
@@ -1,10 +1,13 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { ConfigProvider } from 'antd';
 import React from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ActionIconBox } from '../ActionIconBox';
 
 describe('ActionIconBox 组件', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
   const TestIcon = () => <span data-testid="test-icon">Icon</span>;
 
   it('应该渲染基本的图标盒子', () => {
@@ -16,6 +19,47 @@ describe('ActionIconBox 组件', () => {
 
     expect(screen.getByTestId('action-icon-box')).toBeInTheDocument();
     expect(screen.getByTestId('test-icon')).toBeInTheDocument();
+  });
+
+  it('触摸能力下 Tooltip 包裹时仍保留原生 title 兜底', async () => {
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      maxTouchPoints: 5,
+    });
+
+    render(
+      <ActionIconBox title="保存">
+        <TestIcon />
+      </ActionIconBox>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId('action-icon-box')).toHaveAttribute(
+      'title',
+      '保存',
+    );
+  });
+
+  it('无触摸能力且存在 Tooltip 时不设置原生 title 避免双重提示', async () => {
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      maxTouchPoints: 0,
+    });
+
+    render(
+      <ActionIconBox title="保存">
+        <TestIcon />
+      </ActionIconBox>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId('action-icon-box')).not.toHaveAttribute('title');
   });
 
   it('应该显示标题文本', () => {

--- a/src/Components/__tests__/ActionIconBox.test.tsx
+++ b/src/Components/__tests__/ActionIconBox.test.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 import { ConfigProvider } from 'antd';
 import React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import * as adaptiveTooltip from '../../Utils/adaptiveTooltip';
+import { adaptiveTooltipEnvironment } from '../../Utils/adaptiveTooltip';
 import { ActionIconBox } from '../ActionIconBox';
 
 describe('ActionIconBox 组件', () => {
@@ -24,7 +24,7 @@ describe('ActionIconBox 组件', () => {
 
   it('触摸策略为真时 Tooltip 包裹仍保留原生 title 兜底', async () => {
     const spy = vi
-      .spyOn(adaptiveTooltip, 'shouldUseInformationalTooltipClickTrigger')
+      .spyOn(adaptiveTooltipEnvironment, 'isInformationalClickContext')
       .mockReturnValue(true);
 
     try {
@@ -49,7 +49,7 @@ describe('ActionIconBox 组件', () => {
 
   it('触摸策略为假且存在 Tooltip 时不设置原生 title', async () => {
     const spy = vi
-      .spyOn(adaptiveTooltip, 'shouldUseInformationalTooltipClickTrigger')
+      .spyOn(adaptiveTooltipEnvironment, 'isInformationalClickContext')
       .mockReturnValue(false);
 
     try {
@@ -63,7 +63,9 @@ describe('ActionIconBox 组件', () => {
         await Promise.resolve();
       });
 
-      expect(screen.getByTestId('action-icon-box')).not.toHaveAttribute('title');
+      expect(screen.getByTestId('action-icon-box')).not.toHaveAttribute(
+        'title',
+      );
     } finally {
       spy.mockRestore();
     }

--- a/src/Components/__tests__/ActionIconBox.test.tsx
+++ b/src/Components/__tests__/ActionIconBox.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 import { ConfigProvider } from 'antd';
 import React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as adaptiveTooltip from '../../Utils/adaptiveTooltip';
 import { ActionIconBox } from '../ActionIconBox';
 
 describe('ActionIconBox 组件', () => {
@@ -21,45 +22,51 @@ describe('ActionIconBox 组件', () => {
     expect(screen.getByTestId('test-icon')).toBeInTheDocument();
   });
 
-  it('触摸能力下 Tooltip 包裹时仍保留原生 title 兜底', async () => {
-    vi.stubGlobal('navigator', {
-      ...navigator,
-      maxTouchPoints: 5,
-    });
+  it('触摸策略为真时 Tooltip 包裹仍保留原生 title 兜底', async () => {
+    const spy = vi
+      .spyOn(adaptiveTooltip, 'shouldUseInformationalTooltipClickTrigger')
+      .mockReturnValue(true);
 
-    render(
-      <ActionIconBox title="保存">
-        <TestIcon />
-      </ActionIconBox>,
-    );
+    try {
+      render(
+        <ActionIconBox title="保存">
+          <TestIcon />
+        </ActionIconBox>,
+      );
 
-    await act(async () => {
-      await Promise.resolve();
-    });
+      await act(async () => {
+        await Promise.resolve();
+      });
 
-    expect(screen.getByTestId('action-icon-box')).toHaveAttribute(
-      'title',
-      '保存',
-    );
+      expect(screen.getByTestId('action-icon-box')).toHaveAttribute(
+        'title',
+        '保存',
+      );
+    } finally {
+      spy.mockRestore();
+    }
   });
 
-  it('无触摸能力且存在 Tooltip 时不设置原生 title 避免双重提示', async () => {
-    vi.stubGlobal('navigator', {
-      ...navigator,
-      maxTouchPoints: 0,
-    });
+  it('触摸策略为假且存在 Tooltip 时不设置原生 title', async () => {
+    const spy = vi
+      .spyOn(adaptiveTooltip, 'shouldUseInformationalTooltipClickTrigger')
+      .mockReturnValue(false);
 
-    render(
-      <ActionIconBox title="保存">
-        <TestIcon />
-      </ActionIconBox>,
-    );
+    try {
+      render(
+        <ActionIconBox title="保存">
+          <TestIcon />
+        </ActionIconBox>,
+      );
 
-    await act(async () => {
-      await Promise.resolve();
-    });
+      await act(async () => {
+        await Promise.resolve();
+      });
 
-    expect(screen.getByTestId('action-icon-box')).not.toHaveAttribute('title');
+      expect(screen.getByTestId('action-icon-box')).not.toHaveAttribute('title');
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it('应该显示标题文本', () => {

--- a/src/History/__tests__/History.test.tsx
+++ b/src/History/__tests__/History.test.tsx
@@ -107,7 +107,7 @@ describe('History Component', () => {
         </TestWrapper>,
       );
 
-      // ActionIconBox 使用 aria-label 和 data-title 属性，而不是 HTML title 属性
+      // ActionIconBox：aria-label / data-title 必有；触摸环境下可额外保留 HTML title 作兜底
       const button = screen.getByLabelText('聊天历史');
       expect(button).toBeInTheDocument();
       expect(button).toHaveAttribute('data-title', '聊天历史');

--- a/src/History/components/HistoryItem.tsx
+++ b/src/History/components/HistoryItem.tsx
@@ -6,6 +6,7 @@ import {
 import { Checkbox, ConfigProvider, Divider, Tooltip } from 'antd';
 import type { CheckboxChangeEvent } from 'antd/es/checkbox';
 import React, { useContext } from 'react';
+import { useAdaptiveTooltipProps } from '../../Hooks/useAdaptiveTooltipProps';
 import { useRefFunction } from '../../Hooks/useRefFunction';
 import { I18nContext } from '../../I18n';
 import { getMaskStyle } from '../constants';
@@ -199,6 +200,7 @@ const HistoryItemSingle = React.memo<HistoryItemProps>(
       () => selectedIds.includes(item.sessionId!),
       [selectedIds, item.sessionId],
     );
+    const adaptiveTitleTooltip = useAdaptiveTooltipProps('informational');
 
     const handleClick = useRefFunction((e: React.MouseEvent) => {
       e.stopPropagation();
@@ -292,6 +294,7 @@ const HistoryItemSingle = React.memo<HistoryItemProps>(
                 title={isTextOverflow ? displayText : null}
                 mouseEnterDelay={0.3}
                 open={isTextOverflow ? undefined : false}
+                {...adaptiveTitleTooltip}
               >
                 <div
                   style={{
@@ -410,6 +413,7 @@ const HistoryItemMulti = React.memo<HistoryItemProps>(
       () => selectedIds.includes(item.sessionId!),
       [selectedIds, item.sessionId],
     );
+    const adaptiveTitleTooltip = useAdaptiveTooltipProps('informational');
 
     /**
      * 处理点击事件
@@ -528,6 +532,7 @@ const HistoryItemMulti = React.memo<HistoryItemProps>(
                 title={isTextOverflow ? displayText : null}
                 mouseEnterDelay={0.3}
                 open={isTextOverflow ? undefined : false}
+                {...adaptiveTitleTooltip}
               >
                 <div
                   style={{
@@ -556,6 +561,7 @@ const HistoryItemMulti = React.memo<HistoryItemProps>(
                   item.description ||
                   (isTask ? locale?.['task.default'] || '任务' : '')
                 }
+                {...adaptiveTitleTooltip}
               >
                 <div
                   style={{

--- a/src/Hooks/useAdaptiveTooltipProps.ts
+++ b/src/Hooks/useAdaptiveTooltipProps.ts
@@ -1,0 +1,33 @@
+import type { TooltipProps } from 'antd';
+import { useLayoutEffect, useState } from 'react';
+import {
+  type AdaptiveTooltipKind,
+  getAdaptiveTooltipProps,
+} from '../Utils/adaptiveTooltip';
+
+/**
+ * 客户端挂载后返回自适应 Tooltip 属性，避免 SSR 与首屏 hydration 不一致。
+ * 监听 resize / orientationchange 以适配旋转与窗口缩放导致的 `isMobileDevice` 变化。
+ */
+export function useAdaptiveTooltipProps(
+  kind: AdaptiveTooltipKind = 'informational',
+): Partial<Pick<TooltipProps, 'trigger'>> {
+  const [tooltipProps, setTooltipProps] = useState<
+    Partial<Pick<TooltipProps, 'trigger'>>
+  >({});
+
+  useLayoutEffect(() => {
+    const update = () => {
+      setTooltipProps(getAdaptiveTooltipProps(kind));
+    };
+    update();
+    window.addEventListener('resize', update);
+    window.addEventListener('orientationchange', update);
+    return () => {
+      window.removeEventListener('resize', update);
+      window.removeEventListener('orientationchange', update);
+    };
+  }, [kind]);
+
+  return tooltipProps;
+}

--- a/src/Hooks/useAdaptiveTooltipProps.ts
+++ b/src/Hooks/useAdaptiveTooltipProps.ts
@@ -1,33 +1,22 @@
 import type { TooltipProps } from 'antd';
-import { useLayoutEffect, useState } from 'react';
+import { useSyncExternalStore } from 'react';
 import {
   type AdaptiveTooltipKind,
-  getAdaptiveTooltipProps,
+  getAdaptiveTooltipTriggerPropsServerSnapshot,
+  getAdaptiveTooltipTriggerPropsSnapshot,
+  subscribeAdaptiveTooltipEnvironment,
 } from '../Utils/adaptiveTooltip';
 
 /**
- * 客户端挂载后返回自适应 Tooltip 属性，避免 SSR 与首屏 hydration 不一致。
- * 监听 resize / orientationchange 以适配旋转与窗口缩放导致的 `isMobileDevice` 变化。
+ * 客户端挂载后返回自适应 Tooltip 属性，与 `useSyncExternalStore` 对齐 SSR。
+ * 环境变化通过共享的 resize/orientationchange 订阅广播，避免每实例重复监听。
  */
 export function useAdaptiveTooltipProps(
   kind: AdaptiveTooltipKind = 'informational',
 ): Partial<Pick<TooltipProps, 'trigger'>> {
-  const [tooltipProps, setTooltipProps] = useState<
-    Partial<Pick<TooltipProps, 'trigger'>>
-  >({});
-
-  useLayoutEffect(() => {
-    const update = () => {
-      setTooltipProps(getAdaptiveTooltipProps(kind));
-    };
-    update();
-    window.addEventListener('resize', update);
-    window.addEventListener('orientationchange', update);
-    return () => {
-      window.removeEventListener('resize', update);
-      window.removeEventListener('orientationchange', update);
-    };
-  }, [kind]);
-
-  return tooltipProps;
+  return useSyncExternalStore(
+    subscribeAdaptiveTooltipEnvironment,
+    () => getAdaptiveTooltipTriggerPropsSnapshot(kind),
+    () => getAdaptiveTooltipTriggerPropsServerSnapshot(kind),
+  );
 }

--- a/src/Hooks/useNativeTitleTooltipFallback.ts
+++ b/src/Hooks/useNativeTitleTooltipFallback.ts
@@ -1,0 +1,25 @@
+import { useLayoutEffect, useState } from 'react';
+import { shouldUseInformationalTooltipClickTrigger } from '../Utils/adaptiveTooltip';
+
+/**
+ * 与 Ant Design Tooltip 同用时，是否在触发器上保留原生 `title`。
+ * 纯鼠标桌面环境为 false，避免与 Tooltip 叠出双重提示；触摸 / 移动为 true，作为无 hover 时的兜底。
+ */
+export function useNativeTitleTooltipFallback(): boolean {
+  const [keep, setKeep] = useState(false);
+
+  useLayoutEffect(() => {
+    const update = () => {
+      setKeep(shouldUseInformationalTooltipClickTrigger());
+    };
+    update();
+    window.addEventListener('resize', update);
+    window.addEventListener('orientationchange', update);
+    return () => {
+      window.removeEventListener('resize', update);
+      window.removeEventListener('orientationchange', update);
+    };
+  }, []);
+
+  return keep;
+}

--- a/src/Hooks/useNativeTitleTooltipFallback.ts
+++ b/src/Hooks/useNativeTitleTooltipFallback.ts
@@ -1,25 +1,18 @@
-import { useLayoutEffect, useState } from 'react';
-import { shouldUseInformationalTooltipClickTrigger } from '../Utils/adaptiveTooltip';
+import { useSyncExternalStore } from 'react';
+import {
+  getAdaptiveEnvironmentServerSnapshot,
+  getAdaptiveEnvironmentSnapshot,
+  subscribeAdaptiveTooltipEnvironment,
+} from '../Utils/adaptiveTooltip';
 
 /**
  * 与 Ant Design Tooltip 同用时，是否在触发器上保留原生 `title`。
- * 纯鼠标桌面环境为 false，避免与 Tooltip 叠出双重提示；触摸 / 移动为 true，作为无 hover 时的兜底。
+ * 纯鼠标桌面环境为 false；触摸 / 移动为 true。与 `useAdaptiveTooltipProps` 共享环境订阅。
  */
 export function useNativeTitleTooltipFallback(): boolean {
-  const [keep, setKeep] = useState(false);
-
-  useLayoutEffect(() => {
-    const update = () => {
-      setKeep(shouldUseInformationalTooltipClickTrigger());
-    };
-    update();
-    window.addEventListener('resize', update);
-    window.addEventListener('orientationchange', update);
-    return () => {
-      window.removeEventListener('resize', update);
-      window.removeEventListener('orientationchange', update);
-    };
-  }, []);
-
-  return keep;
+  return useSyncExternalStore(
+    subscribeAdaptiveTooltipEnvironment,
+    getAdaptiveEnvironmentSnapshot,
+    getAdaptiveEnvironmentServerSnapshot,
+  );
 }

--- a/src/MarkdownInputField/AttachmentButton/AttachmentButtonPopover.tsx
+++ b/src/MarkdownInputField/AttachmentButton/AttachmentButtonPopover.tsx
@@ -6,7 +6,7 @@ import {
   PictureOutlined,
   VideoCameraOutlined,
 } from '@ant-design/icons';
-import { Button, Modal, Tooltip } from 'antd';
+import { Button, Modal, Popover, Tooltip } from 'antd';
 import React, { useContext, useMemo, useState } from 'react';
 import { useRefFunction } from '../../Hooks/useRefFunction';
 import type { LocalKeys } from '../../I18n';
@@ -196,9 +196,23 @@ export const AttachmentButtonPopover: React.FC<
     );
   }
 
-  // 如果是移动设备，不显示 Tooltip
+  // 移动设备无稳定 hover：用点击 Popover 展示支持格式说明（vivo/oppo 仍走上方 Modal）
   if (isMobile) {
-    return <span>{children}</span>;
+    return (
+      <Popover
+        trigger="click"
+        placement="top"
+        arrow={false}
+        content={
+          <AttachmentSupportedFormatsContent
+            supportedFormat={supportedFormat}
+            locale={locale}
+          />
+        }
+      >
+        <span style={{ display: 'inline-flex' }}>{children}</span>
+      </Popover>
+    );
   }
 
   return (

--- a/src/MarkdownInputField/AttachmentButton/AttachmentFileList/AttachmentFileIcon.tsx
+++ b/src/MarkdownInputField/AttachmentButton/AttachmentFileList/AttachmentFileIcon.tsx
@@ -1,6 +1,7 @@
 import { Eye, FileFailed, FileUploadingSpin, Play } from '@sofa-design/icons';
 import { Image, Tooltip } from 'antd';
 import React, { useEffect, useState } from 'react';
+import { useAdaptiveTooltipProps } from '../../../Hooks/useAdaptiveTooltipProps';
 import { getFileTypeIcon } from '../../../Workspace/File/utils';
 import { FileType } from '../../../Workspace/types';
 import { AttachmentFile } from '../types';
@@ -125,8 +126,9 @@ export const FileMetaPlaceholder: React.FC<{
     ? (rawFormat.split('/').pop() ?? '').toUpperCase()
     : rawFormat.toUpperCase();
   const formatText = formatSuffix || '-';
+  const adaptiveTooltip = useAdaptiveTooltipProps('informational');
   return (
-    <Tooltip title={file.name}>
+    <Tooltip title={file.name} {...adaptiveTooltip}>
       <div
         data-testid="file-meta-placeholder"
         className={className}

--- a/src/MarkdownInputField/RefinePromptButton/index.tsx
+++ b/src/MarkdownInputField/RefinePromptButton/index.tsx
@@ -1,6 +1,6 @@
 import { LoadingOutlined } from '@ant-design/icons';
 import { TextOptimize } from '@sofa-design/icons';
-import { ConfigProvider, Tooltip } from 'antd';
+import { ConfigProvider } from 'antd';
 import React, { useContext } from 'react';
 
 import { ErrorBoundary } from 'react-error-boundary';
@@ -37,25 +37,22 @@ export const RefinePromptButton: React.FC<RefinePromptButtonProps> = (
     return <TextOptimize />;
   };
 
+  const actionTitle =
+    status === 'loading'
+      ? locale['refine.loading']
+      : locale['refine.oneClickOptimize'];
+
   if (!isBrowserEnv()) {
     return null;
   }
 
   return wrapSSR(
-    <Tooltip
-      title={
-        status === 'loading'
-          ? locale['refine.loading']
-          : locale['refine.oneClickOptimize']
-      }
+    <ActionIconBox
+      title={actionTitle}
+      onClick={handleClick}
+      data-testid="refine-prompt-button"
     >
-      <ActionIconBox
-        title={locale['refine.optimizePrompt']}
-        onClick={handleClick}
-        data-testid="refine-prompt-button"
-      >
-        <ErrorBoundary fallback={<div />}>{renderIcon()}</ErrorBoundary>
-      </ActionIconBox>
-    </Tooltip>,
+      <ErrorBoundary fallback={<div />}>{renderIcon()}</ErrorBoundary>
+    </ActionIconBox>,
   );
 };

--- a/src/MarkdownInputField/__tests__/AttachmentButtonPopover.branches.test.tsx
+++ b/src/MarkdownInputField/__tests__/AttachmentButtonPopover.branches.test.tsx
@@ -178,19 +178,19 @@ describe('AttachmentButtonPopover 分支覆盖', () => {
 
   /* ====== 移动设备分支 ====== */
 
-  describe('移动设备下渲染纯 span', () => {
-    it('isMobile 时渲染纯 span 包裹 children', () => {
+  describe('移动设备下使用 Popover 展示格式说明', () => {
+    it('isMobile 时点击展开 Popover 展示支持格式', async () => {
       mocks.isMobileDevice.mockReturnValue(true);
 
-      const { container } = render(
+      render(
         <AttachmentButtonPopover>
           <button type="button">Upload</button>
         </AttachmentButtonPopover>,
       );
 
       expect(screen.getByText('Upload')).toBeInTheDocument();
-      // 不应有 Tooltip 或 Modal
-      expect(container.querySelector('.ant-tooltip')).toBeNull();
+      fireEvent.click(screen.getByText('Upload'));
+      expect(await screen.findByText(/jpg/i)).toBeInTheDocument();
     });
   });
 

--- a/src/MarkdownInputField/__tests__/RefinePromptButton.test.tsx
+++ b/src/MarkdownInputField/__tests__/RefinePromptButton.test.tsx
@@ -190,17 +190,31 @@ describe('RefinePromptButton', () => {
 
       const button = screen.getByTestId('refine-prompt-button');
       expect(button).toHaveAttribute('role', 'button');
-      expect(button).toHaveAttribute('aria-label', '优化提示词');
+      expect(button).toHaveAttribute('aria-label', '一键优化提示词');
       expect(button).toHaveAttribute('tabIndex', '0');
     });
 
-    it('should show correct tooltip for idle state', () => {
+    it('should show correct tooltip title for idle state', () => {
       render(
         <RefinePromptButton isHover={false} status="idle" onRefine={vi.fn()} />,
       );
 
       const button = screen.getByTestId('refine-prompt-button');
-      expect(button).toHaveAttribute('data-title', '优化提示词');
+      expect(button).toHaveAttribute('data-title', '一键优化提示词');
+    });
+
+    it('should use loading copy for aria and tooltip title when loading', () => {
+      render(
+        <RefinePromptButton
+          isHover={false}
+          status="loading"
+          onRefine={vi.fn()}
+        />,
+      );
+
+      const button = screen.getByTestId('refine-prompt-button');
+      expect(button).toHaveAttribute('aria-label', '优化中');
+      expect(button).toHaveAttribute('data-title', '优化中');
     });
   });
 

--- a/src/MarkdownInputField/__tests__/events/MarkdownInputField.onSend.test.tsx
+++ b/src/MarkdownInputField/__tests__/events/MarkdownInputField.onSend.test.tsx
@@ -13,6 +13,8 @@ vi.mock('../../../Hooks/useRefFunction', () => ({
 
 describe('useSendHandler - onSend 防重复触发', () => {
   const createMockParams = (overrides: Record<string, any> = {}) => {
+    const { props: propsOverride, ...restOverrides } = overrides;
+
     const markdownEditorRef = {
       current: {
         store: {
@@ -30,7 +32,7 @@ describe('useSendHandler - onSend 防重复触发', () => {
       onChange: vi.fn(),
       onSend: vi.fn().mockResolvedValue(undefined),
       allowEmptySubmit: false,
-      ...(overrides.props || {}),
+      ...(propsOverride || {}),
     };
 
     return {
@@ -45,8 +47,7 @@ describe('useSendHandler - onSend 防重复触发', () => {
       setFileMap: vi.fn(),
       recording: false,
       stopRecording: vi.fn().mockResolvedValue(undefined),
-      ...overrides,
-      props,
+      ...restOverrides,
     };
   };
 

--- a/src/Plugins/chart/ChartMark/Container.tsx
+++ b/src/Plugins/chart/ChartMark/Container.tsx
@@ -39,7 +39,7 @@ export const Container: React.FC<{
         Math.abs(preSize.width - newSize.width) > 30 || // 从 20 增加到 30
         Math.abs(preSize.height - newSize.height) > 30 // 从 20 增加到 30
       ) {
-        chart.resize(newSize.width, newSize.height);
+        chart.resize?.(newSize.width, newSize.height);
         sizeRef.current = newSize;
         return;
       }

--- a/src/Plugins/chart/ChartStatistic/index.tsx
+++ b/src/Plugins/chart/ChartStatistic/index.tsx
@@ -2,6 +2,7 @@ import { QuestionCircleOutlined } from '@ant-design/icons';
 import { ConfigProvider, Tooltip } from 'antd';
 import clsx from 'clsx';
 import React, { useContext } from 'react';
+import { useAdaptiveTooltipProps } from '../../../Hooks/useAdaptiveTooltipProps';
 import { useStyle } from './style';
 import { formatNumber, NumberFormatOptions } from './utils';
 
@@ -77,6 +78,7 @@ const ChartStatistic: React.FC<ChartStatisticProps> = ({
   const { getPrefixCls } = useContext(ConfigProvider.ConfigContext);
   const prefixCls = getPrefixCls('chart-statistic');
   const { wrapSSR, hashId } = useStyle(prefixCls);
+  const informationalTooltip = useAdaptiveTooltipProps('informational');
 
   // 渲染数值
   const renderValue = () => {
@@ -117,7 +119,12 @@ const ChartStatistic: React.FC<ChartStatisticProps> = ({
     ) : null;
 
     const questionIcon = tooltip ? (
-      <Tooltip mouseEnterDelay={0.3} title={tooltip} placement="top">
+      <Tooltip
+        mouseEnterDelay={0.3}
+        title={tooltip}
+        placement="top"
+        {...informationalTooltip}
+      >
         <QuestionCircleOutlined
           className={clsx(
             `${prefixCls}-question-icon`,

--- a/src/Plugins/chart/__tests__/ChartMark.test.tsx
+++ b/src/Plugins/chart/__tests__/ChartMark.test.tsx
@@ -36,7 +36,7 @@ vi.mock('react-chartjs-2', () => {
   return {
     Line: R.forwardRef(({ data, options }: any, ref: any) => {
       R.useEffect(() => {
-        if (ref) ref.current = {};
+        if (ref) ref.current = { resize: vi.fn() };
       }, [ref]);
       // 覆盖 Line.tsx 148,149,160：调用 scales ticks callback
       R.useEffect(() => {
@@ -59,7 +59,7 @@ vi.mock('react-chartjs-2', () => {
     }),
     Bar: R.forwardRef(({ data, options }: any, ref: any) => {
       R.useEffect(() => {
-        if (ref) ref.current = {};
+        if (ref) ref.current = { resize: vi.fn() };
       }, [ref]);
       // 覆盖 Column.tsx 154,155,166,177 与 Bar.tsx 155,166,167,177：调用 scales ticks callback 并设置 ref
       R.useEffect(() => {
@@ -90,7 +90,7 @@ vi.mock('react-chartjs-2', () => {
     }),
     Doughnut: R.forwardRef(({ data }: any, ref: any) => {
       R.useEffect(() => {
-        if (ref) ref.current = {};
+        if (ref) ref.current = { resize: vi.fn() };
       }, [ref]);
       return R.createElement('div', {
         'data-testid': 'doughnut-chart',

--- a/src/ThoughtChainList/CostMillis.tsx
+++ b/src/ThoughtChainList/CostMillis.tsx
@@ -1,6 +1,7 @@
 import { FieldTimeOutlined } from '@ant-design/icons';
 import { Tooltip } from 'antd';
-import React, { useContext, useMemo } from 'react';
+import React, { useContext } from 'react';
+import { useAdaptiveTooltipProps } from '../Hooks/useAdaptiveTooltipProps';
 import { I18nContext, LocalKeys } from '../I18n';
 
 /**
@@ -94,36 +95,40 @@ export const msToTimes = (ms: number | undefined | null, locale: LocalKeys) => {
  */
 export const CostMillis = (props: { costMillis?: number }) => {
   const { locale } = useContext(I18nContext);
+  const adaptiveTooltip = useAdaptiveTooltipProps('informational');
 
-  return useMemo(() => {
-    if (props.costMillis === undefined || props.costMillis === null) {
-      return null;
-    }
-    return (
-      <Tooltip mouseEnterDelay={0.3} title={props.costMillis + 'ms'}>
-        <span
-          style={{
-            display: 'flex',
-            flexDirection: 'row',
-            alignItems: 'center',
-            padding: '1px 10px',
-            gap: '6px',
-            borderRadius: '12px',
-            height: '2em',
-            minHeight: '28px',
-            fontSize: '0.9em',
-            wordBreak: 'break-all',
-            wordWrap: 'break-word',
-            maxWidth: '100%',
-            background:
-              'radial-gradient(22% 66% at 96% 113%, rgba(255, 255, 245, 0.52) 0%, rgba(230, 238, 255, 0) 100%), radial-gradient(14% 234% at 100% 50%, rgba(162, 255, 255, 0.28) 0%, rgba(153, 202, 255, 0.1193) 13%, rgba(229, 189, 255, 0.0826) 38%, rgba(235, 255, 245, 0) 100%), #FFFFFF',
-            border: '1px solid rgba(227, 230, 234, 0.65)',
-          }}
-        >
-          <FieldTimeOutlined />
-          {msToTimes(props.costMillis, locale)}
-        </span>
-      </Tooltip>
-    );
-  }, [props.costMillis, locale]);
+  if (props.costMillis === undefined || props.costMillis === null) {
+    return null;
+  }
+
+  return (
+    <Tooltip
+      mouseEnterDelay={0.3}
+      title={props.costMillis + 'ms'}
+      {...adaptiveTooltip}
+    >
+      <span
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          alignItems: 'center',
+          padding: '1px 10px',
+          gap: '6px',
+          borderRadius: '12px',
+          height: '2em',
+          minHeight: '28px',
+          fontSize: '0.9em',
+          wordBreak: 'break-all',
+          wordWrap: 'break-word',
+          maxWidth: '100%',
+          background:
+            'radial-gradient(22% 66% at 96% 113%, rgba(255, 255, 245, 0.52) 0%, rgba(230, 238, 255, 0) 100%), radial-gradient(14% 234% at 100% 50%, rgba(162, 255, 255, 0.28) 0%, rgba(153, 202, 255, 0.1193) 13%, rgba(229, 189, 255, 0.0826) 38%, rgba(235, 255, 245, 0) 100%), #FFFFFF',
+          border: '1px solid rgba(227, 230, 234, 0.65)',
+        }}
+      >
+        <FieldTimeOutlined />
+        {msToTimes(props.costMillis, locale)}
+      </span>
+    </Tooltip>
+  );
 };

--- a/src/Utils/__tests__/adaptiveTooltip.test.ts
+++ b/src/Utils/__tests__/adaptiveTooltip.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  getAdaptiveTooltipProps,
+  shouldUseInformationalTooltipClickTrigger,
+} from '../adaptiveTooltip';
+
+describe('adaptiveTooltip', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('window 未定义时 getAdaptiveTooltipProps 返回空对象', () => {
+    vi.stubGlobal('window', undefined);
+    expect(getAdaptiveTooltipProps('informational')).toEqual({});
+    expect(getAdaptiveTooltipProps('interactive')).toEqual({});
+  });
+
+  it('interactive 种类不附加 click trigger', () => {
+    vi.stubGlobal('window', { innerWidth: 375 });
+    vi.stubGlobal('navigator', {
+      userAgent:
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15',
+      maxTouchPoints: 5,
+    });
+    expect(getAdaptiveTooltipProps('interactive')).toEqual({});
+    expect(getAdaptiveTooltipProps('informational')).toEqual({
+      trigger: ['hover', 'click'],
+    });
+  });
+
+  it('shouldUseInformationalTooltipClickTrigger 在触摸能力下为 true', () => {
+    vi.stubGlobal('window', {
+      innerWidth: 1920,
+      ontouchstart: null,
+    });
+    vi.stubGlobal('navigator', {
+      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+      maxTouchPoints: 10,
+    });
+    expect(shouldUseInformationalTooltipClickTrigger()).toBe(true);
+  });
+});

--- a/src/Utils/adaptiveTooltip.ts
+++ b/src/Utils/adaptiveTooltip.ts
@@ -3,6 +3,22 @@ import { isMobileDevice } from './env';
 
 export type AdaptiveTooltipKind = 'informational' | 'interactive';
 
+/** 无自适应 trigger 时的稳定引用，避免无谓重渲染 */
+export const EMPTY_TOOLTIP_TRIGGER_PROPS: Partial<
+  Pick<TooltipProps, 'trigger'>
+> = Object.freeze({});
+
+const HOVER_CLICK_TRIGGER = Object.freeze(['hover', 'click'] as const);
+
+/** 信息类触摸/移动场景下的稳定 trigger 配置 */
+export const INFORMATIONAL_TOOLTIP_TRIGGER_PROPS: Partial<
+  Pick<TooltipProps, 'trigger'>
+> = Object.freeze({
+  trigger: HOVER_CLICK_TRIGGER as unknown as NonNullable<
+    TooltipProps['trigger']
+  >,
+});
+
 function isTouchEnvironment(): boolean {
   if (typeof window === 'undefined' || typeof navigator === 'undefined') {
     return false;
@@ -15,31 +31,137 @@ function isTouchEnvironment(): boolean {
 }
 
 /**
+ * 环境判定单一入口：与导出函数、订阅快照共用同一引用，便于单测 `vi.spyOn`。
+ */
+export const adaptiveTooltipEnvironment = {
+  isInformationalClickContext(): boolean {
+    if (typeof window === 'undefined') return false;
+    return isMobileDevice() || isTouchEnvironment();
+  },
+};
+
+/**
  * 信息类 Tooltip 是否在触摸 / 窄屏移动场景下启用「点击展开」。
  * - `isMobileDevice()`：UA 或 触摸 + 小屏
  * - `isTouchEnvironment()`：存在触摸能力（含触屏笔记本）
  */
 export function shouldUseInformationalTooltipClickTrigger(): boolean {
-  if (typeof window === 'undefined') return false;
-  return isMobileDevice() || isTouchEnvironment();
+  return adaptiveTooltipEnvironment.isInformationalClickContext();
+}
+
+function readInformationalEnvironmentActive(): boolean {
+  return adaptiveTooltipEnvironment.isInformationalClickContext();
+}
+
+// ── 共享订阅：全页至多一对 window 监听 ─────────────────────────────────────
+
+const environmentListeners = new Set<() => void>();
+let windowEventsAttached = false;
+/** 上次因窗口事件广播过的值，用于省略无变化的 resize 回调 */
+let lastBroadcastActive: boolean | null = null;
+
+function syncInformationalEnvironmentFromWindow(): void {
+  const next = readInformationalEnvironmentActive();
+  if (lastBroadcastActive === next) return;
+  lastBroadcastActive = next;
+  environmentListeners.forEach((listener) => listener());
+}
+
+function attachWindowEventsIfNeeded(): void {
+  if (typeof window === 'undefined' || windowEventsAttached) return;
+  windowEventsAttached = true;
+  window.addEventListener('resize', syncInformationalEnvironmentFromWindow);
+  window.addEventListener(
+    'orientationchange',
+    syncInformationalEnvironmentFromWindow,
+  );
+}
+
+function detachWindowEventsIfIdle(): void {
+  if (typeof window === 'undefined' || !windowEventsAttached) return;
+  window.removeEventListener('resize', syncInformationalEnvironmentFromWindow);
+  window.removeEventListener(
+    'orientationchange',
+    syncInformationalEnvironmentFromWindow,
+  );
+  windowEventsAttached = false;
 }
 
 /**
- * 为 Ant Design Tooltip 生成自适应 `trigger`。
- * - `informational`：触摸或移动场景使用 `hover` + `click`，便于移动端查看说明；点击空白处由 rc-tooltip 关闭
- * - `interactive`：保持默认（仅 hover），避免与按钮/链接等主点击行为抢第一下触摸
+ * 供 `useSyncExternalStore` 使用：所有消费者共享同一组 resize/orientation 监听。
+ * 快照函数每次读取当前环境并返回稳定对象/布尔引用；窗口变化时仅广播订阅者，由 React 与 `Object.is` 自行跳过未变化的重渲染。
+ */
+export function subscribeAdaptiveTooltipEnvironment(
+  onChange: () => void,
+): () => void {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  const wasEmpty = environmentListeners.size === 0;
+  environmentListeners.add(onChange);
+
+  if (wasEmpty) {
+    attachWindowEventsIfNeeded();
+  }
+
+  return () => {
+    environmentListeners.delete(onChange);
+    if (environmentListeners.size === 0) {
+      detachWindowEventsIfIdle();
+      lastBroadcastActive = null;
+    }
+  };
+}
+
+/** 客户端快照：与原生 title 兜底共用，每次读取当前环境 */
+export function getAdaptiveEnvironmentSnapshot(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  return readInformationalEnvironmentActive();
+}
+
+export function getAdaptiveEnvironmentServerSnapshot(): boolean {
+  return false;
+}
+
+export function getAdaptiveTooltipTriggerPropsSnapshot(
+  kind: AdaptiveTooltipKind,
+): Partial<Pick<TooltipProps, 'trigger'>> {
+  if (typeof window === 'undefined') {
+    return EMPTY_TOOLTIP_TRIGGER_PROPS;
+  }
+  if (kind === 'interactive') {
+    return EMPTY_TOOLTIP_TRIGGER_PROPS;
+  }
+  return readInformationalEnvironmentActive()
+    ? INFORMATIONAL_TOOLTIP_TRIGGER_PROPS
+    : EMPTY_TOOLTIP_TRIGGER_PROPS;
+}
+
+export function getAdaptiveTooltipTriggerPropsServerSnapshot(
+  kind: AdaptiveTooltipKind,
+): Partial<Pick<TooltipProps, 'trigger'>> {
+  void kind;
+  return EMPTY_TOOLTIP_TRIGGER_PROPS;
+}
+
+/**
+ * 为 Ant Design Tooltip 生成自适应 `trigger`（每次读取当前环境，供非订阅场景 / 单测）。
+ * - `informational`：触摸或移动场景使用 `hover` + `click`
+ * - `interactive`：保持默认（仅 hover）
  */
 export function getAdaptiveTooltipProps(
   kind: AdaptiveTooltipKind = 'informational',
 ): Partial<Pick<TooltipProps, 'trigger'>> {
   if (typeof window === 'undefined') {
-    return {};
+    return EMPTY_TOOLTIP_TRIGGER_PROPS;
   }
   if (kind === 'interactive') {
-    return {};
+    return EMPTY_TOOLTIP_TRIGGER_PROPS;
   }
-  if (shouldUseInformationalTooltipClickTrigger()) {
-    return { trigger: ['hover', 'click'] };
-  }
-  return {};
+  return shouldUseInformationalTooltipClickTrigger()
+    ? INFORMATIONAL_TOOLTIP_TRIGGER_PROPS
+    : EMPTY_TOOLTIP_TRIGGER_PROPS;
 }

--- a/src/Utils/adaptiveTooltip.ts
+++ b/src/Utils/adaptiveTooltip.ts
@@ -1,0 +1,45 @@
+import type { TooltipProps } from 'antd';
+import { isMobileDevice } from './env';
+
+export type AdaptiveTooltipKind = 'informational' | 'interactive';
+
+function isTouchEnvironment(): boolean {
+  if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+    return false;
+  }
+  return (
+    'ontouchstart' in window ||
+    (typeof navigator.maxTouchPoints === 'number' &&
+      navigator.maxTouchPoints > 0)
+  );
+}
+
+/**
+ * 信息类 Tooltip 是否在触摸 / 窄屏移动场景下启用「点击展开」。
+ * - `isMobileDevice()`：UA 或 触摸 + 小屏
+ * - `isTouchEnvironment()`：存在触摸能力（含触屏笔记本）
+ */
+export function shouldUseInformationalTooltipClickTrigger(): boolean {
+  if (typeof window === 'undefined') return false;
+  return isMobileDevice() || isTouchEnvironment();
+}
+
+/**
+ * 为 Ant Design Tooltip 生成自适应 `trigger`。
+ * - `informational`：触摸或移动场景使用 `hover` + `click`，便于移动端查看说明；点击空白处由 rc-tooltip 关闭
+ * - `interactive`：保持默认（仅 hover），避免与按钮/链接等主点击行为抢第一下触摸
+ */
+export function getAdaptiveTooltipProps(
+  kind: AdaptiveTooltipKind = 'informational',
+): Partial<Pick<TooltipProps, 'trigger'>> {
+  if (typeof window === 'undefined') {
+    return {};
+  }
+  if (kind === 'interactive') {
+    return {};
+  }
+  if (shouldUseInformationalTooltipClickTrigger()) {
+    return { trigger: ['hover', 'click'] };
+  }
+  return {};
+}

--- a/src/Workspace/Browser/index.tsx
+++ b/src/Workspace/Browser/index.tsx
@@ -13,6 +13,7 @@ import {
 import classNames from 'clsx';
 import React, { useContext, useMemo, useState } from 'react';
 import { ActionIconBox } from '../../Components/ActionIconBox';
+import { useAdaptiveTooltipProps } from '../../Hooks/useAdaptiveTooltipProps';
 import { I18nContext, compileTemplate } from '../../I18n';
 import { useBrowserStyle } from './style';
 
@@ -200,6 +201,7 @@ export const BrowserHeader: React.FC<BrowserHeaderProps> = ({
   onBack,
 }) => {
   const { prefixCls, wrapSSR, hashId } = useBrowserContext();
+  const headerTooltipProps = useAdaptiveTooltipProps('informational');
 
   return wrapSSR(
     <div className={classNames(`${prefixCls}-header-left`, hashId)}>
@@ -217,7 +219,11 @@ export const BrowserHeader: React.FC<BrowserHeaderProps> = ({
           onClick={onBack}
         />
       )}
-      <Tooltip title={activeLabel} mouseEnterDelay={0.5}>
+      <Tooltip
+        title={activeLabel}
+        mouseEnterDelay={0.5}
+        {...headerTooltipProps}
+      >
         <div className={classNames(`${prefixCls}-header-title`, hashId)}>
           {activeLabel}
         </div>
@@ -369,6 +375,7 @@ const Browser: React.FC<BrowserProps> = ({
   const { locale } = useContext(I18nContext);
 
   const { prefixCls, wrapSSR, hashId } = useBrowserContext();
+  const suggestionLabelTooltipProps = useAdaptiveTooltipProps('informational');
 
   const { items: results, loading } = useMemo(() => {
     if (!activeSuggestion) {
@@ -430,7 +437,11 @@ const Browser: React.FC<BrowserProps> = ({
                   >
                     {suggestionIcon || <Search />}
                   </div>
-                  <Tooltip title={item.label} mouseEnterDelay={0.5}>
+                  <Tooltip
+                    title={item.label}
+                    mouseEnterDelay={0.5}
+                    {...suggestionLabelTooltipProps}
+                  >
                     <div
                       className={classNames(
                         `${prefixCls}-suggestion-text`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -703,6 +703,7 @@ export {
 export { useThrottleFn } from './Hooks/useThrottleFn';
 
 export {
+  adaptiveTooltipEnvironment,
   getAdaptiveTooltipProps,
   shouldUseInformationalTooltipClickTrigger,
   type AdaptiveTooltipKind,

--- a/src/index.ts
+++ b/src/index.ts
@@ -688,6 +688,7 @@ export {
 } from './Components/VisualList';
 
 // ─── Hooks ───────────────────────────────────────────────────────────────────
+export { useAdaptiveTooltipProps } from './Hooks/useAdaptiveTooltipProps';
 export { useAutoScroll } from './Hooks/useAutoScroll';
 export { useLanguage } from './Hooks/useLanguage';
 export { useRefFunction } from './Hooks/useRefFunction';
@@ -699,6 +700,12 @@ export {
   type GenerateStyle,
 } from './Hooks/useStyle';
 export { useThrottleFn } from './Hooks/useThrottleFn';
+
+export {
+  getAdaptiveTooltipProps,
+  shouldUseInformationalTooltipClickTrigger,
+  type AdaptiveTooltipKind,
+} from './Utils/adaptiveTooltip';
 
 // ─── 国际化 ──────────────────────────────────────────────────────────────────
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -691,6 +691,7 @@ export {
 export { useAdaptiveTooltipProps } from './Hooks/useAdaptiveTooltipProps';
 export { useAutoScroll } from './Hooks/useAutoScroll';
 export { useLanguage } from './Hooks/useLanguage';
+export { useNativeTitleTooltipFallback } from './Hooks/useNativeTitleTooltipFallback';
 export { useRefFunction } from './Hooks/useRefFunction';
 export {
   resetComponent,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Touch/mobile adaptive tooltips, attachment mobile Popover, RefinePromptButton single-layer tooltip, ActionIconBox native `title` fallback, shared environment subscription, and test fixes.

## Recent refactor (addresses review / Bugbot)

- **`useAdaptiveTooltipProps` & `useNativeTitleTooltipFallback`** now use **`useSyncExternalStore`** with **`subscribeAdaptiveTooltipEnvironment`**: at most **one** `resize` + `orientationchange` pair per page.
- **Stable frozen** `EMPTY_TOOLTIP_TRIGGER_PROPS` / `INFORMATIONAL_TOOLTIP_TRIGGER_PROPS` so `Object.is` can bail out when the environment has not changed.
- **Resize handler** compares `lastBroadcastActive` and only notifies subscribers when the boolean context **actually** changes.
- **`adaptiveTooltipEnvironment.isInformationalClickContext()`** is the single implementation entry for both exports and snapshots so **`vi.spyOn` works** (fixes ESM lexical binding issue with spying only the wrapper export).
- Replaced **`useLayoutEffect`** with **`useSyncExternalStore`** (no SSR `useLayoutEffect` warning for these hooks).
- **`getAdaptiveTooltipProps`** still recomputes for one-off / test use and returns the same stable objects.

## Tests

- ActionIconBox: spy `adaptiveTooltipEnvironment.isInformationalClickContext`.
- `MarkdownInputField.onSend` mock dedupe, adaptive tooltip unit tests.

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2101c13e-6dff-47ad-a2c7-9bf69d416e3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2101c13e-6dff-47ad-a2c7-9bf69d416e3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

