### PR TITLE
style(MarkdownRenderer): mark highlight border-radius 4px

### DIFF
--- a/src/MarkdownRenderer/markdownReactShared.ts
+++ b/src/MarkdownRenderer/markdownReactShared.ts
@@ -430,7 +430,7 @@ const buildEditorAlignedComponents = (
         style: {
           background: 'var(--ant-color-warning-bg, #f59e0b)',
           padding: '0.1em 0.2em',
-          borderRadius: 2,
+          borderRadius: 4,
         },
         children,
       });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the default inline style for Markdown `<mark>` elements rendered by `markdownReactShared` so `border-radius` is **4px** instead of **2px**, matching the requested visual for highlighted text (for example `==/skills==` style highlights).

## Change

- `src/MarkdownRenderer/markdownReactShared.ts`: `mark` component `style.borderRadius` `2` → `4` (React inline style numbers are pixels).

## Testing

- `pnpm test -- src/MarkdownRenderer --run` was executed locally; two failures in `MarkdownRenderer.test.tsx` (filemap placeholder assertions) appear unrelated to this one-line style change.

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f5e61b4-68ec-4dd2-938a-0e97cd251641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f5e61b4-68ec-4dd2-938a-0e97cd251641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

