### PR TITLE
fix(MarkdownEditor): parse <mark> as highlighted text in MarkdownInputField

### DIFF
--- a/src/MarkdownEditor/editor/elements/index.tsx
+++ b/src/MarkdownEditor/editor/elements/index.tsx
@@ -528,6 +528,20 @@ const MLeafComponent = (
   if (leaf.italic) {
     style.fontStyle = 'italic';
   }
+  if (leaf.mark) {
+    children = (
+      <mark
+        data-testid="markdown-mark"
+        style={{
+          background: 'var(--ant-color-warning-bg, #f59e0b)',
+          padding: '0.1em 0.2em',
+          borderRadius: 2,
+        }}
+      >
+        {children}
+      </mark>
+    );
+  }
   if (leaf.html) {
     prefixClassName = classNames(mdEditorBaseClass + '-m-html');
   }

--- a/src/MarkdownEditor/editor/parser/__tests__/parseText.test.ts
+++ b/src/MarkdownEditor/editor/parser/__tests__/parseText.test.ts
@@ -170,6 +170,11 @@ describe('parseText', () => {
       const result = applyHtmlTagsToElement({ text: 'x' }, [{ tag: 'strong' }]);
       expect(result.bold).toBe(true);
     });
+
+    it('tag 为 mark 时设置 mark', () => {
+      const result = applyHtmlTagsToElement({ text: 'hi' }, [{ tag: 'mark' }]);
+      expect(result).toEqual({ text: 'hi', mark: true });
+    });
   });
 
   describe('handleTextAndInlineElementsPure', () => {

--- a/src/MarkdownEditor/editor/parser/__tests__/parserMarkdownToSlateNode.test.ts
+++ b/src/MarkdownEditor/editor/parser/__tests__/parserMarkdownToSlateNode.test.ts
@@ -147,6 +147,31 @@ describe('parserMarkdownToSlateNode', () => {
       });
     });
 
