### PR TITLE
Cursor/doc cards testids

### DIFF
--- a/src/Plugins/chart/AreaChart/index.tsx
+++ b/src/Plugins/chart/AreaChart/index.tsx
@@ -1,4 +1,4 @@
-import { ConfigProvider } from 'antd';
+﻿import { ConfigProvider } from 'antd';
 import {
   ChartData,
   Chart as ChartJS,
@@ -21,7 +21,7 @@ import {
   useChartDataFilter,
   useChartStatistics,
   useChartTheme,
-  useDetectTheme,
+  useResolvedChartTheme,
   useResponsiveSize,
 } from '../hooks';
 import { StatisticConfigType } from '../hooks/useChartStatistic';
@@ -267,9 +267,7 @@ const AreaChart: React.FC<AreaChartProps> = ({
     filteredDataByFilterLabel,
   } = useChartDataFilter(data);
 
-  // 主题颜色
-  const detectedTheme = useDetectTheme();
-  const resolvedTheme = theme ?? detectedTheme;
+  const { resolvedTheme, autoDetectTheme } = useResolvedChartTheme(theme);
   const { axisTextColor, gridColor, isLight } = useChartTheme(resolvedTheme);
 
   // 从数据中提取唯一的类型
@@ -478,6 +476,7 @@ const AreaChart: React.FC<AreaChartProps> = ({
       baseClassName={baseClassName}
       className={rootClassName}
       theme={resolvedTheme}
+      autoDetectTheme={autoDetectTheme}
       isMobile={isMobile}
       variant={variant}
       style={rootStyle}

--- a/src/Plugins/chart/BarChart/index.tsx
+++ b/src/Plugins/chart/BarChart/index.tsx
@@ -1,4 +1,4 @@
-import { ConfigProvider } from 'antd';
+﻿import { ConfigProvider } from 'antd';
 import {
   BarElement,
   CategoryScale,
@@ -23,7 +23,7 @@ import {
   downloadChart,
 } from '../components';
 import { defaultColorList } from '../const';
-import { useChartTheme, useDetectTheme } from '../hooks';
+import { useChartTheme, useResolvedChartTheme } from '../hooks';
 import { StatisticConfigType } from '../hooks/useChartStatistic';
 import type { ChartClassNames, ChartStyles } from '../types/classNames';
 import {
@@ -631,8 +631,7 @@ const BarChart: React.FC<BarChartProps> = ({
     }));
   }, [filterLabels]);
 
-  const detectedTheme = useDetectTheme();
-  const resolvedTheme = theme ?? detectedTheme;
+  const { resolvedTheme, autoDetectTheme } = useResolvedChartTheme(theme);
 
   // 使用 useChartTheme hook 获取主题相关颜色
   const { axisTextColor, gridColor, isLight } = useChartTheme(resolvedTheme);
@@ -1015,6 +1014,7 @@ const BarChart: React.FC<BarChartProps> = ({
       baseClassName={baseClassName}
       className={rootClassName}
       theme={resolvedTheme}
+      autoDetectTheme={autoDetectTheme}
       isMobile={isMobile}
       variant={variant}
       style={rootStyle}

--- a/src/Plugins/chart/BoxPlotChart/index.tsx
+++ b/src/Plugins/chart/BoxPlotChart/index.tsx
@@ -1,4 +1,4 @@
-import {
+﻿import {
   BoxAndWiskers,
   BoxPlotController,
 } from '@sgratzl/chartjs-chart-boxplot';
@@ -23,7 +23,7 @@ import {
   downloadChart,
 } from '../components';
 import { defaultColorList } from '../const';
-import { StatisticConfigType, useDetectTheme } from '../hooks';
+import { StatisticConfigType, useResolvedChartTheme } from '../hooks';
 import type { ChartClassNames, ChartStyles } from '../types/classNames';
 import { hexToRgba, resolveCssVariable } from '../utils';
 import { useStyle } from './style';
@@ -382,8 +382,7 @@ const BoxPlotChart: React.FC<BoxPlotChartProps> = ({
     return { labels, datasets };
   }, [filteredData, types, labels, color, showOutliers]);
 
-  const detectedTheme = useDetectTheme();
-  const resolvedTheme = theme ?? detectedTheme;
+  const { resolvedTheme, autoDetectTheme } = useResolvedChartTheme(theme);
   const isLight = resolvedTheme === 'light';
   const axisTextColor = isLight
     ? 'rgba(0, 25, 61, 0.3255)'
@@ -503,6 +502,7 @@ const BoxPlotChart: React.FC<BoxPlotChartProps> = ({
       <ChartContainer
         baseClassName={classNames(`${prefixCls}-container`, hashId)}
         theme={resolvedTheme}
+        autoDetectTheme={autoDetectTheme}
         className={classNames(classNamesProp?.root, className)}
         isMobile={isMobile}
         variant={props.variant}
@@ -541,6 +541,7 @@ const BoxPlotChart: React.FC<BoxPlotChartProps> = ({
     <ChartContainer
       baseClassName={classNames(`${prefixCls}-container`, hashId)}
       theme={resolvedTheme}
+      autoDetectTheme={autoDetectTheme}
       className={classNames(classNamesProp?.root, className)}
       isMobile={isMobile}
       variant={props.variant}

--- a/src/Plugins/chart/DocCards/DocCards.tsx
+++ b/src/Plugins/chart/DocCards/DocCards.tsx
@@ -1,4 +1,4 @@
-import { ConfigProvider } from 'antd';
+﻿import { ConfigProvider } from 'antd';
 import classNames from 'clsx';
 import React, { memo, useContext, useMemo } from 'react';
 import { I18nContext } from '../../../I18n';
@@ -100,14 +100,23 @@ const DocCardsComponent: React.FC<DocCardsProps> = ({
   const headerNode = useMemo(() => {
     if (!title && !toolbar) return null;
     return (
-      <div className={classNames(`${prefixCls}-header`, hashId)}>
+      <div
+        className={classNames(`${prefixCls}-header`, hashId)}
+        data-testid="doc-cards-header"
+      >
         {title ? (
-          <div className={classNames(`${prefixCls}-title`, hashId)}>
+          <div
+            className={classNames(`${prefixCls}-title`, hashId)}
+            data-testid="doc-cards-title"
+          >
             {title}
           </div>
         ) : null}
         {toolbar ? (
-          <div className={classNames(`${prefixCls}-toolbar`, hashId)}>
+          <div
+            className={classNames(`${prefixCls}-toolbar`, hashId)}
+            data-testid="doc-cards-toolbar"
+          >
             {toolbar}
           </div>
         ) : null}
@@ -121,9 +130,13 @@ const DocCardsComponent: React.FC<DocCardsProps> = ({
         className={classNames(prefixCls, hashId, className)}
         style={style}
         contentEditable={false}
+        data-testid="doc-cards"
       >
         {headerNode}
-        <div className={classNames(`${prefixCls}-empty`, hashId)}>
+        <div
+          className={classNames(`${prefixCls}-empty`, hashId)}
+          data-testid="doc-cards-empty"
+        >
           {i18n?.locale?.docCards || '卡片列表'}
         </div>
       </div>,
@@ -135,12 +148,14 @@ const DocCardsComponent: React.FC<DocCardsProps> = ({
       className={classNames(prefixCls, hashId, className)}
       style={style}
       contentEditable={false}
+      data-testid="doc-cards"
     >
       {headerNode}
       <div
         className={classNames(`${prefixCls}-grid`, hashId)}
         style={gridStyle}
         role="list"
+        data-testid="doc-cards-grid"
       >
         {data.map((row, rowIndex) => {
           const titleText = toDisplayText(row[fields.title]).trim();
@@ -161,9 +176,13 @@ const DocCardsComponent: React.FC<DocCardsProps> = ({
               key={cardKey}
               className={classNames(`${prefixCls}-item`, hashId)}
               role="listitem"
+              data-testid={`doc-cards-item-${rowIndex}`}
             >
               {titleText ? (
-                <h3 className={classNames(`${prefixCls}-item-title`, hashId)}>
+                <h3
+                  className={classNames(`${prefixCls}-item-title`, hashId)}
+                  data-testid={`doc-cards-item-${rowIndex}-title`}
+                >
                   {titleText}
                 </h3>
               ) : null}
@@ -171,6 +190,7 @@ const DocCardsComponent: React.FC<DocCardsProps> = ({
                 <div
                   className={classNames(`${prefixCls}-item-url`, hashId)}
                   title={rawUrl}
+                  data-testid={`doc-cards-item-${rowIndex}-url`}
                 >
                   {safeLink ? (
                     // 仅外部链接（http(s)/mailto/tel）开新 tab；站内绝对路径、相对路径、
@@ -180,6 +200,7 @@ const DocCardsComponent: React.FC<DocCardsProps> = ({
                         `${prefixCls}-item-link`,
                         hashId,
                       )}
+                      data-testid={`doc-cards-item-${rowIndex}-link`}
                       href={rawUrl}
                       {...(isExternalLink(rawUrl)
                         ? {
@@ -196,7 +217,10 @@ const DocCardsComponent: React.FC<DocCardsProps> = ({
                 </div>
               ) : null}
               {descText ? (
-                <p className={classNames(`${prefixCls}-item-desc`, hashId)}>
+                <p
+                  className={classNames(`${prefixCls}-item-desc`, hashId)}
+                  data-testid={`doc-cards-item-${rowIndex}-desc`}
+                >
                   {descText}
                 </p>
               ) : null}
@@ -205,13 +229,15 @@ const DocCardsComponent: React.FC<DocCardsProps> = ({
                   className={classNames(`${prefixCls}-item-tags`, hashId)}
                   role="list"
                   aria-label={i18n?.locale?.docCardsTags || '标签列表'}
+                  data-testid={`doc-cards-item-${rowIndex}-tags`}
                 >
-                  {tags.map((tag) => (
+                  {tags.map((tag, tagIndex) => (
                     <span
                       key={tag}
                       className={classNames(`${prefixCls}-tag`, hashId)}
                       role="listitem"
                       title={tag}
+                      data-testid={`doc-cards-item-${rowIndex}-tag-${tagIndex}`}
                     >
                       {tag}
                     </span>

--- a/src/Plugins/chart/DonutChart/index.tsx
+++ b/src/Plugins/chart/DonutChart/index.tsx
@@ -1,4 +1,4 @@
-import { ConfigProvider } from 'antd';
+﻿import { ConfigProvider } from 'antd';
 import {
   ArcElement,
   Chart as ChartJS,
@@ -21,7 +21,7 @@ import {
 } from '../components';
 import { defaultColorList } from '../const';
 import { isWindowDefined } from '../env';
-import { useChartTheme, useDetectTheme } from '../hooks';
+import { useChartTheme, useResolvedChartTheme } from '../hooks';
 import { resolveCssVariable } from '../utils';
 import {
   SINGLE_MODE_DESKTOP_CUTOUT,
@@ -129,9 +129,7 @@ const DonutChart: React.FC<DonutChartProps> = ({
   const { isMobile, windowWidth } = useMobile();
   const locale = useLocale();
 
-  // 使用 useChartTheme hook 获取主题相关颜色
-  const detectedTheme = useDetectTheme();
-  const resolvedTheme = theme ?? detectedTheme;
+  const { resolvedTheme, autoDetectTheme } = useResolvedChartTheme(theme);
   const { isLight } = useChartTheme(resolvedTheme);
 
   // 默认配置：当 configs 不传时，使用默认配置，showLegend 默认为 true
@@ -317,6 +315,7 @@ const DonutChart: React.FC<DonutChartProps> = ({
       className={classNames(classNamesProp?.root, className)}
       variant={props.variant}
       theme={resolvedTheme}
+      autoDetectTheme={autoDetectTheme}
       isMobile={isMobile}
       style={{
         ['--donut-item-min-width' as any]: `${dimensions.width}px`,
@@ -329,6 +328,7 @@ const DonutChart: React.FC<DonutChartProps> = ({
           baseClassName={`${baseClassName}-toolbar-wrapper`}
           variant="borderless"
           theme={resolvedTheme}
+          autoDetectTheme={autoDetectTheme}
           isMobile={isMobile}
         >
           {title && (
@@ -401,6 +401,7 @@ const DonutChart: React.FC<DonutChartProps> = ({
         baseClassName={`${baseClassName}-content`}
         variant="borderless"
         theme={resolvedTheme}
+        autoDetectTheme={autoDetectTheme}
         isMobile={isMobile}
       >
         {renderConfigs.map((cfg, idx) => {
@@ -676,6 +677,7 @@ const DonutChart: React.FC<DonutChartProps> = ({
               baseClassName={`${baseClassName}-chart-wrapper`}
               variant="borderless"
               theme={resolvedTheme}
+              autoDetectTheme={autoDetectTheme}
               isMobile={isMobile}
             >
               {isSingleValueMode ? (
@@ -683,6 +685,7 @@ const DonutChart: React.FC<DonutChartProps> = ({
                   baseClassName={`${baseClassName}-single`}
                   variant="borderless"
                   theme={resolvedTheme}
+                  autoDetectTheme={autoDetectTheme}
                   isMobile={isMobile}
                   style={{
                     ['--donut-chart-height' as any]: `${dimensions.height}px`,
@@ -729,6 +732,7 @@ const DonutChart: React.FC<DonutChartProps> = ({
                   baseClassName={`${baseClassName}-row`}
                   variant="borderless"
                   theme={resolvedTheme}
+                  autoDetectTheme={autoDetectTheme}
                   isMobile={isMobile}
                   style={{
                     ...(isMobile
@@ -740,6 +744,7 @@ const DonutChart: React.FC<DonutChartProps> = ({
                     baseClassName={`${baseClassName}-chart`}
                     variant="borderless"
                     theme={resolvedTheme}
+                    autoDetectTheme={autoDetectTheme}
                     isMobile={isMobile}
                     style={{
                       ['--donut-chart-width' as any]: `${dimensions.chartWidth}px`,

--- a/src/Plugins/chart/FunnelChart/index.tsx
+++ b/src/Plugins/chart/FunnelChart/index.tsx
@@ -1,4 +1,4 @@
-import { ConfigProvider } from 'antd';
+﻿import { ConfigProvider } from 'antd';
 import type { LegendItem, PointStyle } from 'chart.js';
 import {
   BarElement,
@@ -22,7 +22,7 @@ import {
   downloadChart,
 } from '../components';
 import { defaultColorList } from '../const';
-import { useChartTheme, useDetectTheme } from '../hooks';
+import { useChartTheme, useResolvedChartTheme } from '../hooks';
 import { StatisticConfigType } from '../hooks/useChartStatistic';
 import type { ChartClassNames, ChartStyles } from '../types/classNames';
 import {
@@ -428,9 +428,7 @@ const FunnelChart: React.FC<FunnelChartProps> = ({
     return filterLabels?.map((l) => ({ key: l, label: l }));
   }, [filterLabels]);
 
-  // 使用 useChartTheme hook 获取主题相关颜色
-  const detectedTheme = useDetectTheme();
-  const resolvedTheme = theme ?? detectedTheme;
+  const { resolvedTheme, autoDetectTheme } = useResolvedChartTheme(theme);
   const { axisTextColor, isLight } = useChartTheme(resolvedTheme);
 
   const options: ChartOptions<'bar'> = {
@@ -754,6 +752,7 @@ const FunnelChart: React.FC<FunnelChartProps> = ({
       baseClassName={baseClassName}
       className={classNames(classNamesObj?.root, className, containerClassName)}
       theme={resolvedTheme}
+      autoDetectTheme={autoDetectTheme}
       isMobile={isMobile}
       variant={props.variant}
       style={{

--- a/src/Plugins/chart/HistogramChart/index.tsx
+++ b/src/Plugins/chart/HistogramChart/index.tsx
@@ -1,4 +1,4 @@
-import { ConfigProvider } from 'antd';
+﻿import { ConfigProvider } from 'antd';
 import {
   BarElement,
   CategoryScale,
@@ -21,7 +21,7 @@ import {
   downloadChart,
 } from '../components';
 import { defaultColorList } from '../const';
-import { StatisticConfigType, useDetectTheme } from '../hooks';
+import { StatisticConfigType, useResolvedChartTheme } from '../hooks';
 import type { ChartClassNames, ChartStyles } from '../types/classNames';
 import { hexToRgba, resolveCssVariable } from '../utils';
 import { useStyle } from './style';
@@ -454,8 +454,7 @@ const HistogramChart: React.FC<HistogramChartProps> = ({
     };
   }, [histogramData, types, binning, color, stacked]);
 
-  const detectedTheme = useDetectTheme();
-  const resolvedTheme = theme ?? detectedTheme;
+  const { resolvedTheme, autoDetectTheme } = useResolvedChartTheme(theme);
   const isLight = resolvedTheme === 'light';
   const axisTextColor = isLight
     ? 'rgba(0, 25, 61, 0.3255)'
@@ -567,6 +566,7 @@ const HistogramChart: React.FC<HistogramChartProps> = ({
       <ChartContainer
         baseClassName={classNames(`${prefixCls}-container`, hashId)}
         theme={resolvedTheme}
+        autoDetectTheme={autoDetectTheme}
         className={classNames(classNamesProp?.root, className)}
         isMobile={isMobile}
         variant={props.variant}
@@ -605,6 +605,7 @@ const HistogramChart: React.FC<HistogramChartProps> = ({
     <ChartContainer
       baseClassName={classNames(`${prefixCls}-container`, hashId)}
       theme={resolvedTheme}
+      autoDetectTheme={autoDetectTheme}
       className={classNames(classNamesProp?.root, className)}
       isMobile={isMobile}
       variant={props.variant}

--- a/src/Plugins/chart/LineChart/index.tsx
+++ b/src/Plugins/chart/LineChart/index.tsx
@@ -1,4 +1,4 @@
-import { ConfigProvider } from 'antd';
+﻿import { ConfigProvider } from 'antd';
 import { ChartData, Chart as ChartJS, ChartOptions } from 'chart.js';
 import classNames from 'clsx';
 import React, { useContext, useLayoutEffect, useMemo, useRef } from 'react';
@@ -16,7 +16,7 @@ import {
   useChartDataFilter,
   useChartStatistics,
   useChartTheme,
-  useDetectTheme,
+  useResolvedChartTheme,
   useResponsiveSize,
 } from '../hooks';
 import { StatisticConfigType } from '../hooks/useChartStatistic';
@@ -154,9 +154,7 @@ const LineChart: React.FC<LineChartProps> = ({
     filteredDataByFilterLabel,
   } = useChartDataFilter(data);
 
-  // 主题颜色
-  const detectedTheme = useDetectTheme();
-  const resolvedTheme = theme ?? detectedTheme;
+  const { resolvedTheme, autoDetectTheme } = useResolvedChartTheme(theme);
   const { axisTextColor, gridColor, isLight } = useChartTheme(resolvedTheme);
 
   // 从数据中提取唯一的类型
@@ -354,6 +352,7 @@ const LineChart: React.FC<LineChartProps> = ({
       baseClassName={baseClassName}
       className={rootClassName}
       theme={resolvedTheme}
+      autoDetectTheme={autoDetectTheme}
       isMobile={isMobile}
       variant={props.variant}
       style={rootStyle}

--- a/src/Plugins/chart/RadarChart/index.tsx
+++ b/src/Plugins/chart/RadarChart/index.tsx
@@ -22,7 +22,7 @@ import {
   downloadChart,
 } from '../components';
 import { defaultColorList } from '../const';
-import { useChartTheme, useDetectTheme } from '../hooks';
+import { useChartTheme, useResolvedChartTheme } from '../hooks';
 import { StatisticConfigType } from '../hooks/useChartStatistic';
 import type { ChartClassNames, ChartStyles } from '../types/classNames';
 import { hexToRgba, resolveCssVariable } from '../utils';
@@ -124,9 +124,7 @@ const RadarChart: React.FC<RadarChartProps> = ({
   const prefixCls = getPrefixCls('radar-chart');
   const { wrapSSR, hashId } = useStyle(prefixCls);
 
-  // 主题颜色 - 必须在所有条件返回之前调用
-  const detectedTheme = useDetectTheme();
-  const resolvedTheme = theme ?? detectedTheme;
+  const { resolvedTheme, autoDetectTheme } = useResolvedChartTheme(theme);
   const { axisTextColor, gridColor, isLight } = useChartTheme(resolvedTheme);
 
   // 处理 ChartStatistic 组件配置
@@ -253,6 +251,7 @@ const RadarChart: React.FC<RadarChartProps> = ({
       <ChartContainer
         baseClassName={classNames(`${prefixCls}-container`)}
         theme={resolvedTheme}
+        autoDetectTheme={autoDetectTheme}
         className={classNames(classNamesObj?.root, hashId, className)}
         isMobile={isMobile}
         variant={props.variant}
@@ -652,6 +651,7 @@ const RadarChart: React.FC<RadarChartProps> = ({
       <ChartContainer
         baseClassName={classNames(`${prefixCls}-container`)}
         theme={resolvedTheme}
+        autoDetectTheme={autoDetectTheme}
         className={classNames(classNamesObj?.root, hashId, className)}
         isMobile={isMobile}
         variant={props.variant}
@@ -723,6 +723,7 @@ const RadarChart: React.FC<RadarChartProps> = ({
       <ChartContainer
         baseClassName={classNames(`${prefixCls}-container`)}
         theme={resolvedTheme}
+        autoDetectTheme={autoDetectTheme}
         className={classNames(classNamesObj?.root, hashId, className)}
         isMobile={isMobile}
         variant={props.variant}

--- a/src/Plugins/chart/ScatterChart/index.tsx
+++ b/src/Plugins/chart/ScatterChart/index.tsx
@@ -22,7 +22,7 @@ import {
   downloadChart,
 } from '../components';
 import { defaultColorList } from '../const';
-import { useChartTheme, useDetectTheme } from '../hooks';
+import { useChartTheme, useResolvedChartTheme } from '../hooks';
 import { StatisticConfigType } from '../hooks/useChartStatistic';
 import type { ChartClassNames, ChartStyles } from '../types/classNames';
 import { hexToRgba, resolveCssVariable } from '../utils';
@@ -146,9 +146,7 @@ const ScatterChart: React.FC<ScatterChartProps> = ({
   const prefixCls = getPrefixCls('scatter-chart');
   const { wrapSSR, hashId } = useStyle(prefixCls);
 
-  // 主题颜色 - 必须在所有条件返回之前调用
-  const detectedTheme = useDetectTheme();
-  const resolvedTheme = theme ?? detectedTheme;
+  const { resolvedTheme, autoDetectTheme } = useResolvedChartTheme(theme);
   const { axisTextColor, gridColor, isLight } = useChartTheme(resolvedTheme);
 
   // 处理 ChartStatistic 组件配置
@@ -263,6 +261,7 @@ const ScatterChart: React.FC<ScatterChartProps> = ({
       <ChartContainer
         baseClassName={classNames(`${prefixCls}-container`)}
         theme={resolvedTheme}
+        autoDetectTheme={autoDetectTheme}
         className={classNames(classNamesObj?.root, hashId, className)}
         isMobile={isMobile}
         variant={props.variant}
@@ -785,6 +784,7 @@ const ScatterChart: React.FC<ScatterChartProps> = ({
       <ChartContainer
         baseClassName={classNames(`${prefixCls}-container`)}
         theme={resolvedTheme}
+        autoDetectTheme={autoDetectTheme}
         className={classNames(classNamesObj?.root, hashId, className)}
         isMobile={isMobile}
         variant={props.variant}
@@ -869,6 +869,7 @@ const ScatterChart: React.FC<ScatterChartProps> = ({
       <ChartContainer
         baseClassName={classNames(`${prefixCls}-container`)}
         theme={resolvedTheme}
+        autoDetectTheme={autoDetectTheme}
         isMobile={isMobile}
         className={classNames(hashId, className)}
         variant={props.variant}

--- a/src/Plugins/chart/__tests__/AreaChart.branches.test.tsx
+++ b/src/Plugins/chart/__tests__/AreaChart.branches.test.tsx
@@ -1,4 +1,4 @@
-import '@testing-library/jest-dom';
+﻿import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
@@ -85,6 +85,10 @@ vi.mock('../hooks', () => ({
     isMobile: false,
   })),
   useDetectTheme: vi.fn(() => 'light'),
+  useResolvedChartTheme: vi.fn((theme?: 'light' | 'dark') => ({
+    resolvedTheme: (theme ?? 'light') as 'light' | 'dark',
+    autoDetectTheme: theme === undefined,
+  })),
 }));
 
 vi.mock('../components', () => ({

--- a/src/Plugins/chart/__tests__/AreaChart/index.test.tsx
+++ b/src/Plugins/chart/__tests__/AreaChart/index.test.tsx
@@ -1,4 +1,4 @@
-import '@testing-library/jest-dom';
+﻿import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -108,6 +108,10 @@ vi.mock('../../hooks', () => ({
   })),
   useChartStatistics: vi.fn(() => null),
   useDetectTheme: vi.fn(() => 'light'),
+  useResolvedChartTheme: vi.fn((theme?: 'light' | 'dark') => ({
+    resolvedTheme: (theme ?? 'light') as 'light' | 'dark',
+    autoDetectTheme: theme === undefined,
+  })),
 }));
 
 // Mock utils
@@ -225,6 +229,18 @@ describe('AreaChart', () => {
 
       // 检查默认标题是否显示
       expect(screen.getByText('面积图')).toBeInTheDocument();
+    });
+
+    it('未传 theme 时使用检测结果驱动 useChartTheme', () => {
+      render(<AreaChart data={sampleData} title="t" />);
+      expect(hooks.useResolvedChartTheme).toHaveBeenCalled();
+      expect(hooks.useChartTheme).toHaveBeenCalledWith('light');
+    });
+
+    it('传入 theme=dark 时 props 覆盖检测结果', () => {
+      render(<AreaChart data={sampleData} title="t" theme="dark" />);
+      expect(hooks.useResolvedChartTheme).toHaveBeenCalledWith('dark');
+      expect(hooks.useChartTheme).toHaveBeenCalledWith('dark');
     });
   });
 

--- a/src/Plugins/chart/__tests__/DocCards.test.tsx
+++ b/src/Plugins/chart/__tests__/DocCards.test.tsx
@@ -1,4 +1,4 @@
-import '@testing-library/jest-dom';
+﻿import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { describe, expect, it } from 'vitest';
@@ -215,24 +215,41 @@ describe('DocCards 组件渲染', () => {
     expect(screen.getByText('交互式示例')).toBeInTheDocument();
     expect(screen.getByText('深链')).toBeInTheDocument();
     expect(screen.getByText('暗色模式')).toBeInTheDocument();
+
+    expect(screen.getByTestId('doc-cards')).toBeInTheDocument();
+    expect(screen.getByTestId('doc-cards-grid')).toBeInTheDocument();
+    expect(screen.getByTestId('doc-cards-header')).toBeInTheDocument();
+    expect(screen.getByTestId('doc-cards-title')).toHaveTextContent(
+      '优秀开发者文档站',
+    );
+    expect(screen.getByTestId('doc-cards-item-0')).toBeInTheDocument();
+    expect(screen.getByTestId('doc-cards-item-0-title')).toHaveTextContent(
+      'Tailwind CSS Docs',
+    );
+    expect(screen.getByTestId('doc-cards-item-0-link')).toHaveAttribute(
+      'href',
+      'https://tailwindcss.com/docs',
+    );
+    expect(screen.getByTestId('doc-cards-item-0-tags')).toBeInTheDocument();
+    expect(screen.getByTestId('doc-cards-item-0-tag-0')).toHaveTextContent(
+      '交互式示例',
+    );
   });
 
   it('缺少「亮点」列时不渲染标签区且不报错', () => {
     const cols = buildColumns(['名称', '简介']);
     const data = [{ 名称: 'A', 简介: 'description' }];
-    const { container } = render(<DocCards columns={cols} data={data} />);
+    render(<DocCards columns={cols} data={data} />);
     expect(screen.getByText('A')).toBeInTheDocument();
     expect(screen.getByText('description')).toBeInTheDocument();
-    expect(
-      container.querySelectorAll('[class*="-item-tags"]'),
-    ).toHaveLength(0);
+    expect(screen.queryByTestId('doc-cards-item-0-tags')).not.toBeInTheDocument();
   });
 
   it('无法解析主标题列时仅渲染空状态而不抛错', () => {
     const cols = buildColumns(['col1', 'col2']);
     const data = [{ col1: '1', col2: '2' }];
     render(<DocCards title="x" columns={cols} data={data} />);
-    expect(screen.getByText('卡片列表')).toBeInTheDocument();
+    expect(screen.getByTestId('doc-cards-empty')).toHaveTextContent('卡片列表');
   });
 
   it('不安全 URL 走纯文本，不渲染为可点击链接', () => {
@@ -254,17 +271,15 @@ describe('DocCards 组件渲染', () => {
   it('cardColumns 控制 grid-template-columns，超过 4 时 clamp 到 4', () => {
     const cols = buildColumns(['名称']);
     const data = [{ 名称: 'a' }];
-    const { container, rerender } = render(
+    const { rerender } = render(
       <DocCards columns={cols} data={data} cardColumns={3} />,
     );
-    const grid = container.querySelector('[class*="-grid"]') as HTMLElement;
-    expect(grid?.style.gridTemplateColumns).toBe(
-      'repeat(3, minmax(0, 1fr))',
-    );
+    const grid = screen.getByTestId('doc-cards-grid');
+    expect(grid.style.gridTemplateColumns).toBe('repeat(3, minmax(0, 1fr))');
 
     rerender(<DocCards columns={cols} data={data} cardColumns={9} />);
-    const grid2 = container.querySelector('[class*="-grid"]') as HTMLElement;
-    expect(grid2?.style.gridTemplateColumns).toBe(
+    const grid2 = screen.getByTestId('doc-cards-grid');
+    expect(grid2.style.gridTemplateColumns).toBe(
       'repeat(4, minmax(0, 1fr))',
     );
   });
@@ -282,13 +297,16 @@ describe('DocCards 组件渲染', () => {
     );
     expect(screen.getByText('标题')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'tool' })).toBeInTheDocument();
+    expect(screen.getByTestId('doc-cards-toolbar')).toContainElement(
+      screen.getByRole('button', { name: 'tool' }),
+    );
   });
 
   it('描述列纯空白时不渲染段落', () => {
     const cols = buildColumns(['名称', '简介']);
     const data = [{ 名称: 'a', 简介: '   ' }];
-    const { container } = render(<DocCards columns={cols} data={data} />);
-    expect(container.querySelectorAll('[class*="-item-desc"]')).toHaveLength(0);
+    render(<DocCards columns={cols} data={data} />);
+    expect(screen.queryByTestId('doc-cards-item-0-desc')).not.toBeInTheDocument();
   });
 
   it('外部链接打新 tab，站内路径/锚点保持原 tab', () => {
@@ -323,12 +341,10 @@ describe('DocCards 组件渲染', () => {
 
   it('标签容器 aria-label 使用「标签列表」文案而非容器名', () => {
     const data = [{ 名称: 'a', 亮点: 'tag1, tag2' }];
-    const { container } = render(
+    render(
       <DocCards columns={buildColumns(['名称', '亮点'])} data={data} />,
     );
-    const tagsContainer = container.querySelector(
-      '[class*="-item-tags"]',
-    ) as HTMLElement;
-    expect(tagsContainer?.getAttribute('aria-label')).toBe('标签列表');
+    const tagsContainer = screen.getByTestId('doc-cards-item-0-tags');
+    expect(tagsContainer.getAttribute('aria-label')).toBe('标签列表');
   });
 });

--- a/src/Plugins/chart/__tests__/LineChart/index.test.tsx
+++ b/src/Plugins/chart/__tests__/LineChart/index.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+﻿import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import {
   afterEach,
@@ -160,6 +160,10 @@ vi.mock('../../hooks', () => ({
   }),
   useChartStatistics: () => null,
   useDetectTheme: () => 'light',
+  useResolvedChartTheme: (theme?: 'light' | 'dark') => ({
+    resolvedTheme: (theme ?? 'light') as 'light' | 'dark',
+    autoDetectTheme: theme === undefined,
+  }),
 }));
 
 // Mock chart utils

--- a/src/Plugins/chart/__tests__/hooks/useResolvedChartTheme.test.tsx
+++ b/src/Plugins/chart/__tests__/hooks/useResolvedChartTheme.test.tsx
@@ -1,0 +1,25 @@
+﻿import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../hooks/useDetectTheme', () => ({
+  useDetectTheme: vi.fn(() => 'light'),
+}));
+
+import { useDetectTheme } from '../../hooks/useDetectTheme';
+import { useResolvedChartTheme } from '../../hooks/useResolvedChartTheme';
+
+describe('useResolvedChartTheme', () => {
+  it('uses explicit theme when provided', () => {
+    vi.mocked(useDetectTheme).mockReturnValue('dark');
+    const { result } = renderHook(() => useResolvedChartTheme('light'));
+    expect(result.current.resolvedTheme).toBe('light');
+    expect(result.current.autoDetectTheme).toBe(false);
+  });
+
+  it('falls back to detected theme when theme is omitted', () => {
+    vi.mocked(useDetectTheme).mockReturnValue('dark');
+    const { result } = renderHook(() => useResolvedChartTheme(undefined));
+    expect(result.current.resolvedTheme).toBe('dark');
+    expect(result.current.autoDetectTheme).toBe(true);
+  });
+});

--- a/src/Plugins/chart/hooks/index.ts
+++ b/src/Plugins/chart/hooks/index.ts
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * @fileoverview 图表插件 Hooks 统一导出文件
  * 提供图表组件相关的 React Hooks
  * @author Chart Plugin Team
@@ -14,3 +14,4 @@ export { useChartTheme } from './useChartTheme';
 export { useDetectTheme } from './useDetectTheme';
 export type { DetectThemeOptions } from './useDetectTheme';
 export { useResponsiveSize } from './useResponsiveSize';
+export { useResolvedChartTheme } from './useResolvedChartTheme';

--- a/src/Plugins/chart/hooks/useResolvedChartTheme.ts
+++ b/src/Plugins/chart/hooks/useResolvedChartTheme.ts
@@ -1,0 +1,17 @@
+import { useDetectTheme } from './useDetectTheme';
+
+/**
+ * 统一解析图表主题：`theme` 显式传入时优先；未传时自动检测页面/系统。
+ * `autoDetectTheme` 供 {@link ChartContainer} 与解析结果对齐（避免容器侧重复探测）。
+ */
+export function useResolvedChartTheme(theme: 'light' | 'dark' | undefined): {
+  resolvedTheme: 'light' | 'dark';
+  autoDetectTheme: boolean;
+} {
+  const detectedTheme = useDetectTheme();
+  const resolvedTheme: 'light' | 'dark' = theme ?? detectedTheme;
+  return {
+    resolvedTheme,
+    autoDetectTheme: theme === undefined,
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates theme resolution across many chart components and how `ChartContainer` auto-detection is driven, which could subtly affect light/dark rendering in different embedding contexts. Changes are otherwise straightforward and covered by added/updated tests.
> 
> **Overview**
> **Unifies chart theme selection** by introducing `useResolvedChartTheme` and switching chart components (e.g. `AreaChart`, `LineChart`, `BarChart`, `DonutChart`, `FunnelChart`, `HistogramChart`, `BoxPlotChart`, `RadarChart`, `ScatterChart`) to use it instead of per-component `useDetectTheme` logic.
> 
> Charts now pass `autoDetectTheme` into `ChartContainer` so the container can skip redundant theme observation when a theme is explicitly provided.
> 
> **Improves testability of `DocCards`** by adding stable `data-testid` attributes to header/grid/items/tags and updating tests accordingly, plus adds new unit tests for `useResolvedChartTheme` and theme override behavior in `AreaChart`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6304e180449908af36a252c715fb0f79b67889e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->