### PR TITLE
Cursor/fix file upload click (#533)

### DIFF
--- a/src/MarkdownInputField/hooks/useFileUploadManager.ts
+++ b/src/MarkdownInputField/hooks/useFileUploadManager.ts
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+﻿import { useContext, useEffect, useRef } from 'react';
 import { useRefFunction } from '../../Hooks/useRefFunction';
 import { I18nContext } from '../../I18n';
 import type { AttachmentButtonProps } from '../AttachmentButton';
@@ -81,6 +81,19 @@ export const useFileUploadManager = ({
   onFileMapChange,
 }: FileUploadManagerProps): FileUploadManagerReturn => {
   const { locale } = useContext(I18nContext);
+
+  /** 复用单个隐藏 file input，避免反复创建/卸载导致部分环境下选择器异常 */
+  const hiddenFileInputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    return () => {
+      const el = hiddenFileInputRef.current;
+      if (el?.parentNode) {
+        el.parentNode.removeChild(el);
+      }
+      hiddenFileInputRef.current = null;
+    };
+  }, []);
 
   const fileList = Array.from(fileMap?.values() || []);
   const uploadingCount = fileList.filter(
@@ -176,12 +189,19 @@ export const useFileUploadManager = ({
     }
 
     const accept = getAcceptValue(forGallery || false);
-    const input = document.createElement('input');
-    input.id = 'uploadImage' + '_' + Math.random();
-    input.type = 'file';
+
+    let input = hiddenFileInputRef.current;
+    if (!input) {
+      input = document.createElement('input');
+      input.type = 'file';
+      input.style.display = 'none';
+      hiddenFileInputRef.current = input;
+      document.body.appendChild(input);
+    }
+
     input.accept = accept;
     input.multiple = attachment?.allowMultiple ?? true;
-    input.style.display = 'none';
+    input.value = '';
 
     input.onchange = async (e: Event) => {
       if (input.dataset.readonly) {
@@ -215,9 +235,7 @@ export const useFileUploadManager = ({
     if (input.dataset.readonly) {
       return;
     }
-    document.body.appendChild(input);
     input.click();
-    input.remove();
   });
 
   /**


### PR DESCRIPTION
* fix(MarkdownInputField): 修复文件上传点击失效

不要在 input.click() 之后同步 remove()，否则部分浏览器无法弹出
文件选择器或不触发 change。改为在 change 的 finally 与 window
focus（取消选择）时统一 detachInput，并通过标记保证只卸载一次。



* refactor(MarkdownInputField): 复用隐藏 file input 并靠清空 value 复位

单例 ref 挂住 input，每次打开前更新 accept/multiple 并清空 value； onchange 结束后同样清空；组件卸载时再从 body 移除。移除 focus
卸载逻辑。



---------

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the file-picker trigger mechanics by reusing a singleton hidden `<input type="file">` and altering its lifecycle; this can affect cross-browser upload selection behavior and edge cases like repeated clicks/cancel flows.
> 
> **Overview**
> Fixes intermittent file-upload picker failures in `useFileUploadManager` by **stopping the immediate detach/removal of the file input after `click()`**.
> 
> The hook now **reuses a single hidden `<input type="file">`** stored in a ref, resets it via `value = ''` before/after selection, and only removes it from `document.body` on unmount via `useEffect` cleanup (while keeping the existing `dataset.readonly` guard to prevent concurrent triggers).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a80e4bbd1110cb1e16c681de47b01cc661a9dd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->