### PR TITLE
docs(demos): MarkdownInputField 演示重构与入口调整

### DIFF
--- a/docs/demos/e2e/markdown-input-field-tags.tsx
+++ b/docs/demos/e2e/markdown-input-field-tags.tsx
@@ -1,1 +1,1 @@
-export { default } from '../markdownInputField';
+export { default } from '../markdownInputField/basic';

--- a/docs/demos/markdownInputField-onFocus-demo.tsx
+++ b/docs/demos/markdownInputField-onFocus-demo.tsx
@@ -1,1 +1,0 @@
-export { default } from './markdownInputField/on-focus';

--- a/docs/demos/markdownInputField-webllm.tsx
+++ b/docs/demos/markdownInputField-webllm.tsx
@@ -1,1 +1,0 @@
-export { default } from './markdownInputField/web-llm';

--- a/docs/demos/markdownInputField.tsx
+++ b/docs/demos/markdownInputField.tsx
@@ -1,1 +1,0 @@
-export { default } from './markdownInputField/basic';

--- a/docs/demos/markdownInputField/_constants.ts
+++ b/docs/demos/markdownInputField/_constants.ts
@@ -28,3 +28,25 @@ export const pageStyle: CSSProperties = {
 };
 
 export const inputMinStyle: CSSProperties = { minHeight: 66 };
+
+/** 通用模拟上传：返回一个临时 blob URL，并附加可控延时 */
+export const mockUpload = async (file: File, delay = 800): Promise<string> => {
+  await new Promise((resolve) => setTimeout(resolve, delay));
+  return URL.createObjectURL(file);
+};
+
+/** 通用模拟删除：清理 blob URL，避免内存泄漏 */
+export const mockDelete = async (file: {
+  url?: string;
+  previewUrl?: string;
+}): Promise<void> => {
+  const fileUrl = typeof file.url === 'string' ? file.url : undefined;
+  const previewUrl =
+    typeof file.previewUrl === 'string' ? file.previewUrl : undefined;
+  if (fileUrl?.startsWith('blob:')) {
+    URL.revokeObjectURL(fileUrl);
+  }
+  if (previewUrl?.startsWith('blob:') && previewUrl !== fileUrl) {
+    URL.revokeObjectURL(previewUrl);
+  }
+};

--- a/docs/demos/markdownInputField/attachment-basic.tsx
+++ b/docs/demos/markdownInputField/attachment-basic.tsx
@@ -1,7 +1,13 @@
 import { MarkdownInputField } from '@ant-design/agentic-ui';
 import { Typography } from 'antd';
 import React, { useMemo } from 'react';
-import { TAG_ITEMS, TEMPLATE_VALUE, pageStyle } from './_constants';
+import {
+  TAG_ITEMS,
+  TEMPLATE_VALUE,
+  mockDelete,
+  mockUpload,
+  pageStyle,
+} from './_constants';
 import { useDemoSend } from './useDemoSend';
 
 const { Text, Title } = Typography;
