### PR TITLE
refactor(MarkdownEditor): align inline code/tag plugin with Slate editor overrides

### DIFF
--- a/src/MarkdownEditor/editor/plugins/__tests__/codeTagLeafBehavior.test.ts
+++ b/src/MarkdownEditor/editor/plugins/__tests__/codeTagLeafBehavior.test.ts
@@ -1,0 +1,62 @@
+import { createEditor, Transforms } from 'slate';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  handleTagRemoveTextOperation,
+  moveSelectionOutOfCodeTagLeaf,
+  tryInsertTextOutsideTagOnDoubleSpace,
+} from '../codeTagLeafBehavior';
+
+const tagNode = (text: string) => ({ text, tag: true, code: true });
+
+describe('codeTagLeafBehavior', () => {
+  it('handleTagRemoveTextOperation 空 tag 转为普通文本', () => {
+    const editor = createEditor();
+    editor.children = [{ type: 'paragraph', children: [tagNode('  ')] }];
+    const apply = vi.fn();
+    const setNodesSpy = vi.spyOn(Transforms, 'setNodes');
+
+    const handled = handleTagRemoveTextOperation(
+      editor,
+      { type: 'remove_text', path: [0, 0], offset: 0, text: ' ' },
+      apply,
+    );
+
+    expect(handled).toBe(true);
+    expect(setNodesSpy).toHaveBeenCalled();
+    expect(apply).not.toHaveBeenCalled();
+    setNodesSpy.mockRestore();
+  });
+
+  it('moveSelectionOutOfCodeTagLeaf 在 code 叶子上移出选区', () => {
+    const editor = createEditor();
+    editor.children = [
+      {
+        type: 'paragraph',
+        children: [{ text: 'x', code: true }, { text: ' y' }],
+      },
+    ];
+    editor.selection = {
+      anchor: { path: [0, 0], offset: 1 },
+      focus: { path: [0, 0], offset: 1 },
+    };
+
+    const selectSpy = vi.spyOn(Transforms, 'select');
+    expect(moveSelectionOutOfCodeTagLeaf(editor)).toBe(true);
+    expect(selectSpy).toHaveBeenCalled();
+    selectSpy.mockRestore();
+  });
+
+  it('tryInsertTextOutsideTagOnDoubleSpace 第二个空格插入到节点外', () => {
+    const editor = createEditor();
+    editor.children = [{ type: 'paragraph', children: [tagNode('a ')] }];
+    editor.selection = {
+      anchor: { path: [0, 0], offset: 2 },
+      focus: { path: [0, 0], offset: 2 },
+    };
+
+    const insertSpy = vi.spyOn(Transforms, 'insertNodes');
+    expect(tryInsertTextOutsideTagOnDoubleSpace(editor, ' ')).toBe(true);
+    expect(insertSpy).toHaveBeenCalledWith(editor, [{ text: ' ' }]);
+    insertSpy.mockRestore();
+  });
+});

