### PR TITLE
feat(Workspace): animated tab count with digit pop-in

### DIFF
--- a/src/Workspace/WorkspaceTabCountDigits.tsx
+++ b/src/Workspace/WorkspaceTabCountDigits.tsx
@@ -1,0 +1,76 @@
+import classNames from 'clsx';
+import React, { useEffect, useRef, useState } from 'react';
+
+/** 与样式中 `--workspace-tab-count-digit-stagger` 一致（ms） */
+const TAB_COUNT_DIGIT_STAGGER_MS = 70;
+
+export interface WorkspaceTabCountDigitsProps {
+  value: number;
+  prefixCls: string;
+  hashId?: string;
+}
+
+export const WorkspaceTabCountDigits: React.FC<
+  WorkspaceTabCountDigitsProps
+> = ({ value, prefixCls, hashId }) => {
+  const [isAnimating, setIsAnimating] = useState(true);
+  const lastSerializedRef = useRef<string | null>(null);
+  const digits = String(value).split('');
+
+  useEffect(() => {
+    const serialized = String(value);
+    if (process.env.NODE_ENV === 'test') {
+      lastSerializedRef.current = serialized;
+      return;
+    }
+    if (lastSerializedRef.current === null) {
+      lastSerializedRef.current = serialized;
+      return;
+    }
+    if (lastSerializedRef.current === serialized) {
+      return;
+    }
+    lastSerializedRef.current = serialized;
+    setIsAnimating(false);
+    let innerRaf = 0;
+    const outerRaf = requestAnimationFrame(() => {
+      innerRaf = requestAnimationFrame(() => setIsAnimating(true));
+    });
+    return () => {
+      cancelAnimationFrame(outerRaf);
+      if (innerRaf) {
+        cancelAnimationFrame(innerRaf);
+      }
+    };
+  }, [value]);
+
+  return (
+    <span
+      aria-label={String(value)}
+      className={classNames(
+        `${prefixCls}-tab-count-digits`,
+        hashId,
+        isAnimating && `${prefixCls}-tab-count-digits--animating`,
+      )}
+      data-testid="workspace-tab-count-digits"
+    >
+      {digits.map((ch, index) => (
+        <span
+          key={`${index}-${ch}`}
+          className={classNames(`${prefixCls}-tab-count-digit`, hashId)}
+          style={
+            index > 0
+              ? {
+                  animationDelay: `${index * TAB_COUNT_DIGIT_STAGGER_MS}ms`,
+                }
+              : undefined
+          }
+        >
+          {ch}
+        </span>
+      ))}
+    </span>
+  );
+};
+
+WorkspaceTabCountDigits.displayName = 'WorkspaceTabCountDigits';