@@ -12,21 +18,8 @@ export default () => {
   const attachmentConfig = useMemo(
     () => ({
       enable: true as const,
-      upload: async (file: File) =>
-        new Promise<string>((resolve) => {
-          setTimeout(() => resolve(URL.createObjectURL(file)), 1000);
-        }),
-      onDelete: async (file: { url?: string; previewUrl?: string }) => {
-        const fileUrl = typeof file.url === 'string' ? file.url : undefined;
-        const previewUrl =
-          typeof file.previewUrl === 'string' ? file.previewUrl : undefined;
-        if (fileUrl?.startsWith('blob:')) {
-          URL.revokeObjectURL(fileUrl);
-        }
-        if (previewUrl?.startsWith('blob:') && previewUrl !== fileUrl) {
-          URL.revokeObjectURL(previewUrl);
-        }
-      },
+      upload: (file: File) => mockUpload(file, 1000),
+      onDelete: mockDelete,
     }),
     [],
   );

--- a/docs/demos/markdownInputField/basic.tsx
+++ b/docs/demos/markdownInputField/basic.tsx
@@ -7,7 +7,7 @@ import { useDemoSend } from './useDemoSend';
 const { Text, Title } = Typography;
 
 export default () => {
-  const { sentList, handleSend, handleStop } = useDemoSend();
+  const { handleSend, handleStop } = useDemoSend();
 
   const asyncTagItems = useCallback(
     async (props: { placeholder?: string } | undefined) =>
@@ -26,11 +26,6 @@ export default () => {
       <Text type="secondary" style={{ display: 'block', marginBottom: 12 }}>
         `tagInputProps.items` 异步返回候选；`value` 展示模板占位语法。
       </Text>
-      {sentList.length > 0 ? (
-        <Text type="secondary" style={{ display: 'block', marginBottom: 8 }}>
-          已发送 {sentList.length} 条（模拟 1s 延迟；停止可中断）
-        </Text>
-      ) : null}
       <MarkdownInputField
         style={inputMinStyle}
         value={TEMPLATE_VALUE}

--- a/docs/demos/markdownInputField/border-radius.tsx
+++ b/docs/demos/markdownInputField/border-radius.tsx
@@ -7,7 +7,7 @@ import { useDemoSend } from './useDemoSend';
 const { Text, Title } = Typography;
 
 export default () => {
-  const [borderRadius, setBorderRadius] = useState(0);
+  const [borderRadius, setBorderRadius] = useState(12);
   const { handleSend, handleStop } = useDemoSend();
 
   const asyncTagItems = useCallback(

--- a/docs/demos/markdownInputField/custom-attachment-popover.tsx
+++ b/docs/demos/markdownInputField/custom-attachment-popover.tsx
@@ -1,4 +1,7 @@
-import type { AttachmentFile } from '@ant-design/agentic-ui';
+import type {
+  AttachmentButtonProps,
+  AttachmentFile,
+} from '@ant-design/agentic-ui';
 import { MarkdownInputField } from '@ant-design/agentic-ui';
 import {
   FileImageOutlined,
@@ -17,278 +20,233 @@ import {
 } from 'antd';
 import React, { useState } from 'react';
 
-/**
- * 自定义附件按钮 Popover 演示
- */
-const CustomAttachmentPopoverDemo: React.FC = () => {
-  const [value, setValue] = useState('尝试点击不同样式的附件按钮来上传文件...');
+type RenderProps = Parameters<NonNullable<AttachmentButtonProps['render']>>[0];
+
+const SimpleTooltipPopover = ({ children, supportedFormat }: RenderProps) => (
+  <Tooltip title={`点击上传${supportedFormat?.type || '文件'}`} placement="top">
+    {children as React.ReactElement}
+  </Tooltip>
+);
+
+const CustomContentPopover = ({ children, supportedFormat }: RenderProps) => {
+  const content = (
+    <div style={{ maxWidth: 200 }}>
+      <div style={{ marginBottom: 8, fontWeight: 'bold' }}>
+        <FileImageOutlined /> 上传{supportedFormat?.type || '文件'}
+      </div>
+      <div style={{ fontSize: 12, color: '#666' }}>
+        支持格式: {supportedFormat?.extensions?.join(', ')}
+      </div>
+      <Divider style={{ margin: '8px 0' }} />
+      <Button type="link" size="small" icon={<InfoCircleOutlined />}>
+        查看上传帮助
+      </Button>
+    </div>
+  );
+
+  return (
+    <Popover
+      content={content}
+      title="文件上传"
+      trigger="hover"
+      placement="topRight"
+    >
+      {children as React.ReactElement}
+    </Popover>
+  );
+};
+
+const ModalTriggerPopover = ({ children, supportedFormat }: RenderProps) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    setIsModalOpen(true);
+  };
+
+  return (
+    <>
+      <Tooltip title="点击打开上传向导">
+        <div
+          onClick={handleClick}
+          style={{ display: 'inline-block', cursor: 'pointer' }}
+        >
+          {children}
+        </div>
+      </Tooltip>
+      <Modal
+        title="文件上传向导"
+        open={isModalOpen}
+        onCancel={() => setIsModalOpen(false)}
+        footer={[
+          <Button key="cancel" onClick={() => setIsModalOpen(false)}>
+            取消
+          </Button>,
+          <Button
+            key="upload"
+            type="primary"
+            icon={<UploadOutlined />}
+            onClick={() => {
+              message.success('上传功能演示');
+              setIsModalOpen(false);
+            }}
+          >
+            选择文件上传
+          </Button>,
+        ]}
+      >
+        <Space direction="vertical" style={{ width: '100%' }}>
+          <Card size="small">
+            <div style={{ display: 'flex', alignItems: 'center' }}>
+              {supportedFormat?.icon}
+              <span style={{ marginLeft: 8 }}>
+                支持{supportedFormat?.type || '文件'}格式
+              </span>
+            </div>
+          </Card>
+          <div>
+            <strong>支持的文件类型:</strong>
+            <div style={{ marginTop: 4 }}>
+              {supportedFormat?.extensions?.map((ext) => (
+                <span
+                  key={ext}
+                  style={{
+                    display: 'inline-block',
+                    background: '#f0f0f0',
+                    padding: '2px 6px',
+                    borderRadius: 3,
+                    fontSize: 12,
+                    marginRight: 4,
+                    marginBottom: 4,
+                  }}
+                >
+                  .{ext}
+                </span>
+              ))}
+            </div>
+          </div>
+        </Space>
+      </Modal>
+    </>
+  );
+};
+
+const ColorfulPopover = ({ children, supportedFormat }: RenderProps) => {
+  const extensions = supportedFormat?.extensions ?? [];
+  const content = (
+    <div
+      style={{
+        background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+        color: 'white',
+        padding: 12,
+        borderRadius: 8,
+        border: 'none',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', marginBottom: 8 }}>
+        {supportedFormat?.icon}
+        <span style={{ marginLeft: 8, fontWeight: 'bold' }}>
+          拖拽或点击上传{supportedFormat?.type}
+        </span>
+      </div>
+      <div style={{ fontSize: 12, opacity: 0.9 }}>
+        {extensions.slice(0, 3).join(', ')}
+        {extensions.length > 3 && ` 等${extensions.length}种格式`}
+      </div>
+    </div>
+  );
+
+  return (
+    <Popover
+      content={content}
+      trigger="hover"
+      placement="top"
+      styles={{ body: { padding: 0 } }}
+    >
+      {children as React.ReactElement}
+    </Popover>
+  );
+};
+
+type DemoCardProps = {
+  title: string;
+  initialValue: string;
+  placeholder: string;
+  render?: AttachmentButtonProps['render'];
+};
+
+const DemoCard: React.FC<DemoCardProps> = ({
+  title,
+  initialValue,
+  placeholder,
+  render,
+}) => {
+  const [value, setValue] = useState(initialValue);
   const [fileMap, setFileMap] = useState<Map<string, AttachmentFile>>(
     new Map(),
   );
 
-  // 模拟文件上传
   const handleUpload = async (file: AttachmentFile) => {
     await new Promise((resolve) => setTimeout(resolve, 1000));
     return `https://example.com/files/${file.name}`;
   };
 
-  // 处理文件映射变化
-  const handleFileMapChange = (files?: Map<string, AttachmentFile>) => {
-    if (files) {
-      setFileMap(files);
-    }
-  };
-
-  // 示例1：简单的 Tooltip 替换
-  const SimpleTooltipPopover = ({ children, supportedFormat }: any) => (
-    <Tooltip
-      title={`点击上传${supportedFormat?.type || '文件'}`}
-      placement="top"
-    >
-      {children}
-    </Tooltip>
-  );
-
-  // 示例2：自定义 Popover 内容
-  const CustomContentPopover = ({ children, supportedFormat }: any) => {
-    const content = (
-      <div style={{ maxWidth: 200 }}>
-        <div style={{ marginBottom: 8, fontWeight: 'bold' }}>
-          <FileImageOutlined /> 上传{supportedFormat?.type || '文件'}
-        </div>
-        <div style={{ fontSize: 12, color: '#666' }}>
-          支持格式: {supportedFormat?.extensions?.join(', ')}
-        </div>
-        <Divider style={{ margin: '8px 0' }} />
-        <Button type="link" size="small" icon={<InfoCircleOutlined />}>
-          查看上传帮助
-        </Button>
-      </div>
-    );
-
-    return (
-      <Popover
-        content={content}
-        title="文件上传"
-        trigger="hover"
-        placement="topRight"
-      >
-        {children}
-      </Popover>
-    );
-  };
-
-  // 示例3：点击触发 Modal 的 Popover
-  const ModalTriggerPopover = ({ children, supportedFormat }: any) => {
-    const [isModalOpen, setIsModalOpen] = useState(false);
-
-    const handleClick = (e: React.MouseEvent) => {
-      e.stopPropagation();
-      e.preventDefault();
-      setIsModalOpen(true);
-    };
-
-    return (
-      <>
-        <Tooltip title="点击打开上传向导">
-          <div
-            onClick={handleClick}
-            style={{ display: 'inline-block', cursor: 'pointer' }}
-          >
-            {children}
-          </div>
-        </Tooltip>
-        <Modal
-          title="文件上传向导"
-          open={isModalOpen}
-          onCancel={() => setIsModalOpen(false)}
-          footer={[
-            <Button
-              key="cancel"
-              onClick={(e) => {
-                e.stopPropagation();
-                e.preventDefault();
-                setIsModalOpen(false);
-              }}
-            >
-              取消
-            </Button>,
-            <Button
-              key="upload"
-              type="primary"
-              icon={<UploadOutlined />}
-              onClick={() => {
-                message.success('上传功能演示');
-                setIsModalOpen(false);
-              }}
-            >
-              选择文件上传
-            </Button>,
-          ]}
-        >
-          <Space direction="vertical" style={{ width: '100%' }}>
-            <Card size="small">
-              <div style={{ display: 'flex', alignItems: 'center' }}>
-                {supportedFormat?.icon}
-                <span style={{ marginLeft: 8 }}>
-                  支持{supportedFormat?.type || '文件'}格式
-                </span>
-              </div>
-            </Card>
-            <div>
-              <strong>支持的文件类型:</strong>
-              <div style={{ marginTop: 4 }}>
-                {supportedFormat?.extensions?.map((ext: string) => (
-                  <span
-                    key={ext}
-                    style={{
-                      display: 'inline-block',
-                      background: '#f0f0f0',
-                      padding: '2px 6px',
-                      borderRadius: 3,
-                      fontSize: 12,
-                      marginRight: 4,
-                      marginBottom: 4,
-                    }}
-                  >
-                    .{ext}
-                  </span>
-                ))}
-              </div>
-            </div>
-          </Space>
-        </Modal>
-      </>
-    );
-  };
-
-  // 示例4：彩色样式的 Popover
-  const ColorfulPopover = ({ children, supportedFormat }: any) => {
-    const content = (
-      <div
-        style={{
-          background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-          color: 'white',
-          padding: 12,
-          borderRadius: 8,
-          border: 'none',
-        }}
-      >
-        <div style={{ display: 'flex', alignItems: 'center', marginBottom: 8 }}>
-          {supportedFormat?.icon}
-          <span style={{ marginLeft: 8, fontWeight: 'bold' }}>
-            拖拽或点击上传{supportedFormat?.type}
-          </span>
-        </div>
-        <div style={{ fontSize: 12, opacity: 0.9 }}>
-          {supportedFormat?.extensions?.slice(0, 3).join(', ')}
-          {supportedFormat?.extensions?.length > 3 &&
-            ` 等${supportedFormat.extensions.length}种格式`}
-        </div>
-      </div>
-    );
-
-    return (
-      <Popover
-        content={content}
-        trigger="hover"
-        placement="top"
-        styles={{ body: { padding: 0 } }}
-      >
-        {children}
-      </Popover>
-    );
-  };
-
   return (
-    <div style={{ padding: 24 }}>
-      <h2>自定义附件按钮 Popover 演示</h2>
-      <p>
-        通过 <code>render</code> 属性，您可以完全自定义附件按钮的交互体验。
-      </p>
-
-      <Space direction="vertical" size="large" style={{ width: '100%' }}>
-        {/* 默认样式 */}
-        <Card title="默认样式" size="small">
-          <MarkdownInputField
-            value={value}
-            onChange={setValue}
-            attachment={{
-              enable: true,
-              upload: handleUpload,
-              fileMap: fileMap,
-              onFileMapChange: handleFileMapChange,
-            }}
-            placeholder="默认的附件按钮样式..."
-          />
-        </Card>
-
-        {/* 简单 Tooltip */}
-        <Card title="简单 Tooltip 替换" size="small">
-          <MarkdownInputField
-            value={value}
-            onChange={setValue}
-            attachment={{
-              enable: true,
-              upload: handleUpload,
-              fileMap: fileMap,
-              onFileMapChange: handleFileMapChange,
-              render: SimpleTooltipPopover,
-            }}
-            placeholder="使用简单 Tooltip 的附件按钮..."
-          />
-        </Card>
-
-        {/* 自定义内容 */}
-        <Card title="自定义 Popover 内容" size="small">
-          <MarkdownInputField
-            value={value}
-            onChange={setValue}
-            attachment={{
-              enable: true,
-              upload: handleUpload,
-              fileMap: fileMap,
-              onFileMapChange: handleFileMapChange,
-              render: CustomContentPopover,
-            }}
-            placeholder="显示详细信息的附件按钮..."
-          />
-        </Card>
-
-        {/* Modal 触发器 */}
-        <Card title="Modal 上传向导" size="small">
-          <MarkdownInputField
-            value={value}
-            onChange={setValue}
-            attachment={{
-              enable: true,
-              upload: handleUpload,
-              fileMap: fileMap,
-              onFileMapChange: handleFileMapChange,
-              render: ModalTriggerPopover,
-            }}
-            placeholder="点击附件按钮打开上传向导..."
-          />
-        </Card>
-
-        {/* 彩色样式 */}
-        <Card title="彩色样式 Popover" size="small">
-          <MarkdownInputField
-            value={value}
-            onChange={setValue}
-            attachment={{
-              enable: true,
-              upload: handleUpload,
-              fileMap: fileMap,
-              onFileMapChange: handleFileMapChange,
-              render: ColorfulPopover,
-            }}
-            placeholder="彩色样式的附件按钮..."
-          />
-        </Card>
-      </Space>
-    </div>
+    <Card title={title} size="small">
+      <MarkdownInputField
+        value={value}
+        onChange={setValue}
+        attachment={{
+          enable: true,
+          upload: handleUpload,
+          fileMap,
+          onFileMapChange: (files) => files && setFileMap(files),
+          render,
+        }}
+        placeholder={placeholder}
+      />
+    </Card>
   );
 };
 
-export default CustomAttachmentPopoverDemo;
+export default () => (
+  <div style={{ padding: 24 }}>
+    <h2>自定义附件按钮 Popover 演示</h2>
+    <p>
+      通过 <code>render</code> 属性，您可以完全自定义附件按钮的交互体验。
+    </p>
+
+    <Space direction="vertical" size="large" style={{ width: '100%' }}>
+      <DemoCard
+        title="默认样式"
+        initialValue=""
+        placeholder="默认的附件按钮样式..."
+      />
+      <DemoCard
+        title="简单 Tooltip 替换"
+        initialValue=""
+        placeholder="使用简单 Tooltip 的附件按钮..."
+        render={SimpleTooltipPopover}
+      />
+      <DemoCard
+        title="自定义 Popover 内容"
+        initialValue=""
+        placeholder="显示详细信息的附件按钮..."
+        render={CustomContentPopover}
+      />
+      <DemoCard
+        title="Modal 上传向导"
+        initialValue=""
+        placeholder="点击附件按钮打开上传向导..."
+        render={ModalTriggerPopover}
+      />
+      <DemoCard
+        title="彩色样式 Popover"
+        initialValue=""
+        placeholder="彩色样式的附件按钮..."
+        render={ColorfulPopover}
+      />
+    </Space>
+  </div>
+);

--- a/docs/demos/markdownInputField/custom-send-button.tsx
+++ b/docs/demos/markdownInputField/custom-send-button.tsx
@@ -3,7 +3,7 @@ import {
   type ActionsSlotState,
 } from '@ant-design/agentic-ui';
 import { SendOutlined, SettingOutlined } from '@ant-design/icons';
-import { Button, Space, Tooltip } from 'antd';
+import { Button, Tooltip } from 'antd';
 import React, { useState } from 'react';
 
 /**
@@ -77,48 +77,19 @@ const CustomSendButtonDemo: React.FC = () => {
         这个示例展示了如何使用 <code>actionsRender</code> 属性来自定义发送按钮。
       </p>
 
-      <Space direction="vertical" size="large" style={{ width: '100%' }}>
-        <MarkdownInputField
-          value={value}
-          onChange={setValue}
-          onSend={handleSend}
-          placeholder="请输入消息内容..."
-          disabled={loading}
-          typing={loading}
-          actionsRender={customActionsRender}
-          style={{
-            minHeight: '120px',
-            maxHeight: '300px',
-          }}
-        />
-
-        <div
-          style={{
-            padding: '16px',
-            background: '#f5f5f5',
-            borderRadius: '8px',
-            fontSize: '13px',
-          }}
-        >
-          <h4 style={{ margin: '0 0 8px 0' }}>功能说明：</h4>
-          <ul style={{ margin: 0, paddingLeft: '20px' }}>
-            <li>
-              🎯 <strong>自定义发送按钮</strong>
-              ：替换默认的发送图标为带文字的按钮
-            </li>
-            <li>
-              ⚙️ <strong>添加设置按钮</strong>：在发送区域添加额外的操作按钮
-            </li>
-            <li>
-              🎨 <strong>状态响应</strong>：按钮会根据 hover、loading、disabled
-              状态变化
-            </li>
-            <li>
-              💡 <strong>提示信息</strong>：每个按钮都有相应的 Tooltip 提示
-            </li>
-          </ul>
-        </div>
-      </Space>
+      <MarkdownInputField
+        value={value}
+        onChange={setValue}
+        onSend={handleSend}
+        placeholder="请输入消息内容..."
+        disabled={loading}
+        typing={loading}
+        actionsRender={customActionsRender}
+        style={{
+          minHeight: '120px',
+          maxHeight: '300px',
+        }}
+      />
     </div>
   );
 };

--- a/docs/demos/markdownInputField/disable-hover-animation.tsx
+++ b/docs/demos/markdownInputField/disable-hover-animation.tsx
@@ -1,32 +1,51 @@
 import { MarkdownInputField } from '@ant-design/agentic-ui';
+import { Typography } from 'antd';
 import React, { useState } from 'react';
+import { pageStyle } from './_constants';
+import { useDemoSend } from './useDemoSend';
 
-/**
- * 禁用 hover 动画示例
- */
-const DisableHoverAnimationDemo: React.FC = () => {
+const { Text, Title } = Typography;
+
+export default () => {
   const [value, setValue] = useState(
     '试试将鼠标悬停在输入框上，看看是否有阴影动画效果...',
   );
+  const { handleSend, handleStop } = useDemoSend();
 
   return (
-    <div style={{ padding: '24px', maxWidth: '980px', margin: '0 auto' }}>
-      <h3>默认启用 hover 动画</h3>
-      <MarkdownInputField
-        value={value}
-        onChange={setValue}
-        placeholder="将鼠标悬停在这里，会看到阴影动画效果"
-      />
+    <div style={pageStyle}>
+      <div>
+        <Title level={5} style={{ marginTop: 0, marginBottom: 4 }}>
+          默认启用 hover 动画
+        </Title>
+        <Text type="secondary" style={{ display: 'block', marginBottom: 8 }}>
+          鼠标悬停时会出现阴影动画。
+        </Text>
+        <MarkdownInputField
+          value={value}
+          onChange={setValue}
+          onSend={handleSend}
+          onStop={handleStop}
+          placeholder="将鼠标悬停在这里，会看到阴影动画效果"
+        />
+      </div>
 
-      <h3 style={{ marginTop: '32px' }}>禁用 hover 动画</h3>
-      <MarkdownInputField
-        value={value}
-        onChange={setValue}
-        placeholder="将鼠标悬停在这里，不会看到阴影动画效果"
-        disableHoverAnimation={true}
-      />
+      <div>
+        <Title level={5} style={{ marginTop: 0, marginBottom: 4 }}>
+          禁用 hover 动画
+        </Title>
+        <Text type="secondary" style={{ display: 'block', marginBottom: 8 }}>
+          `disableHoverAnimation` 关闭悬停阴影。
+        </Text>
+        <MarkdownInputField
+          value={value}
+          onChange={setValue}
+          onSend={handleSend}
+          onStop={handleStop}
+          placeholder="将鼠标悬停在这里，不会看到阴影动画效果"
+          disableHoverAnimation
+        />
+      </div>
     </div>
   );
 };
-
-export default DisableHoverAnimationDemo;

--- a/docs/demos/markdownInputField/max-file-count-exceed.tsx
+++ b/docs/demos/markdownInputField/max-file-count-exceed.tsx
@@ -1,68 +1,48 @@
 import { MarkdownInputField } from '@ant-design/agentic-ui';
-import { Card, Space, message } from 'antd';
+import { Typography, message } from 'antd';
 import React, { useState } from 'react';
+import { mockDelete, mockUpload, pageStyle } from './_constants';
+
+const { Text, Title } = Typography;
 
 const MAX_FILE_COUNT = 3;
 
-/**
- * 文件数量超限回调 Demo
- * 配置 maxFileCount 后，当选择的文件数量超出限制时，
- * 通过 onExceedMaxCount 回调通知消费者，由消费者展示提示信息。
- */
-const MaxFileCountExceedDemo: React.FC = () => {
+export default () => {
   const [value, setValue] = useState(
     '先上传 2 个文件，再次选择 2 个文件（2+2>3），观察超限提示。',
   );
 
   return (
-    <div style={{ padding: 24 }}>
-      <Space direction="vertical" size="large" style={{ width: '100%' }}>
-        <Card size="small" title="文件数量超限回调">
-          <Space direction="vertical" style={{ width: '100%' }}>
-            <p
-              style={{
-                color: 'var(--color-gray-text-secondary)',
-                marginBottom: 8,
-              }}
-            >
-              最多 <strong>{MAX_FILE_COUNT}</strong>{' '}
-              个文件。选择文件数量超限时，会通过 <code>onExceedMaxCount</code>{' '}
-              回调弹出提示，而不是静默失败。
-            </p>
-            <MarkdownInputField
-              value={value}
-              onChange={setValue}
-              attachment={{
-                enable: true,
-                maxFileCount: MAX_FILE_COUNT,
-                allowMultiple: true,
-                onExceedMaxCount: ({
-                  maxCount,
-                  currentCount,
-                  selectedCount,
-                }) => {
-                  const remaining = maxCount - currentCount;
-                  if (remaining <= 0) {
-                    message.warning(`最多上传 ${maxCount} 个文件，已达上限`);
-                  } else {
-                    message.warning(
-                      `最多上传 ${maxCount} 个文件，还可上传 ${remaining} 个，本次选择了 ${selectedCount} 个`,
-                    );
-                  }
-                },
-                upload: async (file) => {
-                  await new Promise((r) => setTimeout(r, 600));
-                  return URL.createObjectURL(file);
-                },
-                onDelete: async () => {},
-              }}
-              placeholder="输入内容后点击附件按钮选择文件..."
-            />
-          </Space>
-        </Card>
-      </Space>
+    <div style={pageStyle}>
+      <Title level={5} style={{ marginTop: 0, marginBottom: 4 }}>
+        文件数量超限回调
+      </Title>
+      <Text type="secondary" style={{ display: 'block', marginBottom: 12 }}>
+        最多 <Text strong>{MAX_FILE_COUNT}</Text> 个文件。选择文件数量超限时会触发{' '}
+        <Text code>onExceedMaxCount</Text> 回调，由消费者展示提示，避免静默失败。
+      </Text>
+      <MarkdownInputField
+        value={value}
+        onChange={setValue}
+        attachment={{
+          enable: true,
+          maxFileCount: MAX_FILE_COUNT,
+          allowMultiple: true,
+          onExceedMaxCount: ({ maxCount, currentCount, selectedCount }) => {
+            const remaining = maxCount - currentCount;
+            if (remaining <= 0) {
+              message.warning(`最多上传 ${maxCount} 个文件，已达上限`);
+              return;
+            }
+            message.warning(
+              `最多上传 ${maxCount} 个文件，还可上传 ${remaining} 个，本次选择了 ${selectedCount} 个`,
+            );
+          },
+          upload: (file) => mockUpload(file, 600),
+          onDelete: mockDelete,
+        }}
+        placeholder="输入内容后点击附件按钮选择文件..."
+      />
     </div>
   );
 };
-
-export default MaxFileCountExceedDemo;

--- a/docs/demos/markdownInputField/max-file-size-error.tsx
+++ b/docs/demos/markdownInputField/max-file-size-error.tsx
@@ -1,55 +1,37 @@
 import { MarkdownInputField } from '@ant-design/agentic-ui';
-import { Card, Space } from 'antd';
+import { Typography } from 'antd';
 import React, { useState } from 'react';
+import { mockDelete, mockUpload, pageStyle } from './_constants';
+
+const { Text, Title } = Typography;
 
 /** 限制为 100KB，便于选择普通文件即可触发「文件超过最大值」报错 */
 const MAX_FILE_SIZE_BYTES = 100 * 1024;
-const MAX_FILE_COUNT = 2;
 
-/**
- * 文件超过最大值报错 Demo
- * 配置 maxFileSize 后，选择超过限制的文件会以 error 状态出现在附件列表中，并展示「文件大小超过 xxx KB」错误文案
- */
-const MaxFileSizeErrorDemo: React.FC = () => {
+export default () => {
   const [value, setValue] = useState(
-    '点击附件按钮选择超过 100KB 的文件，或选择超过 2 个文件，可看到超限报错展示。',
+    '点击附件按钮选择超过 100KB 的文件，可看到大小超限报错。',
   );
 
   return (
-    <div style={{ padding: 24 }}>
-      <Space direction="vertical" size="large" style={{ width: '100%' }}>
-        <Card size="small" title="文件超过最大值报错">
-          <Space direction="vertical" style={{ width: '100%' }}>
-            <p
-              style={{
-                color: 'var(--color-gray-text-secondary)',
-                marginBottom: 8,
-              }}
-            >
-              单文件最大 <strong>100KB</strong>，最多 <strong>2</strong>{' '}
-              个文件。选择超过大小的文件时，会在附件列表中显示「超过 xxx
-              KB」报错。
-            </p>
-            <MarkdownInputField
-              value={value}
-              onChange={setValue}
-              attachment={{
-                enable: true,
-                maxFileSize: MAX_FILE_SIZE_BYTES,
-                maxFileCount: MAX_FILE_COUNT,
-                upload: async (file) => {
-                  await new Promise((r) => setTimeout(r, 600));
-                  return URL.createObjectURL(file);
-                },
-                onDelete: async () => {},
-              }}
-              placeholder="输入内容后点击附件按钮选择文件..."
-            />
-          </Space>
-        </Card>
-      </Space>
+    <div style={pageStyle}>
+      <Title level={5} style={{ marginTop: 0, marginBottom: 4 }}>
+        文件超过最大值报错
+      </Title>
+      <Text type="secondary" style={{ display: 'block', marginBottom: 12 }}>
+        单文件最大 <Text strong>100KB</Text>。选择超过大小的文件时，会在附件列表中显示「超过 xxx KB」报错。
+      </Text>
+      <MarkdownInputField
+        value={value}
+        onChange={setValue}
+        attachment={{
+          enable: true,
+          maxFileSize: MAX_FILE_SIZE_BYTES,
+          upload: (file) => mockUpload(file, 600),
+          onDelete: mockDelete,
+        }}
+        placeholder="输入内容后点击附件按钮选择文件..."
+      />
     </div>
   );
 };
-
-export default MaxFileSizeErrorDemo;

--- a/docs/demos/markdownInputField/on-focus.tsx
+++ b/docs/demos/markdownInputField/on-focus.tsx
@@ -4,44 +4,42 @@ import {
 } from '@ant-design/agentic-ui';
 import { Card, Space, Tag, Typography } from 'antd';
 import React, { useCallback, useState } from 'react';
+import { pageStyle } from './_constants';
+import { useDemoSend } from './useDemoSend';
 
-const { Paragraph, Text, Title } = Typography;
+const { Text, Title } = Typography;
 
 export default () => {
   const [value, setValue] = useState('');
   const [isFocused, setIsFocused] = useState(false);
   const [focusCount, setFocusCount] = useState(0);
   const [blurCount, setBlurCount] = useState(0);
+  const { handleSend, handleStop } = useDemoSend();
 
-  const handleFocus = useCallback(
-    (
-      _value: string,
-      _schema: unknown,
-      _e: React.FocusEvent<HTMLDivElement>,
-    ) => {
-      setIsFocused(true);
-      setFocusCount((c) => c + 1);
-    },
-    [],
-  );
+  const handleFocus = useCallback<
+    NonNullable<MarkdownInputFieldProps['onFocus']>
+  >(() => {
+    setIsFocused(true);
+    setFocusCount((c) => c + 1);
+  }, []);
 
   const handleBlur = useCallback<
     NonNullable<MarkdownInputFieldProps['onBlur']>
-  >((_value, _schema, _e) => {
+  >(() => {
     setIsFocused(false);
     setBlurCount((c) => c + 1);
   }, []);
 
   return (
-    <div style={{ boxSizing: 'border-box', maxWidth: 720, padding: 12 }}>
-      <Title level={4} style={{ marginTop: 0 }}>
+    <div style={pageStyle}>
+      <Title level={5} style={{ marginTop: 0, marginBottom: 4 }}>
         onFocus / onBlur
       </Title>
-      <Paragraph type="secondary" style={{ marginBottom: 16 }}>
+      <Text type="secondary" style={{ display: 'block', marginBottom: 12 }}>
         获得或失去焦点时更新状态；可与埋点、高亮边框等逻辑联动。
-      </Paragraph>
+      </Text>
 
-      <Card size="small" style={{ marginBottom: 16 }}>
+      <Card size="small">
         <Space size="middle" wrap>
           <Text>焦点：</Text>
           <Tag color={isFocused ? 'processing' : 'default'}>
@@ -59,20 +57,9 @@ export default () => {
         placeholder="点击输入框获得焦点…"
         onFocus={handleFocus}
         onBlur={handleBlur}
-        onSend={async () => {
-          await new Promise((resolve) => setTimeout(resolve, 1000));
-        }}
+        onSend={handleSend}
+        onStop={handleStop}
       />
-
-      <Paragraph style={{ marginTop: 16, marginBottom: 0 }}>
-        <Text strong>回调参数</Text>
-      </Paragraph>
-      <ul style={{ marginTop: 8, paddingInlineStart: 20 }}>
-        <li>
-          <Text code>onFocus</Text> / <Text code>onBlur</Text>：首参为当前
-          Markdown 文本，次参为编辑器 schema，第三参为对应的原生事件
-        </li>
-      </ul>
     </div>
   );
 };

--- a/docs/demos/markdownInputField/typing-hint.tsx
+++ b/docs/demos/markdownInputField/typing-hint.tsx
@@ -1,24 +1,26 @@
 import { MarkdownInputField } from '@ant-design/agentic-ui';
 import { Space, Switch, Typography } from 'antd';
 import React, { useState } from 'react';
+import { pageStyle } from './_constants';
 
-/**
- * AI 回复中输入区内提示（typing / 发送 loading 且输入为空）
- */
-const TypingHintDemo: React.FC = () => {
+const { Text, Title } = Typography;
+
+export default () => {
   const [value, setValue] = useState('');
   const [aiReplying, setAiReplying] = useState(true);
 
   return (
-    <div style={{ padding: '24px', maxWidth: '720px', margin: '0 auto' }}>
-      <Typography.Paragraph style={{ marginBottom: 16 }}>
-        打开下方开关时，输入区为只读并显示「AI
-        正在回复」类动画提示（输入框为空时）；关闭开关后可正常输入。发送消息且{' '}
-        <Typography.Text code>onSend</Typography.Text>{' '}
-        未结束时，空输入时同样会显示该提示且为只读。
-      </Typography.Paragraph>
-      <Space style={{ marginBottom: 16 }} align="center">
-        <span>模拟 AI 正在回复（typing）</span>
+    <div style={pageStyle}>
+      <Title level={5} style={{ marginTop: 0, marginBottom: 4 }}>
+        AI 回复中的输入提示
+      </Title>
+      <Text type="secondary" style={{ display: 'block', marginBottom: 12 }}>
+        打开开关时，输入区为只读并显示「AI
+        正在回复」类动画提示（输入框为空时）；关闭后可正常输入。发送消息且
+        <Text code>onSend</Text> 未结束时，空输入同样会显示该提示且为只读。
+      </Text>
+      <Space align="center">
+        <Text>模拟 AI 正在回复（typing）</Text>
         <Switch
           checked={aiReplying}
           onChange={setAiReplying}
@@ -33,13 +35,8 @@ const TypingHintDemo: React.FC = () => {
         onSend={async () => {
           await new Promise((resolve) => setTimeout(resolve, 1200));
         }}
-        style={{
-          minHeight: '120px',
-          maxHeight: '280px',
-        }}
+        style={{ minHeight: 120, maxHeight: 280 }}
       />
     </div>
   );
 };
-
-export default TypingHintDemo;

--- a/docs/demos/markdownInputField/upload-with-response.tsx
+++ b/docs/demos/markdownInputField/upload-with-response.tsx
@@ -3,195 +3,82 @@ import { MarkdownInputField } from '@ant-design/agentic-ui';
 import { Card, Space } from 'antd';
 import React, { useState } from 'react';
 
-/**
- * uploadWithResponse 使用演示
- * 展示如何使用新的上传接口返回完整的响应对象
- */
-const UploadWithResponseDemo: React.FC = () => {
+/** 模拟一次"上传服务"返回的完整响应。20% 概率失败，便于演示错误分支。 */
+const handleUploadWithResponse = async (
+  file: AttachmentFile,
+): Promise<UploadResponse> => {
+  await new Promise((resolve) => setTimeout(resolve, 1500));
+
+  if (Math.random() > 0.8) {
+    return {
+      contentId: null,
+      errorMessage: '文件上传失败：服务器返回 500 错误',
+      fileId: '',
+      fileName: file.name,
+      fileSize: file.size,
+      fileType: file.type,
+      fileUrl: '',
+      uploadStatus: 'FAIL',
+    };
+  }
+
+  const fileId = `${file.name.replace(/\.[^/.]+$/, '')}-${Date.now()}`;
+  const ext = file.type.split('/')[1] || 'unknown';
+  return {
+    contentId: `content-${Date.now()}`,
+    errorMessage: null,
+    fileId,
+    fileName: file.name,
+    fileSize: file.size,
+    fileType: ext,
+    fileUrl: `https://example.com/files/${fileId}.${ext}`,
+    uploadStatus: 'SUCCESS',
+  };
+};
+
+export default () => {
   const [value, setValue] = useState('尝试上传文件，查看完整的上传响应信息...');
   const [fileMap, setFileMap] = useState<Map<string, AttachmentFile>>(
     new Map(),
   );
 
-  // 模拟文件上传 - 返回完整的响应对象
-  const handleUploadWithResponse = async (
-    file: AttachmentFile,
-    index: number,
-  ): Promise<UploadResponse> => {
-    console.log('上传文件:', file.name, '索引:', index);
-
-    // 模拟网络延迟
-    await new Promise((resolve) => setTimeout(resolve, 1500));
-
-    // 模拟不同的上传结果
-    const random = Math.random();
-
-    if (random > 0.8) {
-      // 20% 概率模拟上传失败
-      return {
-        contentId: null,
-        errorMessage: '文件上传失败：服务器返回 500 错误',
-        fileId: '',
-        fileName: file.name,
-        fileSize: file.size,
-        fileType: file.type,
-        fileUrl: '',
-        uploadStatus: 'FAIL',
-      };
-    }
-
-    // 80% 概率成功
-    const fileId = `${file.name.replace(/\.[^/.]+$/, '')}-${Date.now()}`;
-    return {
-      contentId: `content-${Date.now()}`,
-      errorMessage: null,
-      fileId: fileId,
-      fileName: file.name,
-      fileSize: file.size,
-      fileType: file.type.split('/')[1] || 'unknown',
-      fileUrl: `https://example.com/files/${fileId}.${file.type.split('/')[1]}`,
-      uploadStatus: 'SUCCESS',
-    };
-  };
-
-  // 处理文件映射变化
-  const handleFileMapChange = (files?: Map<string, AttachmentFile>) => {
-    if (files) {
-      setFileMap(files);
-    }
-  };
-
-  // 渲染文件信息
-  const renderFileInfo = () => {
-    if (fileMap.size === 0) return null;
-    console.log('fileMap：', fileMap);
-    const filesData = Array.from(fileMap.entries());
-
-    return (
-      <Card size="small" title="上传响应详情">
-        <pre
-          style={{
-            background: '#f5f5f5',
-            padding: 12,
-            borderRadius: 4,
-            overflow: 'auto',
-            maxHeight: 400,
-          }}
-        >
-          {JSON.stringify(filesData, null, 2)}
-        </pre>
-        打开控制台查看fileMap： “fileMap：”
-      </Card>
-    );
-  };
-
   return (
     <div style={{ padding: 24 }}>
       <h2>uploadWithResponse 使用演示</h2>
       <p>
-        使用 <code>uploadWithResponse</code>{' '}
-        接口可以返回完整的上传响应对象，包含文件ID、URL、状态等详细信息。
+        使用 <code>uploadWithResponse</code> 接口可以返回完整的上传响应对象，
+        响应数据自动存储到 <code>file.uploadResponse</code> 中。
       </p>
 
       <Space direction="vertical" size="large" style={{ width: '100%' }}>
-        {/* 基本使用 */}
-        <Card title="基本使用" size="small">
-          <Space direction="vertical" style={{ width: '100%' }}>
-            <MarkdownInputField
-              value={value}
-              onChange={setValue}
-              attachment={{
-                enable: true,
-                uploadWithResponse: handleUploadWithResponse,
-                fileMap: fileMap,
-                onFileMapChange: handleFileMapChange,
+        <MarkdownInputField
+          value={value}
+          onChange={setValue}
+          attachment={{
+            enable: true,
+            uploadWithResponse: handleUploadWithResponse,
+            fileMap,
+            onFileMapChange: (files) => files && setFileMap(files),
+          }}
+          placeholder="点击附件按钮上传文件，查看完整的响应信息..."
+        />
+
+        {fileMap.size > 0 ? (
+          <Card size="small" title="上传响应详情">
+            <pre
+              style={{
+                background: '#f5f5f5',
+                padding: 12,
+                borderRadius: 4,
+                overflow: 'auto',
+                maxHeight: 400,
               }}
-              placeholder="点击附件按钮上传文件，查看完整的响应信息..."
-            />
-
-            {fileMap.size > 0 && (
-              <div style={{ marginTop: 16 }}>{renderFileInfo()}</div>
-            )}
-          </Space>
-        </Card>
-
-        {/* 使用说明 */}
-        <Card title="使用说明" size="small">
-          <Space direction="vertical">
-            <div>
-              <strong>1. 接口定义：</strong>
-              <pre
-                style={{ background: '#f5f5f5', padding: 12, borderRadius: 4 }}
-              >
-                {`uploadWithResponse?: (
-  file: AttachmentFile,
-  index: number
-) => Promise<UploadResponse>;`}
-              </pre>
-            </div>
-
-            <div>
-              <strong>2. 返回对象 UploadResponse：</strong>
-              <pre
-                style={{ background: '#f5f5f5', padding: 12, borderRadius: 4 }}
-              >
-                {`{
-  contentId?: string | null;      // 内容ID
-  errorMessage?: string | null;   // 错误消息
-  fileId: string;                 // 文件ID
-  fileName: string;               // 文件名
-  fileSize?: number | null;       // 文件大小（字节）
-  fileType: string;               // 文件类型
-  fileUrl: string;                // 文件URL
-  uploadStatus: 'SUCCESS' | 'FAIL' | string;  // 上传状态
-}`}
-              </pre>
-            </div>
-
-            <div>
-              <strong>3. 访问响应数据：</strong>
-              <pre
-                style={{ background: '#f5f5f5', padding: 12, borderRadius: 4 }}
-              >
-                {`onFileMapChange={(fileMap) => {
-  fileMap?.forEach(file => {
-    // 访问完整的上传响应
-    const response = file.uploadResponse;
-    console.log('文件ID:', response?.fileId);
-    console.log('文件URL:', response?.fileUrl);
-    console.log('上传状态:', response?.uploadStatus);
-  });
-}}`}
-              </pre>
-            </div>
-
-            <div>
-              <strong>4. 特性：</strong>
-              <ul>
-                <li>✅ 返回完整的响应对象，包含更多元信息</li>
-                <li>✅ 响应数据自动存储在 file.uploadResponse 中</li>
-                <li>✅ 支持自定义错误消息（errorMessage）</li>
-                <li>✅ 优先级高于旧的 upload 接口</li>
-                <li>✅ 向后兼容，可与 upload 接口共存</li>
-              </ul>
-            </div>
-
-            <div>
-              <strong>5. 注意事项：</strong>
-              <ul>
-                <li>
-                  如果同时提供 uploadWithResponse 和 upload，会优先使用
-                  uploadWithResponse
-                </li>
-                <li>uploadStatus 为 'SUCCESS' 时视为上传成功</li>
-                <li>失败时可通过 errorMessage 返回具体的错误信息</li>
-              </ul>
-            </div>
-          </Space>
-        </Card>
+            >
+              {JSON.stringify(Array.from(fileMap.entries()), null, 2)}
+            </pre>
+          </Card>
+        ) : null}
       </Space>
     </div>
   );
 };
-
-export default UploadWithResponseDemo;

--- a/docs/demos/markdownInputField/useDemoSend.ts
+++ b/docs/demos/markdownInputField/useDemoSend.ts
@@ -1,5 +1,9 @@
 import { useCallback, useRef, useState } from 'react';
 
+/**
+ * 模拟一次"发送"流程：1s 延时后追加到 sentList；handleStop 通过 AbortController 中断。
+ * 当 demo 内连续触发发送时，新 controller 会替换 ref，旧的 finally 不会清空 ref，避免误清。
+ */
 export const useDemoSend = () => {
   const [sentList, setSentList] = useState<string[]>([]);
   const sendAbortRef = useRef<AbortController | null>(null);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to documentation/demo code and sample utilities, with no production logic changes. Main risk is broken demo routing/exports or minor behavioral differences in demos (upload/delete mock, send/stop handling).
> 
> **Overview**
> Refactors the `MarkdownInputField` docs demos to use a consistent layout (`pageStyle`/Typography headings) and shared helpers for attachment behavior.
> 
> Introduces `mockUpload`/`mockDelete` in `_constants.ts` to standardize simulated uploads and ensure blob URLs are revoked on delete, and updates attachment-related demos to use these helpers.
> 
> Cleans up and modernizes several demos: removes obsolete top-level re-export demo entry files, updates the e2e entry to point at `markdownInputField/basic`, simplifies `custom-send-button`, improves typing in `on-focus`, and streamlines `upload-with-response` and custom attachment popover examples via reusable `DemoCard`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8893994e08366064d628cdbcb2dbfb4f0b0dbe48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->