### PR TITLE
Cursor/fix file upload click

### DIFF
--- a/src/MarkdownInputField/hooks/useFileUploadManager.ts
+++ b/src/MarkdownInputField/hooks/useFileUploadManager.ts
@@ -1,4 +1,4 @@
-﻿import { useContext } from 'react';
+﻿import { useContext, useEffect, useRef } from 'react';
 import { useRefFunction } from '../../Hooks/useRefFunction';
 import { I18nContext } from '../../I18n';
 import type { AttachmentButtonProps } from '../AttachmentButton';
@@ -81,6 +81,19 @@ export const useFileUploadManager = ({
   onFileMapChange,
 }: FileUploadManagerProps): FileUploadManagerReturn => {
   const { locale } = useContext(I18nContext);
+
+  /** 复用单个隐藏 file input，避免反复创建/卸载导致部分环境下选择器异常 */
+  const hiddenFileInputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    return () => {
+      const el = hiddenFileInputRef.current;
+      if (el?.parentNode) {
+        el.parentNode.removeChild(el);
+      }
+      hiddenFileInputRef.current = null;
+    };
+  }, []);
 
   const fileList = Array.from(fileMap?.values() || []);
   const uploadingCount = fileList.filter(
@@ -176,33 +189,19 @@ export const useFileUploadManager = ({
     }
 
     const accept = getAcceptValue(forGallery || false);
-    const input = document.createElement('input');
-    input.id = 'uploadImage' + '_' + Math.random();
-    input.type = 'file';
+
+    let input = hiddenFileInputRef.current;
+    if (!input) {
+      input = document.createElement('input');
+      input.type = 'file';
+      input.style.display = 'none';
+      hiddenFileInputRef.current = input;
+      document.body.appendChild(input);
+    }
+
     input.accept = accept;
     input.multiple = attachment?.allowMultiple ?? true;
-    input.style.display = 'none';
-
-    let detached = false;
-    const focusHandlerRef: { current: (() => void) | null } = {
-      current: null,
-    };
-    const detachInput = () => {
-      if (detached) {
-        return;
-      }
-      detached = true;
-      if (focusHandlerRef.current) {
-        window.removeEventListener('focus', focusHandlerRef.current);
-      }
-      if (input.parentNode) {
-        input.parentNode.removeChild(input);
-      }
-    };
-    focusHandlerRef.current = () => {
-      // 晚一拍再卸载，避免个别环境下 focus 早于 change 导致选中的文件丢失
-      window.setTimeout(detachInput, 300);
-    };
+    input.value = '';
 
     input.onchange = async (e: Event) => {
       if (input.dataset.readonly) {
@@ -230,20 +229,13 @@ export const useFileUploadManager = ({
       } finally {
         input.value = '';
         delete input.dataset.readonly;
-        detachInput();
       }
     };
 
     if (input.dataset.readonly) {
       return;
     }
-    document.body.appendChild(input);
-    if (focusHandlerRef.current) {
-      window.addEventListener('focus', focusHandlerRef.current);
-    }
     input.click();
-    // 禁止在 click() 之后同步 remove：同一任务内移除会导致部分浏览器无法弹出选择器或无法触发 change。
-    // 选择在 onchange 的 finally 与窗口 focus（用户取消选择）时 detachInput。
   });
 
   /**

--- a/src/MarkdownInputField/hooks/useFileUploadManager.ts
+++ b/src/MarkdownInputField/hooks/useFileUploadManager.ts
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+﻿import { useContext } from 'react';
 import { useRefFunction } from '../../Hooks/useRefFunction';
 import { I18nContext } from '../../I18n';
 import type { AttachmentButtonProps } from '../AttachmentButton';
@@ -183,6 +183,27 @@ export const useFileUploadManager = ({
     input.multiple = attachment?.allowMultiple ?? true;
     input.style.display = 'none';
 
+    let detached = false;
+    const focusHandlerRef: { current: (() => void) | null } = {
+      current: null,
+    };
+    const detachInput = () => {
+      if (detached) {
+        return;
+      }
+      detached = true;
+      if (focusHandlerRef.current) {
+        window.removeEventListener('focus', focusHandlerRef.current);
+      }
+      if (input.parentNode) {
+        input.parentNode.removeChild(input);
+      }
+    };
+    focusHandlerRef.current = () => {
+      // 晚一拍再卸载，避免个别环境下 focus 早于 change 导致选中的文件丢失
+      window.setTimeout(detachInput, 300);
+    };
+
     input.onchange = async (e: Event) => {
       if (input.dataset.readonly) {
         return;
@@ -209,6 +230,7 @@ export const useFileUploadManager = ({
       } finally {
         input.value = '';
         delete input.dataset.readonly;
+        detachInput();
       }
     };
 
@@ -216,8 +238,12 @@ export const useFileUploadManager = ({
       return;
     }
     document.body.appendChild(input);
+    if (focusHandlerRef.current) {
+      window.addEventListener('focus', focusHandlerRef.current);
+    }
     input.click();
-    input.remove();
+    // 禁止在 click() 之后同步 remove：同一任务内移除会导致部分浏览器无法弹出选择器或无法触发 change。
+    // 选择在 onchange 的 finally 与窗口 focus（用户取消选择）时 detachInput。
   });
 
   /**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-side change that only adjusts how the browser `file` input element is created/managed during uploads. Main risk is potential edge cases around stale `onchange` handlers or DOM cleanup across repeated uploads.
> 
> **Overview**
> Fixes flaky file-picker behavior in `useFileUploadManager` by **reusing a single hidden `<input type="file">`** instead of creating/removing a new element on every `uploadImage()` call.
> 
> The hook now keeps the input in a `ref`, resets `input.value` before/after selection to allow re-selecting the same file, and removes the element on unmount via `useEffect` cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60bdd9a254577a41d18156451c5131c7698fb23d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->