### PR TITLE
feat(Workspace): File panel list/tree switch via fileTreeSwitch

### DIFF
--- a/e2e/keyboard-shortcuts.spec.ts
+++ b/e2e/keyboard-shortcuts.spec.ts
@@ -1,5 +1,5 @@
-import { PLAYWRIGHT_FIXTURE_DEMOS } from '../tests/constants/playwrightDemoRoutes';
-import { expect, test } from '../tests/fixtures/page-fixture';
+import { PLAYWRIGHT_FIXTURE_DEMOS } from '../_test_helpers/constants/playwrightDemoRoutes';
+import { expect, test } from '../_test_helpers/fixtures/page-fixture';
 
 /**
  * KeyboardTask 快捷键功能 E2E 测试

--- a/e2e/markdowneditor-basic.spec.ts
+++ b/e2e/markdowneditor-basic.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '../tests/fixtures/page-fixture';
+import { expect, test } from '../_test_helpers/fixtures/page-fixture';
 
 test.describe('MarkdownEditor 基础功能', () => {
   test.beforeEach(async ({ markdownEditorPage }) => {

--- a/e2e/markdowneditor-paste-html-once.spec.ts
+++ b/e2e/markdowneditor-paste-html-once.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '../tests/fixtures/page-fixture';
+import { expect, test } from '../_test_helpers/fixtures/page-fixture';
 
 /**
  * 粘贴 HTML 时 handlePasteEvent 应只插入一次文本（避免与浏览器默认粘贴行为重复插入）

--- a/e2e/markdowninputfield-advanced.spec.ts
+++ b/e2e/markdowninputfield-advanced.spec.ts
@@ -1,5 +1,5 @@
-import { PLAYWRIGHT_FIXTURE_DEMOS } from '../tests/constants/playwrightDemoRoutes';
-import { expect, test } from '../tests/fixtures/page-fixture';
+import { PLAYWRIGHT_FIXTURE_DEMOS } from '../_test_helpers/constants/playwrightDemoRoutes';
+import { expect, test } from '../_test_helpers/fixtures/page-fixture';
 
 test.describe('MarkdownInputField 高级功能', () => {
   test('应该支持多行输入', async ({ markdownInputFieldPage }) => {

--- a/e2e/markdowninputfield-basic.spec.ts
+++ b/e2e/markdowninputfield-basic.spec.ts
@@ -1,5 +1,5 @@
-import { PLAYWRIGHT_FIXTURE_DEMOS } from '../tests/constants/playwrightDemoRoutes';
-import { expect, test } from '../tests/fixtures/page-fixture';
+import { PLAYWRIGHT_FIXTURE_DEMOS } from '../_test_helpers/constants/playwrightDemoRoutes';
+import { expect, test } from '../_test_helpers/fixtures/page-fixture';
 
 test.describe('MarkdownInputField 基础功能', () => {
   test('应该能够正确输入文本', async ({ markdownInputFieldPage }) => {

--- a/e2e/markdowninputfield-interactions.spec.ts
+++ b/e2e/markdowninputfield-interactions.spec.ts
@@ -1,5 +1,5 @@
-import { PLAYWRIGHT_FIXTURE_DEMOS } from '../tests/constants/playwrightDemoRoutes';
-import { expect, test } from '../tests/fixtures/page-fixture';
+import { PLAYWRIGHT_FIXTURE_DEMOS } from '../_test_helpers/constants/playwrightDemoRoutes';
+import { expect, test } from '../_test_helpers/fixtures/page-fixture';
 
 test.describe('MarkdownInputField 交互功能', () => {
   test.describe('发送消息', () => {

--- a/e2e/markdowninputfield-tag-popup-continuous-selection.spec.ts
+++ b/e2e/markdowninputfield-tag-popup-continuous-selection.spec.ts
@@ -1,5 +1,5 @@
-import { PLAYWRIGHT_FIXTURE_DEMOS } from '../tests/constants/playwrightDemoRoutes';
-import { expect, test } from '../tests/fixtures/page-fixture';
+import { PLAYWRIGHT_FIXTURE_DEMOS } from '../_test_helpers/constants/playwrightDemoRoutes';
+import { expect, test } from '../_test_helpers/fixtures/page-fixture';
 
 /**
  * TagPopup 连续选择测试

--- a/e2e/markdowninputfield-tag-popup.spec.ts
+++ b/e2e/markdowninputfield-tag-popup.spec.ts
@@ -1,5 +1,5 @@
-import { PLAYWRIGHT_FIXTURE_DEMOS } from '../tests/constants/playwrightDemoRoutes';
-import { expect, test } from '../tests/fixtures/page-fixture';
+import { PLAYWRIGHT_FIXTURE_DEMOS } from '../_test_helpers/constants/playwrightDemoRoutes';
+import { expect, test } from '../_test_helpers/fixtures/page-fixture';
 
 test.describe('MarkdownInputField Tag Popup', () => {
   test('应该能够通过 tag popup 选择更新输入内容', async ({

--- a/e2e/tool-use-bar.spec.ts
+++ b/e2e/tool-use-bar.spec.ts
@@ -1,5 +1,5 @@
-import { PLAYWRIGHT_FIXTURE_DEMOS } from '../tests/constants/playwrightDemoRoutes';
-import { expect, test } from '../tests/fixtures/page-fixture';
+import { PLAYWRIGHT_FIXTURE_DEMOS } from '../_test_helpers/constants/playwrightDemoRoutes';
+import { expect, test } from '../_test_helpers/fixtures/page-fixture';
 
 test.describe('ToolUseBar 组件', () => {
   test('应该正确渲染工具项', async ({ toolUseBarPage }) => {

--- a/src/MarkdownInputField/__tests__/MarkdownInputField.targeted-coverage.test.tsx
+++ b/src/MarkdownInputField/__tests__/MarkdownInputField.targeted-coverage.test.tsx
@@ -14,7 +14,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const captured = vi.hoisted(() => ({
   editorProps: null as any,
-  animationProps: null as any,
   quickActionsProps: null as any,
 }));
 
@@ -23,14 +22,6 @@ vi.mock('../../MarkdownEditor', () => ({
   BaseMarkdownEditor: (props: any) => {
     captured.editorProps = props;
     return <div data-testid="mock-editor">{props.children}</div>;
-  },
-}));
-
-/* ---- Mock BorderBeamAnimation：捕获 onAnimationComplete ---- */
-vi.mock('../BorderBeamAnimation', () => ({
-  BorderBeamAnimation: (props: any) => {
-    captured.animationProps = props;
-    return <div data-testid="mock-border-beam" />;
   },
 }));
 
