### PR TITLE
fix(MarkdownInputField): use shadow CSS variables for container

### DIFF
--- a/src/MarkdownInputField/style.ts
+++ b/src/MarkdownInputField/style.ts
@@ -80,8 +80,7 @@ const genStyle: GenerateStyle<
     ? {}
     : {
         '&:hover': {
-          boxShadow:
-            '0px 0px 1px 0px rgba(10, 48, 104, 0.25), 0px 2px 7px 0px rgba(10, 48, 104, 0.05), 0px 2px 5px -2px rgba(10, 48, 104, 0.06)',
+          boxShadow: 'var(--shadow-control-lg)',
         },
       };
 
@@ -103,12 +102,10 @@ const genStyle: GenerateStyle<
       '> * ': {
         boxSizing: 'border-box',
       },
-      boxShadow:
-        '0px 0px 1px 0px rgba(10, 48, 104, 0.15), 0px 1.5px 4px -1px rgba(10, 48, 104, 0.04)',
+      boxShadow: 'var(--shadow-control-base)',
       ...hoverStyle,
       '&-focused': {
-        boxShadow:
-          '0px 0px 1px 0px rgba(10, 48, 104, 0.25), 0px 2px 7px 0px rgba(10, 48, 104, 0.05), 0px 2px 5px -2px rgba(10, 48, 104, 0.06)',
+        boxShadow: 'var(--shadow-control-lg)',
       },
 
       '&-enlarged': {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`MarkdownInputField` 主容器原先使用硬编码的 `rgba(10, 48, 104, …)` 多层 `box-shadow`，与同目录下的 `FileMapView`、`AttachmentFileList` 以及全局设计令牌不一致。

## Changes

- 默认态：`var(--shadow-control-base)`
- hover / `&-focused`：`var(--shadow-control-lg)`（与 `disableHoverAnimation` 分支行为保持一致：禁用时无 hover 阴影变化）

这样阴影由宿主或主题中的 `--shadow-control-*` 变量统一控制，便于暗色模式与品牌定制。

## Testing

- `pnpm test -- src/MarkdownInputField`（Vitest 全量匹配到相关套件，全部通过）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f76a65c2-a75d-4727-87bf-a4b6314c7e02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f76a65c2-a75d-4727-87bf-a4b6314c7e02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