--- a/src/MarkdownEditor/editor/plugins/__tests__/withCodeTagPlugin.test.ts
+++ b/src/MarkdownEditor/editor/plugins/__tests__/withCodeTagPlugin.test.ts
@@ -108,10 +108,10 @@ describe('withCodeTagPlugin', () => {
   // ================================================================
 
   describe('insert_text', () => {
-    it('空 tag 输入第一个字符时直接 apply（修复崩溃）', () => {
+    it('空 tag 输入第一个字符时走默认 insertText', () => {
       const base = createEditor();
-      const originalApply = vi.fn();
-      base.apply = originalApply;
+      const originalInsertText = vi.fn();
+      base.insertText = originalInsertText;
       const editor = withCodeTagPlugin(base);
       editor.children = [para(tagNode('$ ', { triggerText: '$' }))];
       editor.selection = {
@@ -119,22 +119,15 @@ describe('withCodeTagPlugin', () => {
         focus: { path: [0, 0], offset: 2 },
       };
 
-      editor.apply({
-        type: 'insert_text',
-        path: [0, 0],
-        offset: 2,
-        text: '任',
-      });
+      editor.insertText('任');
 
-      expect(originalApply).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'insert_text', text: '任' }),
-      );
+      expect(originalInsertText).toHaveBeenCalledWith('任');
     });
 
-    it('空 tag 输入多个字符时直接 apply', () => {
+    it('空 tag 输入多个字符时走默认 insertText', () => {
       const base = createEditor();
-      const originalApply = vi.fn();
-      base.apply = originalApply;
+      const originalInsertText = vi.fn();
+      base.insertText = originalInsertText;
       const editor = withCodeTagPlugin(base);
       editor.children = [para(tagNode('  '))];
       editor.selection = {
@@ -142,16 +135,9 @@ describe('withCodeTagPlugin', () => {
         focus: { path: [0, 0], offset: 2 },
       };
 
-      editor.apply({
-        type: 'insert_text',
-        path: [0, 0],
-        offset: 2,
-        text: 'hello',
-      });
+      editor.insertText('hello');
 
-      expect(originalApply).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'insert_text', text: 'hello' }),
-      );
+      expect(originalInsertText).toHaveBeenCalledWith('hello');
     });
 
     it('tag 末尾连续两个空格时跳出到节点外', () => {
@@ -164,12 +150,7 @@ describe('withCodeTagPlugin', () => {
 
       const insertNodesSpy = vi.spyOn(Transforms, 'insertNodes');
 
-      editor.apply({
-        type: 'insert_text',
-        path: [0, 0],
-        offset: 4,
-        text: ' ',
-      });
+      editor.insertText(' ');
 
       expect(insertNodesSpy).toHaveBeenCalledWith(editor, [{ text: ' ' }]);
       insertNodesSpy.mockRestore();
@@ -177,8 +158,8 @@ describe('withCodeTagPlugin', () => {
 
     it('tag 末尾第一个空格不跳出', () => {
       const base = createEditor();
-      const originalApply = vi.fn();
-      base.apply = originalApply;
+      const originalInsertText = vi.fn();
+      base.insertText = originalInsertText;
       const editor = withCodeTagPlugin(base);
       editor.children = [para(tagNode('abc'))];
       editor.selection = {
@@ -186,22 +167,15 @@ describe('withCodeTagPlugin', () => {
         focus: { path: [0, 0], offset: 3 },
       };
 
-      editor.apply({
-        type: 'insert_text',
-        path: [0, 0],
-        offset: 3,
-        text: ' ',
-      });
+      editor.insertText(' ');
 
-      expect(originalApply).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'insert_text', text: ' ' }),
-      );
+      expect(originalInsertText).toHaveBeenCalledWith(' ');
     });
 
-    it('非 tag 节点的 insert_text 透传', () => {
+    it('非 tag 节点的 insertText 透传', () => {
       const base = createEditor();
-      const originalApply = vi.fn();
-      base.apply = originalApply;
+      const originalInsertText = vi.fn();
+      base.insertText = originalInsertText;
       const editor = withCodeTagPlugin(base);
       editor.children = [para({ text: 'hello' })];
       editor.selection = {
@@ -209,25 +183,18 @@ describe('withCodeTagPlugin', () => {
         focus: { path: [0, 0], offset: 5 },
       };
 
-      editor.apply({
-        type: 'insert_text',
-        path: [0, 0],
-        offset: 5,
-        text: 'x',
-      });
+      editor.insertText('x');
 
-      expect(originalApply).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'insert_text' }),
-      );
+      expect(originalInsertText).toHaveBeenCalledWith('x');
     });
   });
 
   // ================================================================
-  // split_node
+  // split_node（不再在 apply 层拦截；用户回车由 insertBreak 移出 tag/code）
   // ================================================================
 
   describe('split_node', () => {
-    it('tag 节点吞掉 split_node（禁止回车拆分）', () => {
+    it('tag 与 code 叶子的 split_node 透传 apply', () => {
       const base = createEditor();
       const originalApply = vi.fn();
       base.apply = originalApply;
@@ -241,24 +208,7 @@ describe('withCodeTagPlugin', () => {
         properties: {},
       });
 
-      expect(originalApply).not.toHaveBeenCalled();
-    });
-
-    it('code 节点吞掉 split_node', () => {
-      const base = createEditor();
-      const originalApply = vi.fn();
-      base.apply = originalApply;
-      const editor = withCodeTagPlugin(base);
-      editor.children = [para({ text: 'x', code: true })];
-
-      editor.apply({
-        type: 'split_node',
-        path: [0, 0],
-        position: 1,
-        properties: {},
-      });
-
-      expect(originalApply).not.toHaveBeenCalled();
+      expect(originalApply).toHaveBeenCalled();
     });
 
     it('普通节点的 split_node 透传', () => {

--- a/src/MarkdownEditor/editor/plugins/codeTagLeafBehavior.ts
+++ b/src/MarkdownEditor/editor/plugins/codeTagLeafBehavior.ts
@@ -1,0 +1,214 @@
+import { Editor, Node, Operation, Path, Range, Text, Transforms } from 'slate';
+import type { CustomLeaf } from '../../el';
+import { hasRange } from './utils';
+
+export type CodeTagTextLeaf = CustomLeaf & { text: string };
+
+export const isCodeTagTextLeaf = (
+  node: Node,
+): node is CodeTagTextLeaf =>
+  Text.isText(node) && !!(node.tag || node.code);
+
+const PLAIN_TEXT_AFTER_TAG = ' ';
+
+const tagPlaceholderLeaf = (source: CodeTagTextLeaf): CodeTagTextLeaf => ({
+  ...source,
+  tag: true,
+  code: true,
+  text: ' ',
+});
+
+const stripTagMarks = (_leaf: CodeTagTextLeaf): Partial<CodeTagTextLeaf> => ({
+  tag: false,
+  code: false,
+  text: PLAIN_TEXT_AFTER_TAG,
+  triggerText: undefined,
+});
+
+/**
+ * remove_text 仍可能由选区删除、剪切等一次性触发，保留在 apply 层的唯一入口。
+ */
+export const handleTagRemoveTextOperation = (
+  editor: Editor,
+  operation: Operation & { type: 'remove_text' },
+  apply: (op: Operation) => void,
+): boolean => {
+  const currentNode = Node.get(editor, operation.path);
+  if (!isCodeTagTextLeaf(currentNode) || !currentNode.tag) {
+    return false;
+  }
+
+  if (currentNode.text?.trim() === '') {
+    Editor.withoutNormalizing(editor, () => {
+      Transforms.setNodes(editor, stripTagMarks(currentNode), {
+        at: operation.path,
+      });
+    });
+    return true;
+  }
+
+  if (currentNode.text === operation.text) {
+    Editor.withoutNormalizing(editor, () => {
+      Transforms.removeNodes(editor, { at: operation.path });
+      Transforms.insertNodes(editor, tagPlaceholderLeaf(currentNode), {
+        at: operation.path,
+        select: true,
+      });
+    });
+    return true;
+  }
+
+  apply(operation);
+  return true;
+};
+
+export const moveSelectionOutOfCodeTagLeaf = (editor: Editor): boolean => {
+  const { selection } = editor;
+  if (!selection || !Range.isCollapsed(selection)) {
+    return false;
+  }
+
+  try {
+    const node = Node.get(editor, selection.anchor.path);
+    if (!isCodeTagTextLeaf(node)) {
+      return false;
+    }
+
+    const path = selection.anchor.path;
+    const nextPath = Path.next(path);
+    if (Editor.hasPath(editor, nextPath)) {
+      Transforms.select(editor, Editor.start(editor, nextPath));
+    } else {
+      Transforms.insertNodes(
+        editor,
+        { text: '' },
+        { at: nextPath, select: true },
+      );
+    }
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const tryInsertTextOutsideTagOnDoubleSpace = (
+  editor: Editor,
+  text: string,
+): boolean => {
+  const { selection } = editor;
+  if (!selection || !Range.isCollapsed(selection)) {
+    return false;
+  }
+
+  const node = Node.get(editor, selection.anchor.path);
+  if (
+    !isCodeTagTextLeaf(node) ||
+    !node.tag ||
+    text !== ' ' ||
+    selection.anchor.offset !== node.text.length
+  ) {
+    return false;
+  }
+
+  const lastChar = node.text.charAt(node.text.length - 1);
+  if (lastChar !== ' ') {
+    return false;
+  }
+
+  Transforms.insertNodes(editor, [{ text: ' ' }]);
+  return true;
+};
+
+export const handleTagDeleteBackward = (
+  editor: Editor,
+  unit: Parameters<Editor['deleteBackward']>[0],
+  deleteBackward: Editor['deleteBackward'],
+): boolean => {
+  const { selection } = editor;
+  if (!selection || !hasRange(editor, selection) || !Range.isCollapsed(selection)) {
+    return false;
+  }
+
+  const anchorPath = selection.anchor.path;
+
+  try {
+    const curNode = Node.get(editor, anchorPath);
+    const isBeforeTag = selection.anchor.offset <= 1;
+    const previous = Editor.previous(editor, { at: anchorPath });
+
+    if (previous) {
+      const [previousNode, previousPath] = previous;
+      if (
+        isCodeTagTextLeaf(previousNode) &&
+        previousNode.tag &&
+        isBeforeTag
+      ) {
+        if (
+          Text.isText(curNode) &&
+          curNode.text?.trim() &&
+          curNode.text.trimEnd().length === 1 &&
+          selection.anchor.offset > 0
+        ) {
+          Transforms.insertText(editor, '', { at: anchorPath });
+          Transforms.insertNodes(
+            editor,
+            {
+              type: 'paragraph',
+              children: [{ text: ' ' }],
+            },
+            {
+              at: anchorPath,
+              select: true,
+            },
+          );
+          return true;
+        }
+
+        if (Text.isText(curNode) && curNode.text?.trim() && selection.anchor.offset > 0) {
+          deleteBackward(unit);
+          return true;
+        }
+
+        Editor.withoutNormalizing(editor, () => {
+          const parent = Node.get(editor, Path.parent(previousPath));
+
+          if (parent.children.length === 1) {
+            Transforms.setNodes(
+              editor,
+              stripTagMarks(previousNode as CodeTagTextLeaf),
+              { at: previousPath },
+            );
+          } else {
+            Transforms.removeNodes(editor, { at: previousPath });
+          }
+        });
+        return true;
+      }
+    }
+
+    if (
+      isCodeTagTextLeaf(curNode) &&
+      curNode.tag &&
+      curNode.text?.trim()?.length < 1 &&
+      selection.anchor.offset < 1
+    ) {
+      const text = curNode.text?.replace(curNode.triggerText || '', '') ?? '';
+      Transforms.setNodes(
+        editor,
+        {
+          tag: false,
+          code: false,
+        },
+        { at: anchorPath },
+      );
+      Transforms.insertText(editor, text, {
+        at: anchorPath,
+      });
+      return true;
+    }
+  } catch {
+    return false;
+  }
+
+  return false;
+};

--- a/src/MarkdownEditor/editor/plugins/withCodeTagPlugin.ts
+++ b/src/MarkdownEditor/editor/plugins/withCodeTagPlugin.ts
@@ -1,232 +1,47 @@
-import { Editor, Node, Operation, Path, Range, Transforms } from 'slate';
-import { hasRange } from './utils';
+import { Editor, Operation } from 'slate';
+import {
+  handleTagDeleteBackward,
+  handleTagRemoveTextOperation,
+  moveSelectionOutOfCodeTagLeaf,
+  tryInsertTextOutsideTagOnDoubleSpace,
+} from './codeTagLeafBehavior';
 
 /**
- * 处理代码和标签相关节点的操作
+ * 行内 code / tag 叶子节点：用 Slate 推荐的 editor 方法覆写，而非拦截 split_node。
  *
- * @param editor - Slate编辑器实例
- * @param operation - 要处理的操作
- * @param apply - 原始的apply函数
- * @returns 如果操作被处理则返回true，否则返回false
- *
- * @description
- * 处理以下代码和标签相关操作:
- * - 删除文本 (remove_text)，处理特殊触发文本和空标签
- * - 删除节点 (remove_node)，处理代码块周围的空格
- * - 插入文本 (insert_text)，处理代码块中的空格插入
- */
-const handleCodeTagOperation = (
-  editor: Editor,
-  operation: Operation,
-  apply: (op: Operation) => void,
-): boolean => {
-  if (operation.type === 'remove_text') {
-    const currentNode = Node.get(editor, operation.path);
-
-    if (currentNode?.tag) {
-      // 处理空标签的删除
-      if (currentNode.text?.trim() === '') {
-        Editor.withoutNormalizing(editor, () => {
-          Transforms.setNodes(
-            editor,
-            { tag: false, code: false, text: ' ', triggerText: undefined },
-            { at: operation.path },
-          );
-        });
-        return true;
-      }
-
-      if (currentNode.text === operation.text) {
-        Editor.withoutNormalizing(editor, () => {
-          Transforms.removeNodes(editor, { at: operation.path });
-          Transforms.insertNodes(
-            editor,
-            { ...currentNode, tag: true, code: true, text: ' ' },
-            { at: operation.path, select: true },
-          );
-        });
-        return true;
-      }
-      // 光标在 tag 内部，执行原始的删除操作
-      apply(operation);
-      return true;
-    }
-  }
-
-  if (operation.type === 'insert_text') {
-    const currentNode = Node.get(editor, operation.path);
-    if (
-      currentNode?.tag &&
-      operation.text === ' ' &&
-      editor.selection?.focus.offset === currentNode.text.length
-    ) {
-      // 检查前一个字符是否是空格
-      const lastChar = currentNode.text.charAt(currentNode.text.length - 1);
-      if (lastChar === ' ') {
-        // 如果前一个输入是空格，且当前输入也是空格，则插入一个空格到 tag 节点外
-        Transforms.insertNodes(editor, [{ text: ' ' }]);
-        return true;
-      }
-    }
-
-    if (
-      currentNode?.tag &&
-      operation.text.trim().length > 0 &&
-      currentNode.text.trim().length === 0
-    ) {
-      apply(operation);
-      return true;
-    }
-  }
-
-  if (operation.type === 'split_node') {
-    const node = Node.get(editor, operation.path);
-    if (node?.tag || node?.code) {
-      return true;
-    }
-  }
-  return false;
-};
-
-/**
- * 扩展编辑器以处理代码和标签节点的操作
- *
- * @param editor - 要扩展的Slate编辑器实例
- * @returns 增强后的编辑器实例，能够处理代码和标签相关操作
- *
- * @description
- * 该插件重写编辑器的 `apply` 和 `deleteBackward` 方法，添加对代码和标签节点的特殊处理逻辑。
+ * - insertText：tag 末尾连续空格时跳到节点外
+ * - insertBreak：在 tag/code 内先移出光标再换行（避免依赖吞 apply）
+ * - deleteBackward：tag 邻接删除与空 tag 清理
+ * - apply：仅保留 remove_text（选区删除/剪切等一次性删字仍走 Operation）
  */
 export const withCodeTagPlugin = (editor: Editor) => {
-  const { apply, deleteBackward, insertBreak } = editor;
+  const { apply, deleteBackward, insertBreak, insertText } = editor;
 
   editor.apply = (operation: Operation) => {
-    // 尝试处理代码和标签相关操作
-    if (handleCodeTagOperation(editor, operation, apply)) {
+    if (
+      operation.type === 'remove_text' &&
+      handleTagRemoveTextOperation(editor, operation, apply)
+    ) {
       return;
     }
-
-    // 否则执行原始操作
     apply(operation);
   };
 
-  editor.insertBreak = () => {
-    const { selection } = editor;
-    // 光标在 tag/code leaf 内时，先把光标移出节点，再交给原 insertBreak。
-    // split_node 会被 handleCodeTagOperation 拦下导致按 Enter 完全静默；
-    // 这里前置移动光标，让 Enter 在 tag/code 之外正常换行。
-    if (selection && Range.isCollapsed(selection)) {
-      try {
-        const node = Node.get(editor, selection.anchor.path);
-        if (node?.tag || node?.code) {
-          const path = selection.anchor.path;
-          const nextPath = Path.next(path);
-          if (Editor.hasPath(editor, nextPath)) {
-            Transforms.select(editor, Editor.start(editor, nextPath));
-          } else {
-            Transforms.insertNodes(
-              editor,
-              { text: '' },
-              { at: nextPath, select: true },
-            );
-          }
-        }
-      } catch {
-        // 节点已不存在或路径失效时退回默认行为
-      }
+  editor.insertText = (text: string) => {
+    if (tryInsertTextOutsideTagOnDoubleSpace(editor, text)) {
+      return;
     }
+    insertText(text);
+  };
+
+  editor.insertBreak = () => {
+    moveSelectionOutOfCodeTagLeaf(editor);
     insertBreak();
   };
 
-  editor.deleteBackward = (unit: any) => {
-    const { selection } = editor;
-
-    if (
-      selection &&
-      hasRange(editor, selection) &&
-      Range.isCollapsed(selection)
-    ) {
-      const curNode = Node.get(editor, selection.anchor.path);
-
-      // 检查前一个节点是否是 tag
-      try {
-        const [previousNode, previousPath] =
-          Editor.previous(editor, {
-            at: selection.anchor.path,
-          }) || [];
-
-        const isBeforeTag = selection && selection.anchor.offset <= 1;
-        if ((previousNode as any)?.tag && previousPath && isBeforeTag) {
-          // 如果当前节点不为空,且只有一个文本
-          if (
-            curNode.text?.trim() &&
-            curNode.text.trimEnd().length === 1 &&
-            selection.anchor.offset > 0
-          ) {
-            Transforms.insertText(editor, '', { at: selection.anchor.path });
-            Transforms.insertNodes(
-              editor,
-              {
-                type: 'paragraph',
-                children: [{ text: ' ' }],
-              },
-              {
-                at: selection.anchor.path,
-                select: true,
-              },
-            );
-            return;
-          } else if (curNode.text?.trim() && selection.anchor.offset > 0) {
-            deleteBackward(unit);
-            return;
-          }
-          // 如果前一个节点是 tag，直接删除整个 tag
-          Editor.withoutNormalizing(editor, () => {
-            const parent = Node.get(editor, Path.parent(previousPath));
-            const index = previousPath[previousPath.length - 1];
-
-            if (parent.children.length === 1) {
-              // 如果是唯一的节点，转换为普通文本
-              Transforms.setNodes(
-                editor,
-                { tag: false, code: false, text: ' ', triggerText: undefined },
-                { at: previousPath },
-              );
-            } else if (index === 0) {
-              // 如果是第一个节点，删除并合并下一个节点
-              Transforms.removeNodes(editor, { at: previousPath });
-            } else {
-              // 如果是中间或最后节点，先合并再删除
-              Transforms.removeNodes(editor, { at: previousPath });
-            }
-          });
-          return;
-        }
-      } catch (error) {
-        // 如果获取前一个节点失败，继续执行原始删除操作
-      }
-      try {
-        const node = Node.get(editor, selection.anchor.path);
-        if (
-          node?.tag &&
-          node?.text?.trim()?.length < 1 &&
-          selection?.anchor?.offset < 1
-        ) {
-          const text = node?.text?.replace(node.triggerText || '', '');
-          Transforms.setNodes(
-            editor,
-            {
-              tag: false,
-              code: false,
-            },
-            { at: selection.anchor.path },
-          );
-          Transforms.insertText(editor, text, {
-            at: selection.anchor.path,
-          });
-          return;
-        }
-      } catch {}
+  editor.deleteBackward = (unit) => {
+    if (handleTagDeleteBackward(editor, unit, deleteBackward)) {
+      return;
     }
     deleteBackward(unit);
   };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Refactors `withCodeTagPlugin` to follow Slate-recommended patterns instead of intercepting arbitrary operations in `editor.apply`.

## Changes

- Extracted `codeTagLeafBehavior.ts` with focused helpers for tag/code leaf handling
- **Removed** `apply` interception for `split_node` and `insert_text`
- **Added** proper overrides: `insertText`, `insertBreak`, `deleteBackward`
- **Kept** minimal `apply` hook only for `remove_text` (selection delete / cut batch paths)
- Enter in tag/code leaves now relies on `insertBreak` moving the selection out first, not swallowing `split_node`
- Updated unit tests and added `codeTagLeafBehavior.test.ts`

## Testing

```bash
pnpm exec vitest run \
  src/MarkdownEditor/editor/plugins/__tests__/withCodeTagPlugin.test.ts \
  src/MarkdownEditor/editor/plugins/__tests__/codeTagLeafBehavior.test.ts \
  src/MarkdownEditor/editor/plugins/__tests__/withMarkdown.test.tsx
```

All 29 tests in these files pass.

## Follow-up

Ace code block dual-editor (`Plugins/code/components/AceEditor.tsx`) is unchanged; can be refactored separately if needed.

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c3d46d1-60dc-464f-b858-e988d0f41fb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c3d46d1-60dc-464f-b858-e988d0f41fb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