@@ -169,7 +160,6 @@ import { MarkdownInputField } from '../MarkdownInputField';
 describe('MarkdownInputField targeted coverage', () => {
   beforeEach(() => {
     captured.editorProps = null;
-    captured.animationProps = null;
     captured.quickActionsProps = null;
   });
 
@@ -253,17 +243,6 @@ describe('MarkdownInputField targeted coverage', () => {
       captured.editorProps.onPaste(fakeEvent);
     });
     // handlePaste should have been called without error
-    expect(true).toBe(true);
-  });
-
-  it('覆盖 onAnimationComplete 回调', () => {
-    render(<MarkdownInputField />);
-
-    expect(captured.animationProps).toBeTruthy();
-    act(() => {
-      captured.animationProps.onAnimationComplete?.();
-    });
-    // setAnimationComplete(true) called without error
     expect(true).toBe(true);
   });
 

--- a/src/TaskList/TaskList.tsx
+++ b/src/TaskList/TaskList.tsx
@@ -200,6 +200,7 @@ export const TaskList = memo(
               status={summaryStatus}
               prefixCls={prefixCls}
               hashId={hashId}
+              statusTestId={`task-list-simple-summary-status-${summaryStatus}`}
             />
           </div>
           <div className={classNames(`${simpleCls}-text`, hashId)}>

--- a/src/TaskList/components/StatusIcon.tsx
+++ b/src/TaskList/components/StatusIcon.tsx
@@ -9,12 +9,18 @@ interface StatusIconProps {
   status: TaskStatus;
   prefixCls: string;
   hashId: string;
+  /**
+   * 覆盖根节点 `data-testid`（默认 `task-list-status-${status}`）
+   * @description simple 汇总条与列表项都会渲染状态图标，需区分时可传入独立 testid
+   */
+  statusTestId?: string;
 }
 
 const StatusIconComponent: React.FC<StatusIconProps> = ({
   status,
   prefixCls,
   hashId,
+  statusTestId,
 }) => {
   const statusContent = useMemo(() => {
     const contentMap: Record<TaskStatus, React.ReactNode> = {
@@ -37,7 +43,7 @@ const StatusIconComponent: React.FC<StatusIconProps> = ({
         `${prefixCls}-status-${status}`,
         hashId,
       )}
-      data-testid={`task-list-status-${status}`}
+      data-testid={statusTestId ?? `task-list-status-${status}`}
     >
       {statusContent}
     </div>

--- a/src/Workspace/File/FileComponent.tsx
+++ b/src/Workspace/File/FileComponent.tsx
@@ -181,13 +181,11 @@ export const FileComponent: FC<{
     setHeaderFileOverride(null);
   });
 
-  // resetKey 变化 → 重置预览
+  // resetKey 变化 → 重置预览（仅依赖 resetKey；勿依赖 previewFile，否则 onPreview 将 previewFile 从 null 置为有值时会再跑一遍 effect，在 resetKey 已为 0 等合法值时误触发返回列表）
   useEffect(() => {
-    if (resetKey !== undefined && previewFile) {
-      handleBackToList();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [resetKey, previewFile]);
+    if (resetKey === undefined) return;
+    handleBackToList();
+  }, [resetKey, handleBackToList]);
 
   useEffect(() => {
     if (panelView === 'tree') {

--- a/src/Workspace/File/FileComponent.tsx
+++ b/src/Workspace/File/FileComponent.tsx
@@ -1,10 +1,23 @@
-import { ConfigProvider, Empty, Image, Spin, Typography } from 'antd';
+import {
+  ConfigProvider,
+  Empty,
+  Image,
+  Segmented,
+  Spin,
+  Typography,
+} from 'antd';
 import classNames from 'clsx';
 import React, { type FC, useContext, useEffect, useRef, useState } from 'react';
 import { useRefFunction } from '../../Hooks/useRefFunction';
 import { I18nContext, compileTemplate } from '../../I18n';
 import type { MarkdownEditorProps } from '../../MarkdownEditor';
-import type { FileNode, FileProps, FileType, GroupNode } from '../types';
+import type {
+  FileNode,
+  FilePanelViewMode,
+  FileProps,
+  FileType,
+  GroupNode,
+} from '../types';
 import {
   FileGroup,
   GROUP_INITIAL_PAGE_SIZE,
@@ -12,6 +25,7 @@ import {
 } from './components/FileGroup';
 import { FileItem } from './components/FileItem';
 import { SearchInput } from './components/SearchInput';
+import { FileTree } from './FileTree';
 import { isImageFile } from './FileTypeProcessor';
 import {
   getPreviewSource,
@@ -67,6 +81,7 @@ export const FileComponent: FC<{
   showSearch?: boolean;
   searchPlaceholder?: string;
   bindDomId?: FileProps['bindDomId'];
+  fileTreeSwitch?: FileProps['fileTreeSwitch'];
 }> = ({
   nodes,
   onGroupDownload,
@@ -91,6 +106,7 @@ export const FileComponent: FC<{
   showSearch = false,
   searchPlaceholder,
   bindDomId = false,
+  fileTreeSwitch,
 }) => {
   const [previewFile, setPreviewFile] = useState<FileNode | null>(null);
   const [customPreviewContent, setCustomPreviewContent] =
@@ -109,6 +125,16 @@ export const FileComponent: FC<{
   const [flatVisibleCount, setFlatVisibleCount] = useState(
     GROUP_INITIAL_PAGE_SIZE,
   );
+  const [innerPanelView, setInnerPanelView] = useState<FilePanelViewMode>(
+    () => fileTreeSwitch?.defaultView ?? 'list',
+  );
+
+  const isControlledPanelView = fileTreeSwitch?.view !== undefined;
+  const panelView: FilePanelViewMode = fileTreeSwitch
+    ? isControlledPanelView
+      ? (fileTreeSwitch.view as FilePanelViewMode)
+      : innerPanelView
+    : 'list';
 
   // nodes / keyword 变化时重置扁平列表分页
   useEffect(() => {
@@ -162,6 +188,12 @@ export const FileComponent: FC<{
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resetKey, previewFile]);
+
+  useEffect(() => {
+    if (panelView === 'tree') {
+      handleBackToList();
+    }
+  }, [panelView, handleBackToList]);
 
   // nodes 变化 → 同步更新 previewFile（保持预览内容跟随外部数据）
   useEffect(() => {
@@ -323,17 +355,61 @@ export const FileComponent: FC<{
 
   const hasKeyword = Boolean((keyword ?? '').trim());
 
-  const renderSearchInput = () => {
-    if (!showSearch) return null;
+  const handlePanelViewChange = useRefFunction((next: FilePanelViewMode) => {
+    if (!isControlledPanelView) {
+      setInnerPanelView(next);
+    }
+    fileTreeSwitch?.onViewChange?.(next);
+  });
+
+  const renderToolbarRow = () => {
+    const showSwitcher = Boolean(fileTreeSwitch);
+    const showSearchInToolbar =
+      showSearch && (!fileTreeSwitch || panelView === 'list');
+    if (!showSwitcher && !showSearchInToolbar) {
+      return null;
+    }
+    const listLabel =
+      fileTreeSwitch?.listLabel ?? locale?.['workspace.file'] ?? 'File';
+    const treeLabel =
+      fileTreeSwitch?.treeLabel ??
+      locale?.['workspace.fileTree'] ??
+      'File tree';
+    const switchTrailing = showSwitcher && !showSearchInToolbar;
+
     return (
-      <SearchInput
-        keyword={keyword}
-        onChange={onChange}
-        searchPlaceholder={searchPlaceholder}
-        prefixCls={prefixCls}
-        hashId={hashId}
-        locale={locale}
-      />
+      <div
+        className={classNames(`${prefixCls}-toolbar`, hashId)}
+        data-testid="file-toolbar"
+      >
+        {showSearchInToolbar ? (
+          <div className={classNames(`${prefixCls}-toolbar-search`, hashId)}>
+            <SearchInput
+              keyword={keyword}
+              onChange={onChange}
+              searchPlaceholder={searchPlaceholder}
+              prefixCls={prefixCls}
+              hashId={hashId}
+              locale={locale}
+            />
+          </div>
+        ) : null}
+        {showSwitcher ? (
+          <Segmented<FilePanelViewMode>
+            size="small"
+            className={classNames(`${prefixCls}-toolbar-switch`, hashId, {
+              [`${prefixCls}-toolbar-switch--trailing`]: switchTrailing,
+            })}
+            value={panelView}
+            onChange={handlePanelViewChange}
+            options={[
+              { label: listLabel, value: 'list' },
+              { label: treeLabel, value: 'tree' },
+            ]}
+            data-testid="file-panel-view-switch"
+          />
+        ) : null}
+      </div>
     );
   };
 
@@ -514,7 +590,7 @@ export const FileComponent: FC<{
           className={classNames(`${prefixCls}-container`, hashId)}
           data-testid="file-component"
         >
-          {renderSearchInput()}
+          {renderToolbarRow()}
           {loadingRender()}
         </div>
       ) : (
@@ -523,8 +599,17 @@ export const FileComponent: FC<{
             className={classNames(`${prefixCls}-container`, hashId)}
             data-testid="file-component"
           >
-            {renderSearchInput()}
-            {renderFileContent()}
+            {renderToolbarRow()}
+            {panelView === 'tree' && fileTreeSwitch ? (
+              <div
+                className={classNames(`${prefixCls}-tree-panel`, hashId)}
+                data-testid="file-tree-embed"
+              >
+                <FileTree {...fileTreeSwitch.treeProps} resetKey={resetKey} />
+              </div>
+            ) : (
+              renderFileContent()
+            )}
           </div>
         </Spin>
       )}

--- a/src/Workspace/File/index.tsx
+++ b/src/Workspace/File/index.tsx
@@ -9,10 +9,12 @@ export type {
   FileActionRef,
   FileBuiltinActions,
   FileNode,
+  FilePanelViewMode,
   FileProps,
   FileRenderContext,
   FileTreeNode,
   FileTreeProps,
+  FileTreeSwitchConfig,
   FileType,
   GroupNode,
 } from '../types';

--- a/src/Workspace/File/style.ts
+++ b/src/Workspace/File/style.ts
@@ -490,6 +490,38 @@ const genStyle: GenStyleFn<'WorkspaceFile'> = (token) => {
       },
     },
 
+    [`${token.componentCls}-toolbar`]: {
+      display: 'flex',
+      alignItems: 'center',
+      gap: token.marginXS ?? 8,
+      flexShrink: 0,
+      marginBottom: 8,
+    },
+
+    [`${token.componentCls}-toolbar-search`]: {
+      flex: 1,
+      minWidth: 0,
+      [`${token.componentCls}-search ${token.antCls}-input-outlined`]: {
+        marginBottom: 0,
+      },
+    },
+
+    [`${token.componentCls}-toolbar-switch`]: {
+      flexShrink: 0,
+    },
+
+    [`${token.componentCls}-toolbar-switch--trailing`]: {
+      marginInlineStart: 'auto',
+    },
+
+    [`${token.componentCls}-tree-panel`]: {
+      flex: 1,
+      minHeight: 0,
+      display: 'flex',
+      flexDirection: 'column',
+      overflow: 'hidden',
+    },
+
     // 搜索框样式
     [`${token.componentCls}-search`]: {
       [`${token.antCls}-input-outlined`]: {

--- a/src/Workspace/__tests__/File/FileComponent.test.tsx
+++ b/src/Workspace/__tests__/File/FileComponent.test.tsx
@@ -198,6 +198,94 @@ describe('FileComponent', () => {
     });
   });
 
+  describe('fileTreeSwitch 列表与文件树切换', () => {
+    const treeProps = {
+      treeData: [{ key: 'leaf-1', name: 'only.txt', isLeaf: true }],
+      onLoadChildren: vi.fn().mockResolvedValue([]),
+    };
+
+    it('展示段选择器并切换到内嵌文件树', async () => {
+      const nodes: FileNode[] = [
+        { id: 'f1', name: 'list.txt', url: 'https://example.com/a.txt' },
+      ];
+      render(
+        <TestWrapper>
+          <FileComponent nodes={nodes} fileTreeSwitch={{ treeProps }} />
+        </TestWrapper>,
+      );
+      expect(screen.getByTestId('file-panel-view-switch')).toBeInTheDocument();
+      expect(screen.getByText('list.txt')).toBeInTheDocument();
+      fireEvent.click(screen.getByText('文件树'));
+      await waitFor(() => {
+        expect(screen.getByTestId('workspace-file-tree')).toBeInTheDocument();
+      });
+      expect(screen.getByText('only.txt')).toBeInTheDocument();
+      expect(screen.queryByText('list.txt')).not.toBeInTheDocument();
+    });
+
+    it('树视图下隐藏搜索框，切回列表恢复', () => {
+      const nodes: FileNode[] = [
+        { id: 'f1', name: 'list.txt', url: 'https://example.com/a.txt' },
+      ];
+      render(
+        <TestWrapper>
+          <FileComponent
+            nodes={nodes}
+            showSearch
+            keyword=""
+            onChange={vi.fn()}
+            fileTreeSwitch={{
+              treeProps,
+              listLabel: 'List',
+              treeLabel: 'Tree',
+            }}
+          />
+        </TestWrapper>,
+      );
+      expect(screen.getByTestId('file-search-input')).toBeInTheDocument();
+      fireEvent.click(screen.getByText('Tree'));
+      expect(screen.queryByTestId('file-search-input')).not.toBeInTheDocument();
+      fireEvent.click(screen.getByText('List'));
+      expect(screen.getByTestId('file-search-input')).toBeInTheDocument();
+    });
+
+    it('受控 view 时由外部驱动展示', async () => {
+      const nodes: FileNode[] = [
+        { id: 'f1', name: 'list.txt', url: 'https://example.com/a.txt' },
+      ];
+      const onViewChange = vi.fn();
+      const { rerender } = render(
+        <TestWrapper>
+          <FileComponent
+            nodes={nodes}
+            fileTreeSwitch={{
+              treeProps,
+              view: 'list',
+              onViewChange,
+            }}
+          />
+        </TestWrapper>,
+      );
+      fireEvent.click(screen.getByText('文件树'));
+      expect(onViewChange).toHaveBeenCalledWith('tree');
+      rerender(
+        <TestWrapper>
+          <FileComponent
+            nodes={nodes}
+            fileTreeSwitch={{
+              treeProps,
+              view: 'tree',
+              onViewChange,
+            }}
+          />
+        </TestWrapper>,
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId('workspace-file-tree')).toBeInTheDocument();
+      });
+    });
+  });
+
   describe('文件交互', () => {
     it('应该触发文件点击事件', () => {
       const handleClick = vi.fn();
@@ -2646,7 +2734,9 @@ describe('FileComponent', () => {
       );
 
       // isLoading 优先级更高，设为 false 时不应显示 loading
-      expect(container.querySelector('.ant-spin-spinning')).not.toBeInTheDocument();
+      expect(
+        container.querySelector('.ant-spin-spinning'),
+      ).not.toBeInTheDocument();
     });
 
     it('未传 isLoading 时应回退到 loading 属性', () => {

--- a/src/Workspace/__tests__/File/FileComponent.test.tsx
+++ b/src/Workspace/__tests__/File/FileComponent.test.tsx
@@ -1109,6 +1109,33 @@ describe('FileComponent', () => {
         expect(screen.queryByLabelText('返回文件列表')).not.toBeInTheDocument();
       });
     });
+
+    it('resetKey 已传入（含 0）时 onPreview 返回自定义 React 节点打开预览不应闪回列表', async () => {
+      const CustomPreview = () => (
+        <div data-testid="custom-preview-flash-guard">custom body</div>
+      );
+      const handlePreview = vi
+        .fn()
+        .mockResolvedValue((<CustomPreview />) as any);
+      const nodes: FileNode[] = [
+        { id: 'f1', name: 'guard.txt', content: 'Hello' },
+      ];
+
+      render(
+        <TestWrapper>
+          <FileComponent nodes={nodes} onPreview={handlePreview} resetKey={0} />
+        </TestWrapper>,
+      );
+
+      fireEvent.click(screen.getByLabelText('预览'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('custom-preview-flash-guard'),
+        ).toBeInTheDocument();
+      });
+      expect(screen.getByLabelText('返回文件列表')).toBeInTheDocument();
+    });
   });
 
   describe('actionRef功能', () => {

--- a/src/Workspace/index.tsx
+++ b/src/Workspace/index.tsx
@@ -394,9 +394,11 @@ export type { HtmlPreviewProps } from './HtmlPreview';
 export type {
   BrowserProps,
   CustomProps,
+  FilePanelViewMode,
   FileProps,
   FileTreeNode,
   FileTreeProps,
+  FileTreeSwitchConfig,
   RealtimeProps,
   TabConfiguration,
   TabItem,

--- a/src/Workspace/types.ts
+++ b/src/Workspace/types.ts
@@ -535,6 +535,11 @@ export interface FileProps extends BaseChildProps {
   /** 搜索框占位符 */
   searchPlaceholder?: string;
   /**
+   * 列表与文件树视图切换：传入后在搜索框旁展示段选择器；未传入时不展示
+   * @description 切到「文件树」时隐藏搜索框（树数据无内置过滤）；切回「列表」时恢复
+   */
+  fileTreeSwitch?: FileTreeSwitchConfig;
+  /**
    * 是否在文件项根元素上绑定 DOM id
    * @default false
    * @description 置为 false 时，不会向元素写入 id 属性（不影响 React key）
@@ -604,6 +609,26 @@ export interface FileTreeProps extends BaseChildProps {
    * 是否整行可点选（antd Tree `blockNode`），默认 `true`
    */
   blockNode?: boolean;
+}
+
+/** 文件面板在「列表」与「文件树」之间的视图模式 */
+export type FilePanelViewMode = 'list' | 'tree';
+
+/**
+ * 在 {@link FileProps} 上启用「列表 / 文件树」段选择器时的配置
+ * @description 配置后搜索行右侧展示切换；`treeProps` 与独立使用 `Workspace.FileTree` 时一致（`tab`、`resetKey` 由 `Workspace.File` 注入）
+ */
+export interface FileTreeSwitchConfig {
+  treeProps: Omit<FileTreeProps, 'tab' | 'resetKey'>;
+  /** 非受控时的初始视图，默认 `list` */
+  defaultView?: FilePanelViewMode;
+  /** 受控当前视图 */
+  view?: FilePanelViewMode;
+  onViewChange?: (view: FilePanelViewMode) => void;
+  /** 列表选项文案，默认取 `locale['workspace.file']` */
+  listLabel?: React.ReactNode;
+  /** 文件树选项文案，默认取 `locale['workspace.fileTree']` */
+  treeLabel?: React.ReactNode;
 }
 
 export interface CustomProps extends BaseChildProps {

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,10 +41,12 @@ export {
   type FileActionRef,
   type FileBuiltinActions,
   type FileNode,
+  type FilePanelViewMode,
   type FileProps,
   type FileRenderContext,
   type FileTreeNode,
   type FileTreeProps,
+  type FileTreeSwitchConfig,
   type FileType,
   type GroupNode,
   type HtmlPreviewProps,
@@ -560,7 +562,6 @@ export {
   type DocCardsField,
   type DocCardsFieldMap,
   type DocCardsProps,
-  type ResolvedDocCardsFields,
   type DonutChartConfig,
   type DonutChartData,
   type DonutChartProps,
@@ -575,6 +576,7 @@ export {
   type QuadrantChartProps,
   type RadarChartDataItem,
   type RegionOption,
+  type ResolvedDocCardsFields,
   type ScatterChartDataItem,
   type ScatterChartProps,
 } from './Plugins/chart';
@@ -627,7 +629,6 @@ export {
   GradientText,
   type GradientTextProps,
 } from './Components/GradientText';
-export { TextSwap, type TextSwapProps } from './Components/TextSwap';
 export {
   LayoutHeader,
   type LayoutHeaderConfig,
@@ -690,6 +691,7 @@ export {
   resolveSegments,
   type TextAnimateProps,
 } from './Components/TextAnimate';
+export { TextSwap, type TextSwapProps } from './Components/TextSwap';
 export {
   TypingAnimation,
   type TypingAnimationProps,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds optional `fileTreeSwitch` on `Workspace.File` so consumers can show an Ant Design `Segmented` control beside the search row (when `showSearch` is enabled, the input stays on the left in list view). When the tree segment is selected, the panel renders the same `FileTree` behavior as `Workspace.FileTree` using the provided `treeProps` (including `resetKey` injection from the parent `Workspace`).

## Fix: resetKey + custom onPreview flash

The `resetKey` effect previously depended on `[resetKey, previewFile]` and cleared preview when `resetKey !== undefined && previewFile`. Opening custom `onPreview` sets `previewFile` from `null` to a file, re-running the effect while `resetKey` stayed at `0`, which incorrectly called `handleBackToList()` and flashed back to the list. The effect now depends only on `resetKey` (and `handleBackToList`): when `resetKey` is defined, we reset on each **change** of that prop, not when preview opens.

## API

- `FileProps.fileTreeSwitch?: FileTreeSwitchConfig`
- `FileTreeSwitchConfig.treeProps`: `Omit<FileTreeProps, 'tab' | 'resetKey'>` — `tab` continues to come from `File`; `resetKey` is passed through like standalone `Workspace.FileTree`.
- Optional controlled `view` / `onViewChange`, optional `listLabel` / `treeLabel`, and `defaultView` for uncontrolled mode.

## Behavior

- Switching to tree view closes any file preview and hides the search input (tree has no built-in keyword filter); switching back to list restores the search row when `showSearch` is true.
- New exports: `FilePanelViewMode`, `FileTreeSwitchConfig` (package `src/index.ts` and `Workspace` entry).

## Tests

- `FileComponent.test.tsx`: segment visible, tree embed, search visibility, controlled `view` with `onViewChange`.
- Regression: `resetKey={0}` + custom React from `onPreview` stays on preview.

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2228e71a-a3f7-4e8b-8401-28bcbaef23ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2228e71a-a3f7-4e8b-8401-28bcbaef23ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