--- a/src/Workspace/WorkspaceTabCountDigits.tsx
+++ b/src/Workspace/WorkspaceTabCountDigits.tsx
@@ -5,6 +5,8 @@ import React, { useEffect, useRef, useState } from 'react';
 const TAB_COUNT_DIGIT_STAGGER_MS = 70;
 
 export interface WorkspaceTabCountDigitsProps {
+  /** 与 Workspace 标签 `key` 一致，用于拼接稳定的 data-testid */
+  tabKey: string;
   value: number;
   prefixCls: string;
   hashId?: string;
@@ -12,7 +14,7 @@ export interface WorkspaceTabCountDigitsProps {
 
 export const WorkspaceTabCountDigits: React.FC<
   WorkspaceTabCountDigitsProps
-> = ({ value, prefixCls, hashId }) => {
+> = ({ tabKey, value, prefixCls, hashId }) => {
   const [isAnimating, setIsAnimating] = useState(true);
   const lastSerializedRef = useRef<string | null>(null);
   const digits = String(value).split('');
@@ -52,12 +54,13 @@ export const WorkspaceTabCountDigits: React.FC<
         hashId,
         isAnimating && `${prefixCls}-tab-count-digits--animating`,
       )}
-      data-testid="workspace-tab-count-digits"
+      data-testid={`workspace-tab-count-digits--${tabKey}`}
     >
       {digits.map((ch, index) => (
         <span
           key={`${index}-${ch}`}
           className={classNames(`${prefixCls}-tab-count-digit`, hashId)}
+          data-testid={`workspace-tab-count-digit--${tabKey}--${index}`}
           style={
             index > 0
               ? {

--- a/src/Workspace/__tests__/Workspace.test.tsx
+++ b/src/Workspace/__tests__/Workspace.test.tsx
@@ -368,8 +368,9 @@ describe('Workspace Component', () => {
       </TestWrapper>,
     );
 
-    expect(screen.getByText('5')).toBeInTheDocument();
-    expect(screen.getByText('10')).toBeInTheDocument();
+    const digitGroups = screen.getAllByTestId('workspace-tab-count-digits');
+    expect(digitGroups.some((el) => el.textContent === '5')).toBe(true);
+    expect(digitGroups.some((el) => el.textContent === '10')).toBe(true);
   });
 
   it('应该支持自定义标签页配置', () => {
@@ -960,7 +961,11 @@ describe('Workspace Component', () => {
       const onClose = vi.fn();
       const handleAction = vi.fn();
       const customContent = (
-        <button type="button" data-testid="custom-action" onClick={handleAction}>
+        <button
+          type="button"
+          data-testid="custom-action"
+          onClick={handleAction}
+        >
           自定义操作
         </button>
       );

--- a/src/Workspace/__tests__/Workspace.test.tsx
+++ b/src/Workspace/__tests__/Workspace.test.tsx
@@ -368,9 +368,18 @@ describe('Workspace Component', () => {
       </TestWrapper>,
     );
 
-    const digitGroups = screen.getAllByTestId('workspace-tab-count-digits');
-    expect(digitGroups.some((el) => el.textContent === '5')).toBe(true);
-    expect(digitGroups.some((el) => el.textContent === '10')).toBe(true);
+    expect(
+      screen.getByTestId('workspace-tab-count-digits--realtime'),
+    ).toHaveTextContent('5');
+    expect(
+      screen.getByTestId('workspace-tab-count-digits--browser'),
+    ).toHaveTextContent('10');
+    expect(
+      screen.getByTestId('workspace-tab-count-digit--browser--0'),
+    ).toHaveTextContent('1');
+    expect(
+      screen.getByTestId('workspace-tab-count-digit--browser--1'),
+    ).toHaveTextContent('0');
   });
 
   it('应该支持自定义标签页配置', () => {

--- a/src/Workspace/index.tsx
+++ b/src/Workspace/index.tsx
@@ -215,8 +215,12 @@ const Workspace: FC<WorkspaceProps> & {
               {tabConfig.title}
             </span>
             {tabConfig.count !== undefined && (
-              <span className={classNames(`${prefixCls}-tab-count`, hashId)}>
+              <span
+                className={classNames(`${prefixCls}-tab-count`, hashId)}
+                data-testid={`workspace-tab-count--${tabConfig.key}`}
+              >
                 <WorkspaceTabCountDigits
+                  tabKey={tabConfig.key}
                   value={tabConfig.count}
                   prefixCls={prefixCls}
                   hashId={hashId}

--- a/src/Workspace/index.tsx
+++ b/src/Workspace/index.tsx
@@ -36,6 +36,7 @@ import type {
   WorkspacePanelType,
   WorkspaceProps,
 } from './types';
+import { WorkspaceTabCountDigits } from './WorkspaceTabCountDigits';
 
 export type { FileActionRef } from './types';
 
@@ -215,7 +216,11 @@ const Workspace: FC<WorkspaceProps> & {
             </span>
             {tabConfig.count !== undefined && (
               <span className={classNames(`${prefixCls}-tab-count`, hashId)}>
-                {tabConfig.count}
+                <WorkspaceTabCountDigits
+                  value={tabConfig.count}
+                  prefixCls={prefixCls}
+                  hashId={hashId}
+                />
               </span>
             )}
           </div>

--- a/src/Workspace/style.ts
+++ b/src/Workspace/style.ts
@@ -122,6 +122,49 @@ const genStyle: GenStyleFn<'Workspace'> = (token) => {
         backgroundColor: 'var(--color-gray-control-fill-active)',
         borderRadius: '200px',
         boxSizing: 'border-box',
+        '--workspace-tab-count-digit-distance': '8px',
+        '--workspace-tab-count-digit-blur': '2px',
+        '--workspace-tab-count-digit-dur': '500ms',
+        '--workspace-tab-count-digit-stagger': '70ms',
+        '--workspace-tab-count-digit-ease': 'cubic-bezier(0.34, 1.45, 0.64, 1)',
+      },
+
+      [`${token.componentCls}-tab-count-digits`]: {
+        display: 'inline-flex',
+        alignItems: 'baseline',
+      },
+
+      [`${token.componentCls}-tab-count-digit`]: {
+        display: 'inline-block',
+        willChange: 'transform, opacity, filter',
+      },
+
+      [`${token.componentCls}-tab-count-digits--animating ${token.componentCls}-tab-count-digit`]:
+        {
+          animationName: `${token.componentCls}-tabCountDigitPopIn`,
+          animationDuration: 'var(--workspace-tab-count-digit-dur)',
+          animationTimingFunction: 'var(--workspace-tab-count-digit-ease)',
+          animationFillMode: 'both',
+        },
+
+      [`@keyframes ${token.componentCls}-tabCountDigitPopIn`]: {
+        '0%': {
+          transform: 'translate(0, var(--workspace-tab-count-digit-distance))',
+          opacity: 0,
+          filter: 'blur(var(--workspace-tab-count-digit-blur))',
+        },
+        '100%': {
+          transform: 'translate(0, 0)',
+          opacity: 1,
+          filter: 'blur(0)',
+        },
+      },
+
+      '@media (prefers-reduced-motion: reduce)': {
+        [`${token.componentCls}-tab-count-digit`]: {
+          animation: 'none !important',
+          animationDelay: '0ms !important',
+        },
       },
 
       [`${token.componentCls}-content`]: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Workspace segmented tab badge `count` now uses a per-digit pop-in animation inspired by Transitions.dev number pop-in: translate from below, blur, opacity, staggered delays, and cubic-bezier easing.

## Implementation

- Added `WorkspaceTabCountDigits` to split the numeric string, toggle an animating class on value change (double `requestAnimationFrame` replay), and apply inline stagger delays for arbitrary digit length.
- Registered `@keyframes` and digit styles in `Workspace` CSS-in-JS (`style.ts`), with CSS variables on the existing pill (`tab-count`) and `prefers-reduced-motion: reduce` to disable animation.
- Tests assert counts via keyed `data-testid` values tied to each tab’s `key`.

### Test IDs (for E2E / RTL)

| Element | Pattern |
| --- | --- |
| Count pill | `workspace-tab-count--${tabKey}` |
| Digit group | `workspace-tab-count-digits--${tabKey}` |
| Single digit | `workspace-tab-count-digit--${tabKey}--${index}` |

## Notes

- Global `<style id="transitions-p9">` injection from the reference snippet was avoided; styles stay scoped through the existing `genStyleHooks` pipeline.

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fdbcc486-385b-40bd-9268-d0d8854983a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fdbcc486-385b-40bd-9268-d0d8854983a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