+    it('should parse inline <mark> as highlighted leaf (not html code block)', () => {
+      const markdown =
+        'prefix <mark>/alipay-aipay-product-intro </mark> suffix';
+      const result = parserMarkdownToSlateNode(markdown);
+      expect(result.schema).toHaveLength(1);
+      expect(result.schema[0]).toMatchObject({
+        type: 'paragraph',
+        children: [
+          { text: 'prefix ' },
+          { text: '/alipay-aipay-product-intro ', mark: true },
+          { text: ' suffix' },
+        ],
+      });
+    });
+
+    it('should parse block-only <mark>...</mark> as paragraph with mark', () => {
+      const markdown = '<mark>/alipay-aipay-product-intro </mark>';
+      const result = parserMarkdownToSlateNode(markdown);
+      expect(result.schema).toHaveLength(1);
+      expect(result.schema[0]).toMatchObject({
+        type: 'paragraph',
+        children: [{ text: '/alipay-aipay-product-intro ', mark: true }],
+      });
+    });
+
     it('should handle paragraph with inline code', () => {
       const markdown = 'Some `inline code` here';
       const result = parserMarkdownToSlateNode(markdown);

--- a/src/MarkdownEditor/editor/parser/__tests__/parserSlateNodeToMarkdown.test.ts
+++ b/src/MarkdownEditor/editor/parser/__tests__/parserSlateNodeToMarkdown.test.ts
@@ -1431,6 +1431,15 @@ describe('parserSlateNodeToMarkdown - coverage', () => {
     expect(result).toContain('[^');
   });
 
+  it('should serialize mark leaf as mark HTML', () => {
+    const node = {
+      type: 'paragraph',
+      children: [{ text: '/alipay ', mark: true }],
+    };
+    const result = parserSlateNodeToMarkdown([node]);
+    expect(result).toBe('<mark>/alipay </mark>');
+  });
+
   it('should handle mixed format text with no space then next word (isMix space)', () => {
     const node = {
       type: 'paragraph',

--- a/src/MarkdownEditor/editor/parser/parse/parseHtml.ts
+++ b/src/MarkdownEditor/editor/parser/parse/parseHtml.ts
@@ -463,6 +463,37 @@ const handleBlockHtml = (
     return createMediaNodeFromElement(mediaElement);
   }
 
+  const blockOnlyMarkMatch =
+    typeof currentElement?.value === 'string' &&
+    currentElement.value.match(
+      /^\s*<mark(?:\s[^>]*)?>([\s\S]*?)<\/mark>\s*$/i,
+    );
+  if (blockOnlyMarkMatch) {
+    const innerMd = blockOnlyMarkMatch[1];
+    const applyMarkRecursive = (node: any): any => {
+      if (node && typeof node.text === 'string') {
+        return { ...node, mark: true };
+      }
+      if (node?.children && Array.isArray(node.children)) {
+        return {
+          ...node,
+          children: node.children.map(applyMarkRecursive),
+        };
+      }
+      return node;
+    };
+    if (parseMarkdownFn) {
+      const { schema: markSchema } = parseMarkdownFn(innerMd);
+      if (markSchema?.length) {
+        return markSchema.map(applyMarkRecursive);
+      }
+    }
+    return {
+      type: 'paragraph',
+      children: [{ text: innerMd, mark: true }],
+    };
+  }
+
   if (currentElement.value === '<br/>') {
     return { type: 'paragraph', children: [{ text: '' }] };
   }
@@ -718,7 +749,7 @@ const processInlineHtml = (
   }
 
   const htmlMatch = value.match(
-    /<\/?(b|i|del|font|code|span|sup|sub|strong|a)[^\n>]*?>/,
+    /<\/?(b|i|del|font|code|span|sup|sub|strong|a|mark)[^\n>]*?>/,
   );
   if (htmlMatch) {
     const [str, tag] = htmlMatch;

--- a/src/MarkdownEditor/editor/parser/parse/parseText.ts
+++ b/src/MarkdownEditor/editor/parser/parse/parseText.ts
@@ -31,6 +31,7 @@ const hasFormattingProps = (leaf: CustomLeaf): boolean => {
     leaf.bold ||
     leaf.italic ||
     leaf.strikethrough ||
+    leaf.mark ||
     leaf.url ||
     leaf.code ||
     leaf.otherProps?.finished === false
@@ -170,6 +171,9 @@ export const applyHtmlTagsToElement = (el: any, htmlTag: any[]): any => {
     }
     if (t.tag === 'a' && t?.url) {
       result.url = t?.url;
+    }
+    if (t.tag === 'mark') {
+      result.mark = true;
     }
   }
 

--- a/src/MarkdownEditor/editor/parser/parserSlateNodeToMarkdown.ts
+++ b/src/MarkdownEditor/editor/parser/parserSlateNodeToMarkdown.ts
@@ -5,7 +5,7 @@
 import { Node, Text } from 'slate';
 import stringWidth from 'string-width';
 import { debugInfo } from '../../../Utils/debugUtils';
-import { ChartNode } from '../../el';
+import type { ChartNode, CustomLeaf } from '../../el';
 import type { MarkdownEditorPlugin } from '../../plugin';
 import { getMediaType } from '../utils/dom';
 import { JINJA_DOLLAR_PLACEHOLDER } from './constants';
@@ -726,7 +726,7 @@ export const parserSlateNodeToMarkdown = (
 export const isMix = (t: Text) => {
   return (
     Object.keys(t).filter((key) =>
-      ['bold', 'code', 'italic', 'strikethrough'].includes(key),
+      ['bold', 'code', 'italic', 'strikethrough', 'mark'].includes(key),
     ).length > 1
   );
 };
@@ -754,6 +754,7 @@ const textHtml = (t: Text) => {
   if (t.strikethrough) str = `<del>${str}</del>`;
   if (t?.url) str = `<a href="${t?.url}">${str}</a>`;
   if (t?.identifier || t?.fnc) str = `[^${str}]`;
+  if ((t as CustomLeaf).mark) str = `<mark>${str}</mark>`;
   return str;
 };
 
@@ -866,6 +867,7 @@ const composeText = (t: Text, parent: any[]) => {
   if (!t.text && !t.tag) return '';
   if (
     t.highColor ||
+    (t as CustomLeaf).mark ||
     t.identifier ||
     t.fnc ||
     (t.strikethrough && (t.bold || t.italic || t.code))

--- a/src/MarkdownEditor/editor/utils/editorUtils.ts
+++ b/src/MarkdownEditor/editor/utils/editorUtils.ts
@@ -123,6 +123,7 @@ export class EditorUtils {
       leaf.code ||
       leaf.italic ||
       leaf.strikethrough ||
+      leaf.mark ||
       !!leaf?.url ||
       leaf.fnd ||
       leaf.fnc ||
@@ -222,6 +223,7 @@ export class EditorUtils {
     'italic',
     'code',
     'bold',
+    'mark',
     'color',
     'textColor',
     'highColor',

--- a/src/MarkdownEditor/el.ts
+++ b/src/MarkdownEditor/el.ts
@@ -270,6 +270,8 @@ export type CustomLeaf<T = Record<string, any>> = {
   tag?: boolean | null;
   italic?: boolean | null;
   strikethrough?: boolean | null;
+  /** 行内 `<mark>` 高亮（与 MarkdownRenderer 语义一致） */
+  mark?: boolean | null;
   color?: string;
   highColor?: string;
   url?: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`MarkdownInputField` uses the Slate `MarkdownEditor` pipeline. Inline `<mark>...</mark>` was listed as a standard HTML element but was not handled in `processInlineHtml`’s tag-stack regex (only `b|i|del|...|a`), so opening/closing tags could be emitted as literal text or, at block scope, fall through to an `html` fenced code node. Block-only `<mark>...</mark>` also hit the generic “standard HTML → code language html” path.

## Changes

- Extend inline HTML handling to include `mark` in the tag stack (same pattern as `strong`, etc.).
- For a block that consists only of `<mark>...</mark>`, parse the inner content with the normal Markdown parser and set `mark: true` on descendant text leaves (so inner `**bold**` still works).
- Add `mark?: boolean` on `CustomLeaf`, apply in `applyHtmlTagsToElement`, render in `MLeafComponent` as `<mark data-testid="markdown-mark" style="...">` (warning background, padding, `borderRadius: 2` per expected automation DOM).
- Serialize marked leaves back to `<mark>...</mark>` via `textHtml` / `composeText`, include `mark` in `isMix`, `CLEARABLE_MARKS`, and `isDirtLeaf`.

## Tests

- `parseText`: `applyHtmlTagsToElement` for `mark`.
- `parserMarkdownToSlateNode`: inline and block-only `<mark>` fixtures.
- `parserSlateNodeToMarkdown`: round-trip for a marked leaf.

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11234c85-e10f-4dec-a8e1-12afec1c74a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11234c85-e10f-4dec-a8e1-12afec1c74a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

