### PR TITLE
fix(workspace): unify flat and tree file preview/download behavior

### DIFF
--- a/src/Workspace/File/FileTree/FileTreeComponent.tsx
+++ b/src/Workspace/File/FileTree/FileTreeComponent.tsx
@@ -36,11 +36,21 @@ const walkAndIndex = (
 const resolveTreeLeafFile = (node: FileTreeNode): FileNode | null => {
   const hasChildren = Boolean(node.children && node.children.length > 0);
   const resolvedIsLeaf = node.isLeaf ?? !hasChildren;
-  if (!resolvedIsLeaf || !node.file) return null;
+  if (!resolvedIsLeaf) {
+    return null;
+  }
+
+  if (node.file !== undefined && node.file !== null) {
+    return ensureNodeWithId({
+      ...node.file,
+      name: node.file.name ?? node.name,
+      id: node.file.id ?? node.id ?? node.key,
+    });
+  }
+
   return ensureNodeWithId({
-    ...node.file,
-    name: node.file.name ?? node.name,
-    id: node.file.id ?? node.id ?? node.key,
+    name: node.name,
+    id: node.id ?? node.key,
   });
 };
 
@@ -61,10 +71,15 @@ const mapTreeToDataNodes = (
     const resolvedIsLeaf = node.isLeaf ?? !hasChildren;
 
     if (resolvedIsLeaf) {
+      const leafFile = resolveTreeLeafFile(node);
       const title =
-        node.file !== null && node.file !== undefined ? (
+        leafFile !== null ? (
           <FileTreeLeafTitle
-            node={node as FileTreeNode & { file: FileNode }}
+            node={
+              { ...node, file: leafFile } as FileTreeNode & {
+                file: FileNode;
+              }
+            }
             prefixCls={ctx.prefixCls}
             hashId={ctx.hashId}
             locale={ctx.locale}

--- a/src/Workspace/File/FileTree/FileTreeLeafTitle.tsx
+++ b/src/Workspace/File/FileTree/FileTreeLeafTitle.tsx
@@ -10,7 +10,10 @@ import React, { memo, type FC } from 'react';
 
 import { ActionIconBox } from '../../../Components/ActionIconBox';
 import type { FileNode, FileProps, FileTreeNode } from '../../types';
-import { fileTypeProcessor, isImageFile } from '../FileTypeProcessor';
+import {
+  shouldShowFileDownloadAction,
+  shouldShowFilePreviewAction,
+} from '../fileListRowActions';
 import {
   ensureNodeWithId,
   handleDefaultShare,
@@ -45,12 +48,10 @@ const FileTreeLeafTitleComponent: FC<FileTreeLeafTitleProps> = ({
   });
   const isDisabled = node.disabled === true;
 
-  const showDownloadButton = (() => {
-    if (fileWithId.canDownload !== undefined) return fileWithId.canDownload;
-    return Boolean(
-      onDownload || fileWithId.url || fileWithId.content || fileWithId.file,
-    );
-  })();
+  const showDownloadButton = shouldShowFileDownloadAction(
+    fileWithId,
+    onDownload,
+  );
 
   const handleDownload = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -78,15 +79,7 @@ const FileTreeLeafTitleComponent: FC<FileTreeLeafTitleProps> = ({
     handleDefaultShare(fileWithId);
   };
 
-  const showPreviewButton = (() => {
-    if (fileWithId.canPreview !== undefined) return fileWithId.canPreview;
-    return (
-      !!onPreview &&
-      (isImageFile(fileWithId)
-        ? !!(fileWithId.url || fileWithId.previewUrl)
-        : fileTypeProcessor.processFile(fileWithId).canPreview)
-    );
-  })();
+  const showPreviewButton = shouldShowFilePreviewAction(fileWithId, onPreview);
 
   const showShareButton = fileWithId.canShare === true;
   const showLocationButton = fileWithId.canLocate === true;

--- a/src/Workspace/File/FileTree/__tests__/FileTree.test.tsx
+++ b/src/Workspace/File/FileTree/__tests__/FileTree.test.tsx
@@ -321,6 +321,47 @@ describe('Workspace.FileTree', () => {
     );
   });
 
+  it('leaf without explicit file shares download and row preview behavior with flat list', async () => {
+    const onDownload = vi.fn();
+    const onPreview = vi.fn();
+
+    render(
+      <TestWrapper>
+        <Workspace>
+          <Workspace.FileTree
+            treeData={[
+              {
+                key: 'leaf-1',
+                name: 'orphan.md',
+                isLeaf: true,
+              },
+            ]}
+            onLoadChildren={vi.fn()}
+            onDownload={onDownload}
+            onPreview={onPreview}
+          />
+        </Workspace>
+      </TestWrapper>,
+    );
+
+    expect(screen.getByRole('button', { name: '下载' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: '预览' }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '下载' }));
+    expect(onDownload).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'leaf-1', name: 'orphan.md' }),
+    );
+
+    fireEvent.click(screen.getByText('orphan.md'));
+    await waitFor(() => {
+      expect(onPreview).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'leaf-1', name: 'orphan.md' }),
+      );
+    });
+  });
+
   it('invokes onPreview on leaf select when file is set and onFileClick omitted', async () => {
     const onPreview = vi.fn();
     const file: FileNode = {

--- a/src/Workspace/File/components/FileItem.tsx
+++ b/src/Workspace/File/components/FileItem.tsx
@@ -14,7 +14,11 @@ import type {
   FileRenderContext,
 } from '../../types';
 import { formatFileSize, formatLastModified } from '../../utils';
-import { fileTypeProcessor, isImageFile } from '../FileTypeProcessor';
+import { fileTypeProcessor } from '../FileTypeProcessor';
+import {
+  shouldShowFileDownloadAction,
+  shouldShowFilePreviewAction,
+} from '../fileListRowActions';
 import {
   ensureNodeWithId,
   handleDefaultShare,
@@ -78,12 +82,10 @@ const FileItemComponent: FC<FileItemProps> = ({
     }
   };
 
-  const showDownloadButton = (() => {
-    if (fileWithId.canDownload !== undefined) return fileWithId.canDownload;
-    return Boolean(
-      onDownload || fileWithId.url || fileWithId.content || fileWithId.file,
-    );
-  })();
+  const showDownloadButton = shouldShowFileDownloadAction(
+    fileWithId,
+    onDownload,
+  );
 
   const handleDownload = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -111,15 +113,7 @@ const FileItemComponent: FC<FileItemProps> = ({
     handleDefaultShare(fileWithId);
   };
 
-  const showPreviewButton = (() => {
-    if (fileWithId.canPreview !== undefined) return fileWithId.canPreview;
-    return (
-      onPreview &&
-      (isImageFile(fileWithId)
-        ? !!(fileWithId.url || fileWithId.previewUrl)
-        : fileTypeProcessor.processFile(fileWithId).canPreview)
-    );
-  })();
+  const showPreviewButton = shouldShowFilePreviewAction(fileWithId, onPreview);
 
   const showShareButton = fileWithId.canShare === true;
   const showLocationButton = fileWithId.canLocate === true;

--- a/src/Workspace/File/fileListRowActions.ts
+++ b/src/Workspace/File/fileListRowActions.ts
@@ -1,0 +1,33 @@
+import type { FileNode, FileProps } from '../types';
+import { fileTypeProcessor, isImageFile } from './FileTypeProcessor';
+
+/**
+ * 平铺列表与文件树叶子共用：是否展示下载操作（与 {@link FileItem} 行为一致）
+ */
+export const shouldShowFileDownloadAction = (
+  file: FileNode,
+  onDownload?: (f: FileNode) => void,
+): boolean => {
+  if (file.canDownload !== undefined) {
+    return file.canDownload;
+  }
+  return Boolean(onDownload || file.url || file.content || file.file);
+};
+
+/**
+ * 平铺列表与文件树叶子共用：是否展示预览操作（与 {@link FileItem} 行为一致）
+ */
+export const shouldShowFilePreviewAction = (
+  file: FileNode,
+  onPreview?: FileProps['onPreview'],
+): boolean => {
+  if (file.canPreview !== undefined) {
+    return file.canPreview;
+  }
+  return Boolean(
+    onPreview &&
+    (isImageFile(file)
+      ? !!(file.url || file.previewUrl)
+      : fileTypeProcessor.processFile(file).canPreview),
+  );
+};

--- a/src/Workspace/types.ts
+++ b/src/Workspace/types.ts
@@ -593,7 +593,7 @@ export interface FileTreeNode {
   name: string;
   /**
    * 叶子节点对应的文件数据（可选）
-   * @description 传入后可在树行展示预览/下载等操作，并与 {@link FileTreeProps} 的 `onPreview` / `onDownload` 等配合；未传时行为与仅展示名称的叶子一致
+   * @description 未传时由 `name` 与 `id`/`key` 合成与平铺列表一致的 {@link FileNode}，预览/下载按钮与选中行为与 {@link FileItem} 对齐；传入后与 {@link FileTreeProps} 的 `onPreview` / `onDownload` 等配合
    */
   file?: FileNode;
   /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Workspace 文件面板的平铺列表（`FileItem`）与树模式叶子（`FileTreeLeafTitle`）此前各自实现预览/下载按钮是否展示的逻辑，且树节点未传 `file` 时仅渲染纯文本，无法与平铺项对齐。

## Changes

- 新增 `fileListRowActions.ts`，提供 `shouldShowFileDownloadAction` 与 `shouldShowFilePreviewAction`，供列表与树叶子共用。
- `FileTreeComponent` 在叶子未显式传入 `file` 时，用 `name` 与 `id`/`key` 合成 `FileNode`，并始终走 `FileTreeLeafTitle`，使选中、`onPreview`/`onDownload` 与 `FileItem` 一致。
- 更新 `FileTreeNode.file` 的 JSDoc说明。
- 补充单元测试。

## Testing

- `pnpm exec vitest run src/Workspace/File/FileTree/__tests__/FileTree.test.tsx`

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9328519-3ebe-4f97-b65e-5a25ca6ed37f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9328519-3ebe-4f97-b65e-5a25ca6ed37f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

