### PR TITLE
fix(security): 非法 HTML URL 与含 on* 事件的媒体链接降级为纯文本

### DIFF
--- a/src/MarkdownEditor/__tests__/scenarios/markdownToHtml.safe.test.tsx
+++ b/src/MarkdownEditor/__tests__/scenarios/markdownToHtml.safe.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+﻿import { describe, expect, it } from 'vitest';
 import {
   markdownToHtml,
   markdownToHtmlSync,
@@ -155,11 +155,11 @@ Empty code: \`\`
         "<code>&#x3C;script>alert('xss')&#x3C;/script></code>",
       );
 
-      // 验证JavaScript链接被过滤
-      expect(html).not.toContain('javascript:alert');
-
-      // 验证img上的onerror事件被移除
-      expect(html).not.toContain('onerror');
+      // javascript: 链接与含 onerror 的 img 应降级为纯文本，不渲染为可点击/可执行的标签
+      expect(html).not.toMatch(/<a[\s>]/i);
+      expect(html).not.toMatch(/<img[\s>]/i);
+      expect(html).toMatch(/&#x3C;a|&lt;a/i);
+      expect(html).toMatch(/&#x3C;img|&lt;img/i);
 
       // 验证代码块中的内容被安全显示
       // 代码块中的内容被HTML转义，格式可能为 &#x26;lt; 或 &lt;

--- a/src/MarkdownEditor/editor/elements/Media/ReadonlyMedia.tsx
+++ b/src/MarkdownEditor/editor/elements/Media/ReadonlyMedia.tsx
@@ -1,10 +1,14 @@
-import { LoadingOutlined } from '@ant-design/icons';
+﻿import { LoadingOutlined } from '@ant-design/icons';
 import { Skeleton } from 'antd';
 import React, { useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import { useRefFunction } from '../../../../Hooks/useRefFunction';
 import { ElementProps, MediaNode } from '../../../el';
 import { MediaErrorLink } from '../../components/MediaErrorLink';
 import { useGetSetState } from '../../utils';
+import {
+  shouldRenderUrlAsPlainText,
+  UNSAFE_URL_PLAIN_TEXT_STYLE,
+} from '../../../../Utils/htmlUrlSafety';
 import { getMediaType } from '../../utils/dom';
 import { ReadonlyImage } from '../Image';
 
@@ -50,6 +54,10 @@ export const ReadonlyMedia: React.FC<ElementProps<MediaNode>> = React.memo(
       url: '',
       type: getMediaType(element?.url, element.alt),
     });
+
+    const unsafeUrlPlainText = element?.url
+      ? shouldRenderUrlAsPlainText(element.url)
+      : false;
 
     // 如果 finished 为 false，设置 5 秒超时，超时后显示为文本
     useEffect(() => {
@@ -409,6 +417,26 @@ export const ReadonlyMedia: React.FC<ElementProps<MediaNode>> = React.memo(
       element.poster,
       state().loadSuccess,
     ]);
+
+    if (unsafeUrlPlainText && element?.url) {
+      return (
+        <div {...attributes}>
+          <div
+            data-be="media"
+            data-testid="media-unsafe-url-plain-text"
+            style={{
+              width: '100%',
+              maxWidth: '100%',
+              boxSizing: 'border-box',
+            }}
+            contentEditable={false}
+          >
+            <span style={UNSAFE_URL_PLAIN_TEXT_STYLE}>{element.url}</span>
+            <div style={{ display: 'none' }}>{children}</div>
+          </div>
+        </div>
+      );
+    }
 
     return (
       <div {...attributes}>

--- a/src/MarkdownEditor/editor/elements/Media/index.tsx
+++ b/src/MarkdownEditor/editor/elements/Media/index.tsx
@@ -1,4 +1,4 @@
-import { DeleteFilled, EyeOutlined, LoadingOutlined } from '@ant-design/icons';
+﻿import { DeleteFilled, EyeOutlined, LoadingOutlined } from '@ant-design/icons';
 import { Modal, Popover, Skeleton } from 'antd';
 import React, {
   useContext,
@@ -21,6 +21,10 @@ import { AvatarList } from '../../components/ContributorAvatar';
 import { MediaErrorLink } from '../../components/MediaErrorLink';
 import { useEditorStore } from '../../store';
 import { useGetSetState } from '../../utils';
+import {
+  shouldRenderUrlAsPlainText,
+  UNSAFE_URL_PLAIN_TEXT_STYLE,
+} from '../../../../Utils/htmlUrlSafety';
 import { getMediaType } from '../../utils/dom';
 import { ReadonlyImage } from '../Image';
 
@@ -230,6 +234,10 @@ export function Media({
     if (!markdownEditorRef.current) return;
     Transforms.setNodes(markdownEditorRef.current, attr, { at: path });
   });
+
+  const unsafeUrlPlainText = element?.url
+    ? shouldRenderUrlAsPlainText(element.url)
+    : false;
 
   // 如果 finished 为 false，设置 5 秒超时，超时后显示为文本
   useEffect(() => {
@@ -628,6 +636,26 @@ export function Media({
     showAsText,
     (element as any)?.rawMarkdown,
   ]);
+
+  if (unsafeUrlPlainText && element?.url) {
+    return (
+      <div {...attributes}>
+        <div
+          data-be="media"
+          data-testid="media-unsafe-url-plain-text"
+          style={{
+            width: '100%',
+            maxWidth: '100%',
+            boxSizing: 'border-box',
+          }}
+          contentEditable={false}
+        >
+          <span style={UNSAFE_URL_PLAIN_TEXT_STYLE}>{element.url}</span>
+          <div style={{ display: 'none' }}>{children}</div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div {...attributes}>

--- a/src/MarkdownRenderer/markdownReactShared.ts
+++ b/src/MarkdownRenderer/markdownReactShared.ts
@@ -1,4 +1,4 @@
-import { Checkbox, Image } from 'antd';
+﻿import { Checkbox, Image } from 'antd';
 import { toJsxRuntime } from 'hast-util-to-jsx-runtime';
 import React from 'react';
 import { Fragment, jsx, jsxs } from 'react/jsx-runtime';
@@ -11,6 +11,10 @@ import type {
 import type { MarkdownEditorProps } from '../MarkdownEditor/types';
 import { ToolUseBarThink } from '../ToolUseBarThink';
 import { debugInfo } from '../Utils/debugUtils';
+import {
+  shouldRenderUrlAsPlainText,
+  UNSAFE_URL_PLAIN_TEXT_STYLE,
+} from '../Utils/htmlUrlSafety';
 import {
   FncRefForMarkdown,
   extractFootnoteRefFromSupChildren,
@@ -355,6 +359,14 @@ const buildEditorAlignedComponents = (
 
     a: (props: any) => {
       const { node, href, onClick: _origOnClick, ...rest } = props;
+      if (shouldRenderUrlAsPlainText(href || '')) {
+        return jsx('span' as any, {
+          ...rest,
+          'data-testid': 'markdown-unsafe-url-plain-text',
+          style: UNSAFE_URL_PLAIN_TEXT_STYLE,
+          children: href,
+        });
+      }
       const openInNewTab = linkConfig?.openInNewTab !== false;
       const defaultDom = jsx('a' as any, {
         ...rest,
@@ -502,6 +514,14 @@ const buildEditorAlignedComponents = (
 
     img: (props: any) => {
       const { node, src, alt, width, height, ...rest } = props;
+      if (shouldRenderUrlAsPlainText(src || '')) {
+        return jsx('span' as any, {
+          ...rest,
+          'data-testid': 'markdown-unsafe-url-plain-text',
+          style: UNSAFE_URL_PLAIN_TEXT_STYLE,
+          children: src,
+        });
+      }
       const imgWidth = width ? Number(width) || width : 400;
       const defaultDom = jsx('div' as any, {
         'data-be': 'image',

--- a/src/Utils/__tests__/htmlUrlSafety.test.ts
+++ b/src/Utils/__tests__/htmlUrlSafety.test.ts
@@ -1,0 +1,76 @@
+﻿import { describe, expect, it } from 'vitest';
+import {
+  hasDangerousEventHandlers,
+  looksLikeHtmlSnippet,
+  serializeHastElement,
+  shouldElementRenderAsPlainText,
+  shouldRenderUrlAsPlainText,
+} from '../htmlUrlSafety';
+
+describe('htmlUrlSafety', () => {
+  describe('shouldRenderUrlAsPlainText', () => {
+    it('应将含 onerror 的 HTML 片段识别为纯文本', () => {
+      expect(
+        shouldRenderUrlAsPlainText('<img src=x onerror=alert(1)>'),
+      ).toBe(true);
+    });
+
+    it('应将含 onload 的字符串识别为纯文本', () => {
+      expect(shouldRenderUrlAsPlainText('<body onload=alert(1)>')).toBe(true);
+    });
+
+    it('应将 javascript: URL 识别为纯文本', () => {
+      expect(shouldRenderUrlAsPlainText('javascript:alert(1)')).toBe(true);
+    });
+
+    it('应允许正常 https URL', () => {
+      expect(
+        shouldRenderUrlAsPlainText('https://example.com/img.png'),
+      ).toBe(false);
+    });
+  });
+
+  describe('shouldElementRenderAsPlainText', () => {
+    it('img 含 onerror 时应降级', () => {
+      expect(
+        shouldElementRenderAsPlainText({
+          type: 'element',
+          tagName: 'img',
+          properties: { src: 'x', onerror: 'alert(1)' },
+        }),
+      ).toBe(true);
+    });
+
+    it('div 含 onclick 时不应降级（仅剥离属性）', () => {
+      expect(
+        shouldElementRenderAsPlainText({
+          type: 'element',
+          tagName: 'div',
+          properties: { onclick: 'alert(1)' },
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('serializeHastElement', () => {
+    it('应序列化 void 标签', () => {
+      expect(
+        serializeHastElement({
+          tagName: 'img',
+          properties: { src: 'x', onerror: 'alert(1)' },
+        }),
+      ).toBe('<img src="x" onerror="alert(1)">');
+    });
+  });
+
+  describe('hasDangerousEventHandlers / looksLikeHtmlSnippet', () => {
+    it('应检测 onerror', () => {
+      expect(hasDangerousEventHandlers('onerror=alert(1)')).toBe(true);
+    });
+
+    it('应检测 HTML 片段', () => {
+      expect(looksLikeHtmlSnippet('<img src=x>')).toBe(true);
+      expect(looksLikeHtmlSnippet('https://a.com')).toBe(false);
+    });
+  });
+});

--- a/src/Utils/__tests__/rehypeSanitizeUserHtml.test.ts
+++ b/src/Utils/__tests__/rehypeSanitizeUserHtml.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+﻿import { describe, expect, it } from 'vitest';
 import {
   markdownToHtml,
   markdownToHtmlSync,
@@ -97,18 +97,20 @@ describe('rehypeSanitizeUserHtml', () => {
       expect(result).toContain('Safe');
     });
 
-    it('应移除 img 上的 onerror 属性', async () => {
+    it('应将含 onerror 的 img 降级为纯文本', async () => {
       const result = await markdownToHtml('<img src="x" onerror="alert(1)">');
-      expect(result).toContain('<img src="x"');
-      expect(result).not.toContain('onerror');
+      expect(result).not.toMatch(/<img[\s>]/i);
+      expect(result).toMatch(/&#x3C;img|&lt;img/i);
+      expect(result).toMatch(/onerror|onError/i);
     });
 
-    it('应移除 javascript: URL', async () => {
+    it('应将 javascript: 链接降级为纯文本', async () => {
       const result = await markdownToHtml(
         '<a href="javascript:alert(1)">link</a>',
       );
-      expect(result).not.toContain('javascript:');
-      expect(result).toContain('link');
+      expect(result).not.toMatch(/<a[\s>]/i);
+      expect(result).toContain('javascript:');
+      expect(result).toMatch(/&#x3C;a|&lt;a/i);
     });
   });
 

--- a/src/Utils/htmlUrlSafety.ts
+++ b/src/Utils/htmlUrlSafety.ts
@@ -1,0 +1,141 @@
+﻿import type { CSSProperties } from 'react';
+
+/** 含 on* 事件处理器（onerror、onload 等） */
+export const DANGEROUS_EVENT_HANDLER_PATTERN = /\bon\w+\s*=/i;
+
+/** 非法 / 危险 URL 降级为纯文本时的展示样式 */
+export const UNSAFE_URL_PLAIN_TEXT_STYLE: CSSProperties = {
+  display: 'inline-block',
+  padding: '8px 12px',
+  border: '1px solid #d9d9d9',
+  borderRadius: '4px',
+  color: 'rgba(0, 0, 0, 0.65)',
+  wordBreak: 'break-all',
+  whiteSpace: 'pre-wrap',
+  fontFamily: 'monospace',
+  fontSize: '0.9em',
+  maxWidth: '100%',
+  boxSizing: 'border-box',
+};
+
+export const DANGEROUS_URL_SCHEMES = ['javascript:', 'vbscript:'] as const;
+
+/** 携带 href/src 等 URL 且不宜解包为纯文本的媒体/链接标签 */
+const PLAIN_TEXT_ELEMENT_TAGS = new Set([
+  'a',
+  'audio',
+  'embed',
+  'iframe',
+  'img',
+  'object',
+  'source',
+  'svg',
+  'video',
+]);
+
+const HTML_SNIPPET_PATTERN = /<\s*\/?\s*[a-z][\w-]*[^>]*>/i;
+
+const VOID_HTML_TAGS = new Set([
+  'area',
+  'base',
+  'br',
+  'col',
+  'embed',
+  'hr',
+  'img',
+  'input',
+  'link',
+  'meta',
+  'param',
+  'source',
+  'track',
+  'wbr',
+]);
+
+export const hasDangerousEventHandlers = (value: string): boolean =>
+  DANGEROUS_EVENT_HANDLER_PATTERN.test(value);
+
+export const hasDangerousUrlScheme = (value: string): boolean => {
+  const lower = value.toLowerCase().trimStart();
+  return DANGEROUS_URL_SCHEMES.some((scheme) => lower.startsWith(scheme));
+};
+
+/** 字符串是否形如 HTML 片段（非法 URL，如 `<img src=x onerror=...>`） */
+export const looksLikeHtmlSnippet = (value: string): boolean =>
+  HTML_SNIPPET_PATTERN.test(value.trim());
+
+/**
+ * URL / 属性值是否应降级为纯文本展示（非法 HTML URL 或含事件处理器）。
+ */
+export const shouldRenderUrlAsPlainText = (url: string): boolean => {
+  if (!url || typeof url !== 'string') return false;
+  const trimmed = url.trim();
+  if (!trimmed) return false;
+  if (hasDangerousEventHandlers(trimmed)) return true;
+  if (hasDangerousUrlScheme(trimmed)) return true;
+  if (looksLikeHtmlSnippet(trimmed)) return true;
+  return false;
+};
+
+const URL_ATTRIBUTE_KEYS = new Set(['href', 'src', 'xlink:href', 'poster']);
+
+const formatAttrValue = (value: unknown): string => {
+  if (Array.isArray(value)) return value.map(String).join(' ');
+  return String(value);
+};
+
+/** 将 hast element 序列化为原始 HTML 字符串（用于纯文本降级展示） */
+export const serializeHastElement = (node: {
+  tagName: string;
+  properties?: Record<string, unknown>;
+  children?: Array<{ type: string; value?: string; tagName?: string }>;
+}): string => {
+  const tag = node.tagName;
+  const props = node.properties || {};
+  const attrPart = Object.entries(props)
+    .map(([key, value]) => `${key}="${formatAttrValue(value)}"`)
+    .join(' ');
+  const attrStr = attrPart ? ` ${attrPart}` : '';
+
+  if (VOID_HTML_TAGS.has(tag)) {
+    return `<${tag}${attrStr}>`;
+  }
+
+  const inner = (node.children || [])
+    .map((child) => {
+      if (child.type === 'text') return child.value ?? '';
+      if (child.type === 'element' && child.tagName) {
+        return serializeHastElement(child as Parameters<typeof serializeHastElement>[0]);
+      }
+      return '';
+    })
+    .join('');
+
+  return `<${tag}${attrStr}>${inner}</${tag}>`;
+};
+
+const elementHasDangerousProperties = (
+  properties: Record<string, unknown>,
+): boolean => {
+  if (!properties) return false;
+  for (const [key, value] of Object.entries(properties)) {
+    if (key.startsWith('on')) return true;
+    if (typeof value !== 'string') continue;
+    if (hasDangerousUrlScheme(value)) return true;
+    if (URL_ATTRIBUTE_KEYS.has(key) && shouldRenderUrlAsPlainText(value)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+/** hast 元素是否应整体降级为纯文本（而非仅剥离危险属性） */
+export const shouldElementRenderAsPlainText = (node: {
+  type?: string;
+  tagName?: string;
+  properties?: Record<string, unknown>;
+}): boolean => {
+  if (node.type !== 'element' || !node.tagName) return false;
+  if (!PLAIN_TEXT_ELEMENT_TAGS.has(node.tagName)) return false;
+  return elementHasDangerousProperties(node.properties || {});
+};

--- a/src/Utils/rehypeSanitizeUserHtml.ts
+++ b/src/Utils/rehypeSanitizeUserHtml.ts
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * rehype 插件：清理用户输入中的危险 HTML，防止页面布局错乱和 XSS 攻击。
  *
  * 在 rehypeRaw 之后使用，对 hast 树执行：
@@ -6,8 +6,15 @@
  * 2. 完全移除危险元素（script、style 等）及其子节点
  * 3. 解包结构性元素（html、head、body 等），保留子节点
  * 4. 保留 GFM 任务列表的 input[type=checkbox]，移除其他 input
- * 5. 清理所有元素的危险属性（on* 事件、javascript: URL）
+ * 5. 媒体/链接类元素若含 on* 事件、javascript: URL 或非法 HTML URL，降级为纯文本
+ * 6. 其余元素仅清理危险属性（on* 事件、javascript: URL）
  */
+
+import {
+  hasDangerousUrlScheme,
+  serializeHastElement,
+  shouldElementRenderAsPlainText,
+} from './htmlUrlSafety';
 
 /** 应完全移除（含子节点）的危险 HTML 标签 */
 const STRIP_ELEMENTS = new Set([
@@ -40,8 +47,6 @@ const UNWRAP_ELEMENTS = new Set([
   'legend',
 ]);
 
-const DANGEROUS_URL_SCHEMES = ['javascript:', 'vbscript:'];
-
 const sanitizeElementProperties = (
   properties: Record<string, unknown>,
 ): void => {
@@ -52,11 +57,8 @@ const sanitizeElementProperties = (
       continue;
     }
     const value = properties[key];
-    if (typeof value === 'string') {
-      const lower = value.toLowerCase().trimStart();
-      if (DANGEROUS_URL_SCHEMES.some((s) => lower.startsWith(s))) {
-        delete properties[key];
-      }
+    if (typeof value === 'string' && hasDangerousUrlScheme(value)) {
+      delete properties[key];
     }
   }
 };
@@ -79,6 +81,10 @@ const sanitizeHastNode = (node: any): any => {
     // input: 保留 GFM 任务列表 checkbox，移除其他 input
     if (node.tagName === 'input' && !isTaskListCheckbox(node)) {
       return null;
+    }
+
+    if (shouldElementRenderAsPlainText(node)) {
+      return { type: 'text', value: serializeHastElement(node) };
     }
 
     sanitizeElementProperties(node.properties);


### PR DESCRIPTION
防止 <img onerror>、javascript: 等以可执行标签渲染，在 rehype 清理、Markdown 渲染与编辑器媒体组件中统一展示为转义后的字面量。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HTML sanitization and runtime rendering for links/media, which can affect how user content displays and is security-sensitive (XSS prevention). Scope is contained but touches core markdown/Slate rendering paths.
> 
> **Overview**
> Hardens markdown/HTML handling by **downgrading unsafe link/media URLs** (e.g. `javascript:` schemes, strings that look like HTML snippets, or values containing `on*=` handlers) to **escaped plain text** instead of rendering clickable `<a>` or executable media tags.
> 
> Adds shared `htmlUrlSafety` utilities and wires them into `rehypeSanitizeUserHtml`, the Markdown React renderer (`a`/`img`), and both editor media components (`Media`/`ReadonlyMedia`) so unsafe URLs consistently render as styled literal text. Updates and adds tests to assert the new downgrade behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c4061cfd40c2725c71acd81e99c3051ef19dc8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->