### PR TITLE
Cursor/task list loading status fix

### DIFF
--- a/src/TaskList/TaskList.tsx
+++ b/src/TaskList/TaskList.tsx
@@ -112,7 +112,7 @@ export const TaskList = memo(
           text =
             customCompleteText ?? locale?.['taskList.taskComplete'] ?? '任务完成';
           swapKey = `done:${items.map((i) => i.key).join(',')}`;
-        } else if (loadingItem?.title) {
+        } else if (loadingItem) {
           status = 'loading';
           const tpl =
             locale?.['taskList.taskInProgress'] || '正在进行${taskName}任务';

--- a/src/TaskList/__tests__/TaskList.branches.test.tsx
+++ b/src/TaskList/__tests__/TaskList.branches.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+﻿import { fireEvent, render, screen } from '@testing-library/react';
 import { ConfigProvider } from 'antd';
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
@@ -132,6 +132,33 @@ describe('TaskList Component', () => {
     );
 
     expect(screen.getByTestId('task-list-status-error')).toBeInTheDocument();
+  });
+
+  it('运行中时不应显示错误状态', () => {
+    const loadingWithErrorItems = [
+      {
+        key: 'task1',
+        title: '任务1',
+        content: '任务1内容',
+        status: 'error' as const,
+      },
+      {
+        key: 'task2',
+        // 注意：此 loading 任务没有 title
+        content: '任务2内容',
+        status: 'loading' as const,
+      },
+    ];
+
+    render(
+      <TestWrapper>
+        <TaskList items={loadingWithErrorItems} variant="simple" />
+      </TestWrapper>,
+    );
+
+    // 即使有错误存在，但只要有任务在运行中，就应该显示 loading 状态
+    expect(screen.getByTestId('task-list-status-loading')).toBeInTheDocument();
+    expect(screen.queryByTestId('task-list-status-error')).not.toBeInTheDocument();
   });
 
   it('应该显示加载动画', () => {

--- a/src/Workspace/File/FileComponent.tsx
+++ b/src/Workspace/File/FileComponent.tsx
@@ -1,4 +1,4 @@
-import { ConfigProvider, Empty, Image, Spin, Typography } from 'antd';
+﻿import { ConfigProvider, Empty, Image, Spin, Typography } from 'antd';
 import classNames from 'clsx';
 import React, { type FC, useContext, useEffect, useRef, useState } from 'react';
 import { useRefFunction } from '../../Hooks/useRefFunction';
@@ -53,7 +53,11 @@ export const FileComponent: FC<{
   >;
   customActions?: React.ReactNode | ((file: FileNode) => React.ReactNode);
   actionRef?: FileProps['actionRef'];
+  /**
+   * @deprecated @since 2.29.0 请使用 isLoading 代替
+   */
   loading?: FileProps['loading'];
+  isLoading?: FileProps['isLoading'];
   loadingRender?: FileProps['loadingRender'];
   emptyRender?: FileProps['emptyRender'];
   /** 搜索关键字（受控） */
@@ -78,7 +82,8 @@ export const FileComponent: FC<{
   markdownEditorProps,
   customActions,
   actionRef,
-  loading,
+  loading: loadingProp,
+  isLoading,
   loadingRender,
   emptyRender,
   keyword,
@@ -118,6 +123,8 @@ export const FileComponent: FC<{
   );
 
   const safeNodes = nodes || [];
+  // 优先使用 isLoading，向后兼容 loading
+  const loading = isLoading ?? loadingProp;
 
   const { getPrefixCls } = useContext(ConfigProvider.ConfigContext);
   const { locale } = useContext(I18nContext);

--- a/src/Workspace/File/components/FileGroup.tsx
+++ b/src/Workspace/File/components/FileGroup.tsx
@@ -1,4 +1,4 @@
-import classNames from 'clsx';
+﻿import classNames from 'clsx';
 import React, { type FC, useEffect, useRef, useState } from 'react';
 import { useRefFunction } from '../../../Hooks/useRefFunction';
 import { compileTemplate } from '../../../I18n';
@@ -166,4 +166,4 @@ const FileGroupComponent: FC<FileGroupProps> = ({
 
 FileGroupComponent.displayName = 'FileGroup';
 
-export const FileGroup = React.memo(FileGroupComponent);
+export const FileGroup = FileGroupComponent;

--- a/src/Workspace/File/components/FileItem.tsx
+++ b/src/Workspace/File/components/FileItem.tsx
@@ -1,4 +1,4 @@
-import {
+﻿import {
   Download as DownloadIcon,
   Eye as EyeIcon,
   Locate,
@@ -305,4 +305,4 @@ const FileItemComponent: FC<FileItemProps> = ({
 
 FileItemComponent.displayName = 'FileItem';
 
-export const FileItem = React.memo(FileItemComponent);
+export const FileItem = FileItemComponent;

--- a/src/Workspace/File/components/GroupHeader.tsx
+++ b/src/Workspace/File/components/GroupHeader.tsx
@@ -1,4 +1,4 @@
-import {
+﻿import {
   ChevronDown as DownIcon,
   Download as DownloadIcon,
   ChevronRight as RightIcon,
@@ -112,4 +112,4 @@ const GroupHeaderComponent: FC<GroupHeaderProps> = ({
 
 GroupHeaderComponent.displayName = 'GroupHeader';
 
-export const GroupHeader = React.memo(GroupHeaderComponent);
+export const GroupHeader = GroupHeaderComponent;

--- a/src/Workspace/File/components/SearchInput.tsx
+++ b/src/Workspace/File/components/SearchInput.tsx
@@ -1,4 +1,4 @@
-import { Search } from '@sofa-design/icons';
+﻿import { Search } from '@sofa-design/icons';
 import { Input, type InputRef } from 'antd';
 import classNames from 'clsx';
 import React, { type FC, useRef } from 'react';
@@ -46,4 +46,4 @@ const SearchInputComponent: FC<SearchInputProps> = ({
 
 SearchInputComponent.displayName = 'SearchInput';
 
-export const SearchInput = React.memo(SearchInputComponent);
+export const SearchInput = SearchInputComponent;

--- a/src/Workspace/__tests__/File/FileComponent.test.tsx
+++ b/src/Workspace/__tests__/File/FileComponent.test.tsx
@@ -1,4 +1,4 @@
-import {
+﻿import {
   act,
   fireEvent,
   render,
@@ -2613,6 +2613,55 @@ describe('FileComponent', () => {
       const showMoreBtn = screen.getByRole('button', { name: /查看更多/ });
       expect(showMoreBtn).toBeInTheDocument();
       expect(showMoreBtn.textContent).toMatch(/20/);
+    });
+  });
+
+  describe('加载状态', () => {
+    it('isLoading=true 时应显示加载状态', () => {
+      const nodes: FileNode[] = [
+        { id: 'f1', name: 'test.txt', url: 'https://example.com/test.txt' },
+      ];
+
+      const { container } = render(
+        <TestWrapper>
+          <FileComponent nodes={nodes} isLoading />
+        </TestWrapper>,
+      );
+
+      // 检查 Spin 组件的 loading 状态
+      expect(container.querySelector('.ant-spin')).toBeInTheDocument();
+      expect(container.querySelector('.ant-spin-spinning')).toBeInTheDocument();
+    });
+
+    it('isLoading 应优先于 loading 属性', () => {
+      const nodes: FileNode[] = [
+        { id: 'f1', name: 'test.txt', url: 'https://example.com/test.txt' },
+      ];
+
+      const { container } = render(
+        <TestWrapper>
+          {/* isLoading=false, loading=true，最终应不显示 loading */}
+          <FileComponent nodes={nodes} isLoading={false} loading />
+        </TestWrapper>,
+      );
+
+      // isLoading 优先级更高，设为 false 时不应显示 loading
+      expect(container.querySelector('.ant-spin-spinning')).not.toBeInTheDocument();
+    });
+
+    it('未传 isLoading 时应回退到 loading 属性', () => {
+      const nodes: FileNode[] = [
+        { id: 'f1', name: 'test.txt', url: 'https://example.com/test.txt' },
+      ];
+
+      const { container } = render(
+        <TestWrapper>
+          <FileComponent nodes={nodes} loading />
+        </TestWrapper>,
+      );
+
+      // 回退到 loading 属性
+      expect(container.querySelector('.ant-spin-spinning')).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes UI status selection logic and loading flags, and removes `React.memo` from several file-list components, which could affect rendering behavior/performance in list-heavy views. Covered by new unit tests but still touches frequently-rendered components.
> 
> **Overview**
> Fixes `TaskList` summary status so *any* `loading` item (even without a `title`) forces the top bar into `loading` instead of falling back to `error`, and adds a regression test for the loading-vs-error precedence.
> 
> Updates `FileComponent` to support a new `isLoading` prop (**preferred**) with explicit precedence over the deprecated `loading` prop, with accompanying tests.
> 
> Removes `React.memo` wrapping from `FileGroup`, `FileItem`, `GroupHeader`, and `SearchInput` exports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57fb7490c0503a84ed449b2af1ef77642dc5c7a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->