### PR TITLE
fix(bubble): honor WithFalse in runRender so avatarRender: false hides default avatar

### DIFF
--- a/src/Bubble/AIBubble.tsx
+++ b/src/Bubble/AIBubble.tsx
@@ -26,7 +26,14 @@ export const runRender = (
   defaultDom: React.ReactNode,
   ...rest: undefined[]
 ) => {
-  return render ? render(props, defaultDom, ...rest) : defaultDom;
+  // WithFalse：显式 false 表示关闭该插槽，不得回退到 defaultDom
+  if (render === false) {
+    return null;
+  }
+  if (typeof render === 'function') {
+    return render(props, defaultDom, ...rest);
+  }
+  return defaultDom;
 };
 
 const isSameRoleAsPrevious = (preMessage: any, originData: any) => {

--- a/src/Bubble/__tests__/AIBubble.test.tsx
+++ b/src/Bubble/__tests__/AIBubble.test.tsx
@@ -476,6 +476,52 @@ describe('AIBubble', () => {
       ).not.toBeInTheDocument();
     });
 
+    it('avatarRender 为 false 时不渲染默认头像', () => {
+      render(
+        <BubbleConfigProvide>
+          <AIBubble
+            {...defaultProps}
+            preMessage={{
+              content: 'User message',
+              createAt: 1716537500000,
+              id: '122',
+              role: 'user' as RoleType,
+              updateAt: 1716537500000,
+            }}
+            bubbleRenderConfig={{ avatarRender: false }}
+          />
+        </BubbleConfigProvide>,
+      );
+
+      expect(screen.queryByTestId('bubble-avatar')).not.toBeInTheDocument();
+      expect(screen.getByTestId('bubble-avatar-title')).toBeInTheDocument();
+    });
+
+    it('avatarRender 与 titleRender 均为 false 时不渲染 avatar-title 包装器', () => {
+      render(
+        <BubbleConfigProvide>
+          <AIBubble
+            {...defaultProps}
+            preMessage={{
+              content: 'User message',
+              createAt: 1716537500000,
+              id: '122',
+              role: 'user' as RoleType,
+              updateAt: 1716537500000,
+            }}
+            bubbleRenderConfig={{
+              avatarRender: false,
+              titleRender: false,
+            }}
+          />
+        </BubbleConfigProvide>,
+      );
+
+      expect(
+        screen.queryByTestId('bubble-avatar-title'),
+      ).not.toBeInTheDocument();
+    });
+
     it('avatarDom 或 titleDom 至少有一个存在时渲染 avatar-title 包装器', () => {
       render(
         <BubbleConfigProvide>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`BubbleRenderConfig.avatarRender` is typed as `WithFalse<...>` (function or `false`). The shared `runRender` helper used a truthy check (`render ? render(...) : defaultDom`), so `avatarRender: false` was treated like `undefined` and always fell back to the default `BubbleAvatar` DOM.

## Changes

- Update `runRender` in `AIBubble.tsx` to return `null` when the render slot is explicitly `false`, and only call the function when it is a function; otherwise keep the default DOM.
- Add regression tests for `avatarRender: false` and combined `avatarRender` / `titleRender` `false`.

## How to verify

```bash
VITEST_FULL_SUITE=1 pnpm exec vitest run src/Bubble/__tests__/AIBubble.test.tsx
```

## Notes

The same `runRender` path is used for `titleRender`, `contentRender`, `contentBeforeRender`, `contentAfterRender`, etc., so `*: false` now consistently disables that slot per the `WithFalse` contract.

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b3f1699-2c90-42db-90e1-2c9a4777c411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b3f1699-2c90-42db-90e1-2c9a4777c411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

