### PR TITLE
refactor(MarkdownEditor): align card plugin with Slate editor overrides

### DIFF
--- a/src/MarkdownEditor/editor/plugins/__tests__/cardPluginBehavior.test.ts
+++ b/src/MarkdownEditor/editor/plugins/__tests__/cardPluginBehavior.test.ts
@@ -1,0 +1,53 @@
+import { createEditor, Transforms } from 'slate';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  ensureNonEmptyEditor,
+  redirectCardAfterText,
+  tryHandleCardInsertText,
+} from '../cardPluginBehavior';
+
+describe('cardPluginBehavior', () => {
+  it('ensureNonEmptyEditor 在空文档插入空段落', () => {
+    const editor = createEditor();
+    editor.children = [];
+    const insertSpy = vi.spyOn(Transforms, 'insertNodes');
+    ensureNonEmptyEditor(editor);
+    expect(insertSpy).toHaveBeenCalled();
+    insertSpy.mockRestore();
+  });
+
+  it('redirectCardAfterText 在 card 后插入段落', () => {
+    const editor = createEditor();
+    editor.children = [
+      {
+        type: 'card',
+        children: [
+          { type: 'card-before', children: [{ text: '' }] },
+          { type: 'paragraph', children: [{ text: 'body' }] },
+          { type: 'card-after', children: [{ text: '' }] },
+        ],
+      },
+    ];
+    expect(redirectCardAfterText(editor, [0, 2, 0], 'hi')).toBe(true);
+    expect(editor.children.length).toBe(2);
+    expect((editor.children[1] as { type: string }).type).toBe('paragraph');
+  });
+
+  it('tryHandleCardInsertText 在 card-before 不调用默认 insertText', () => {
+    const editor = createEditor();
+    editor.children = [
+      {
+        type: 'card',
+        children: [
+          { type: 'card-before', children: [{ text: '' }] },
+          { type: 'paragraph', children: [{ text: '' }] },
+          { type: 'card-after', children: [{ text: '' }] },
+        ],
+      },
+    ];
+    Transforms.select(editor, { path: [0, 0, 0], offset: 0 });
+    const insertText = vi.fn();
+    expect(tryHandleCardInsertText(editor, 'x', insertText)).toBe(true);
+    expect(insertText).not.toHaveBeenCalled();
+  });
+});

--- a/src/MarkdownEditor/editor/plugins/__tests__/withCardPlugin.test.ts
+++ b/src/MarkdownEditor/editor/plugins/__tests__/withCardPlugin.test.ts
@@ -3,7 +3,7 @@ import { vi } from 'vitest';
 import { withCardPlugin } from '../withCardPlugin';
 
 describe('withCardPlugin', () => {
-  it('insert_text 父节点为 card-before 时阻止输入', () => {
+  it('insertText 父节点为 card-before 时阻止输入', () => {
     const editor = withCardPlugin(createEditor());
     editor.children = [
       {
@@ -15,30 +15,11 @@ describe('withCardPlugin', () => {
         ],
       },
     ];
+    Transforms.select(editor, { path: [0, 0, 0], offset: 0 });
     const textBefore = Node.get(editor, [0, 0, 0]);
-    editor.apply({
-      type: 'insert_text',
-      path: [0, 0, 0],
-      offset: 0,
-      text: 'x',
-    });
+    editor.insertText('x');
     const textAfter = Node.get(editor, [0, 0, 0]);
     expect((textAfter as any).text).toBe((textBefore as any).text);
-  });
-
-  it('insert_text 父节点为 card-after 且 grandParent 非 card 时 return true', () => {
-    const editor = withCardPlugin(createEditor());
-    // card-after 作为根子节点，其 grandParent 为根，非 card
-    editor.children = [{ type: 'card-after', children: [{ text: '' }] }];
-    const textBefore = (Node.get(editor, [0, 0]) as any).text;
-    editor.apply({
-      type: 'insert_text',
-      path: [0, 0],
-      offset: 0,
-      text: 'a',
-    });
-    const textAfter = (Node.get(editor, [0, 0]) as any).text;
-    expect(textAfter).toBe(textBefore);
   });
 
   it('insert_node 父节点为 card-after 且 grandParent 为 card 时插入到卡片后', () => {
@@ -126,21 +107,6 @@ describe('withCardPlugin', () => {
     Transforms.select(editor, { path: [0, 0], offset: 0 });
     editor.insertText('x');
     expect(origInsertText).toHaveBeenCalledWith('x');
-  });
-
-  it('insert_text 父节点为 card-after（不在 card 内）apply 层仍然阻止', () => {
-    const base = createEditor();
-    const origApply = vi.fn();
-    base.apply = origApply;
-    const editor = withCardPlugin(base);
-    editor.children = [{ type: 'card-after', children: [{ text: '' }] }];
-    editor.apply({
-      type: 'insert_text',
-      path: [0, 0],
-      offset: 0,
-      text: 'x',
-    });
-    expect(origApply).not.toHaveBeenCalled();
   });
 
   it('insert_node 路径长度不足时不应抛错', () => {

--- a/src/MarkdownEditor/editor/plugins/cardPluginBehavior.ts
+++ b/src/MarkdownEditor/editor/plugins/cardPluginBehavior.ts
@@ -1,0 +1,394 @@
+import {
+  Editor,
+  Element,
+  Node,
+  Operation,
+  Path,
+  Range,
+  Transforms,
+} from 'slate';
+import type { CardAfterNode, CardBeforeNode, CardNode, ParagraphNode } from '../../el';
+import { clearCardAreaText, hasRange, isCardEmpty } from './utils';
+
+const EMPTY_PARAGRAPH: ParagraphNode = {
+  type: 'paragraph',
+  children: [{ text: '' }],
+};
+
+type CardSlotElement = CardBeforeNode | CardAfterNode;
+
+export const isCardSlotElement = (
+  node: Node | null | undefined,
+): node is CardSlotElement =>
+  Element.isElement(node) &&
+  (node.type === 'card-before' || node.type === 'card-after');
+
+/** 删 card 后若文档为空，补一个空段落，避免后续 selection 拿到无效 path */
+export const ensureNonEmptyEditor = (editor: Editor): void => {
+  if (!editor.children || editor.children.length === 0) {
+    Transforms.insertNodes(editor, EMPTY_PARAGRAPH, { at: [0], select: true });
+  }
+};
+
+export const safeParentPath = (path: Path): Path | null => {
+  if (!path || path.length === 0) {
+    return null;
+  }
+  return Path.parent(path);
+};
+
+export const safeGetNode = (editor: Editor, path: Path | null): Node | null => {
+  if (!path || !Editor.hasPath(editor, path)) {
+    return null;
+  }
+  try {
+    return Node.get(editor, path);
+  } catch {
+    return null;
+  }
+};
+
+export const getCardSlotParent = (
+  editor: Editor,
+  leafPath: Path,
+): { parentPath: Path; parentNode: Node } | null => {
+  const parentPath = safeParentPath(leafPath);
+  if (!parentPath) {
+    return null;
+  }
+  const parentNode = safeGetNode(editor, parentPath);
+  if (!parentNode) {
+    return null;
+  }
+  return { parentPath, parentNode };
+};
+
+/**
+ * 若给定 path 是 card-after 的内部 text 节点路径（[card, 2, 0]），
+ * 返回它所属的 card 的 path 与节点；否则返回 null。
+ */
+export const findCardForCardAfterInner = (
+  editor: Editor,
+  innerPath: Path,
+): { cardPath: Path; cardAfterPath: Path } | null => {
+  const cardAfterPath = safeParentPath(innerPath);
+  if (!cardAfterPath) {
+    return null;
+  }
+  const cardPath = safeParentPath(cardAfterPath);
+  if (!cardPath) {
+    return null;
+  }
+  const cardNode = safeGetNode(editor, cardPath);
+  if (!Element.isElement(cardNode) || cardNode.type !== 'card') {
+    return null;
+  }
+  return { cardPath, cardAfterPath };
+};
+
+export const redirectCardAfterText = (
+  editor: Editor,
+  innerPath: Path,
+  text: string,
+): boolean => {
+  const ctx = findCardForCardAfterInner(editor, innerPath);
+  if (!ctx) {
+    return false;
+  }
+
+  Editor.withoutNormalizing(editor, () => {
+    const afterCardPath = Path.next(ctx.cardPath);
+    Transforms.insertNodes(
+      editor,
+      { type: 'paragraph', children: [{ text }] } satisfies ParagraphNode,
+      { at: afterCardPath },
+    );
+    const newTextPath = [...afterCardPath, 0];
+    Transforms.select(editor, {
+      anchor: { path: newTextPath, offset: text.length },
+      focus: { path: newTextPath, offset: text.length },
+    });
+    clearCardAreaText(editor, ctx.cardAfterPath);
+  });
+  return true;
+};
+
+export const redirectCardAfterFragment = (
+  editor: Editor,
+  innerPath: Path,
+  fragment: Node[],
+): boolean => {
+  const ctx = findCardForCardAfterInner(editor, innerPath);
+  if (!ctx) {
+    return false;
+  }
+
+  Editor.withoutNormalizing(editor, () => {
+    Transforms.insertNodes(editor, fragment, {
+      at: Path.next(ctx.cardPath),
+      select: true,
+    });
+    clearCardAreaText(editor, ctx.cardAfterPath);
+  });
+  return true;
+};
+
+export const redirectCardAfterNode = (
+  editor: Editor,
+  innerPath: Path,
+  node: Node,
+): boolean => {
+  const ctx = findCardForCardAfterInner(editor, innerPath);
+  if (!ctx) {
+    return false;
+  }
+
+  Transforms.insertNodes(editor, node, {
+    at: Path.next(ctx.cardPath),
+  });
+  return true;
+};
+
+export const collectCardPathsForTextOperation = (
+  editor: Editor,
+  textPath: Path,
+): Path[] => {
+  const paths: Path[] = [];
+  let currentPath: Path = textPath;
+
+  while (currentPath.length > 0) {
+    try {
+      const node = Node.get(editor, currentPath);
+      if (Element.isElement(node) && node.type === 'card') {
+        paths.push(currentPath);
+        break;
+      }
+      currentPath = Path.parent(currentPath);
+    } catch {
+      break;
+    }
+  }
+
+  return paths;
+};
+
+export const pruneEmptyCardsAtPaths = (
+  editor: Editor,
+  cardPaths: Path[],
+): void => {
+  for (const cardPath of cardPaths) {
+    const cardNode = safeGetNode(editor, cardPath);
+    if (
+      Element.isElement(cardNode) &&
+      cardNode.type === 'card' &&
+      isCardEmpty(cardNode)
+    ) {
+      Transforms.removeNodes(editor, { at: cardPath });
+      ensureNonEmptyEditor(editor);
+    }
+  }
+};
+
+/**
+ * remove_node / insert_node 仍由 Operation 管线触发，保留在 apply 层。
+ */
+export const handleCardRemoveNodeOperation = (
+  editor: Editor,
+  operation: Operation & { type: 'remove_node' },
+  apply: (op: Operation) => void,
+): boolean => {
+  const { node } = operation;
+
+  if (Element.isElement(node) && node.type === 'card') {
+    apply(operation);
+    ensureNonEmptyEditor(editor);
+    return true;
+  }
+
+  if (Element.isElement(node) && node.type === 'card-after') {
+    const cardPath = safeParentPath(operation.path);
+    const cardNode = safeGetNode(editor, cardPath);
+    if (
+      cardPath &&
+      Element.isElement(cardNode) &&
+      cardNode.type === 'card'
+    ) {
+      apply({
+        type: 'remove_node',
+        path: cardPath,
+        node: cardNode,
+      });
+      ensureNonEmptyEditor(editor);
+      return true;
+    }
+    apply(operation);
+    return true;
+  }
+
+  if (Element.isElement(node) && node.type === 'card-before') {
+    const cardPath = safeParentPath(operation.path);
+    const cardNode = safeGetNode(editor, cardPath);
+    if (
+      cardPath &&
+      Element.isElement(cardNode) &&
+      cardNode.type === 'card'
+    ) {
+      apply({
+        type: 'remove_node',
+        path: cardPath,
+        node: cardNode,
+      });
+      ensureNonEmptyEditor(editor);
+      return true;
+    }
+    apply(operation);
+    return true;
+  }
+
+  const parentPath = safeParentPath(operation.path);
+  if (parentPath) {
+    const parentNode = safeGetNode(editor, parentPath);
+    if (
+      Element.isElement(parentNode) &&
+      parentNode.type === 'card' &&
+      isCardEmpty(parentNode)
+    ) {
+      Transforms.removeNodes(editor, { at: parentPath });
+      ensureNonEmptyEditor(editor);
+      return true;
+    }
+  }
+
+  return false;
+};
+
+export const handleCardInsertNodeOperation = (
+  editor: Editor,
+  operation: Operation & { type: 'insert_node' },
+): boolean => {
+  const parentPath = safeParentPath(operation.path);
+  const parentNode = safeGetNode(editor, parentPath);
+
+  if (isCardSlotElement(parentNode) && parentNode.type === 'card-before') {
+    return true;
+  }
+
+  if (isCardSlotElement(parentNode) && parentNode.type === 'card-after') {
+    if (redirectCardAfterNode(editor, operation.path, operation.node)) {
+      return true;
+    }
+    if (parentPath) {
+      Transforms.insertNodes(editor, operation.node, { at: parentPath });
+      return true;
+    }
+  }
+
+  return false;
+};
+
+export const tryHandleCardInsertText = (
+  editor: Editor,
+  text: string,
+  insertText: (value: string) => void,
+): boolean => {
+  const { selection } = editor;
+  if (!selection || !Range.isCollapsed(selection)) {
+    return false;
+  }
+
+  const slot = getCardSlotParent(editor, selection.anchor.path);
+  if (!slot) {
+    return false;
+  }
+
+  if (slot.parentNode.type === 'card-before') {
+    return true;
+  }
+
+  if (slot.parentNode.type === 'card-after') {
+    if (redirectCardAfterText(editor, selection.anchor.path, text)) {
+      return true;
+    }
+  }
+
+  insertText(text);
+  return true;
+};
+
+export const tryHandleCardInsertFragment = (
+  editor: Editor,
+  fragment: Node[],
+  insertFragment: (value: Node[]) => void,
+): boolean => {
+  const { selection } = editor;
+  if (!selection || !Range.isCollapsed(selection)) {
+    return false;
+  }
+
+  const slot = getCardSlotParent(editor, selection.anchor.path);
+  if (!slot) {
+    return false;
+  }
+
+  if (slot.parentNode.type === 'card-before') {
+    return true;
+  }
+
+  if (slot.parentNode.type === 'card-after') {
+    if (redirectCardAfterFragment(editor, selection.anchor.path, fragment)) {
+      return true;
+    }
+  }
+
+  insertFragment(fragment);
+  return true;
+};
+
+export const handleCardDeleteBackward = (
+  editor: Editor,
+  unit: Parameters<Editor['deleteBackward']>[0],
+  deleteBackward: Editor['deleteBackward'],
+): boolean => {
+  const { selection } = editor;
+  if (!selection || !hasRange(editor, selection) || !Range.isCollapsed(selection)) {
+    return false;
+  }
+
+  const slot = getCardSlotParent(editor, selection.anchor.path);
+  if (!slot) {
+    return false;
+  }
+
+  if (slot.parentNode.type === 'card-before') {
+    return true;
+  }
+
+  if (slot.parentNode.type === 'card-after') {
+    const cardAfterPath = slot.parentPath;
+    const cardPath = safeParentPath(cardAfterPath);
+    const cardNode = safeGetNode(editor, cardPath);
+
+    if (
+      cardPath &&
+      Element.isElement(cardNode) &&
+      cardNode.type === 'card' &&
+      Array.isArray((cardNode as CardNode).children) &&
+      (cardNode as CardNode).children.length >= 2
+    ) {
+      const contentIndex = cardAfterPath[cardAfterPath.length - 1] - 1;
+      if (contentIndex >= 0) {
+        const contentPath = [...cardPath, contentIndex];
+        if (Editor.hasPath(editor, contentPath)) {
+          Transforms.select(editor, Editor.end(editor, contentPath));
+          return true;
+        }
+      }
+      Transforms.removeNodes(editor, { at: cardPath });
+      ensureNonEmptyEditor(editor);
+      return true;
+    }
+  }
+
+  deleteBackward(unit);
+  return true;
+};

--- a/src/MarkdownEditor/editor/plugins/withCardPlugin.ts
+++ b/src/MarkdownEditor/editor/plugins/withCardPlugin.ts
@@ -1,391 +1,66 @@
-import { Editor, Node, Operation, Path, Range, Transforms } from 'slate';
-import { clearCardAreaText, hasRange, isCardEmpty } from './utils';
-
-/** 删 card 后若文档为空，补一个空段落，避免后续 selection 拿到无效 path */
-const ensureNonEmptyEditor = (editor: Editor) => {
-  if (!editor.children || editor.children.length === 0) {
-    Transforms.insertNodes(
-      editor,
-      { type: 'paragraph', children: [{ text: '' }] } as any,
-      { at: [0], select: true },
-    );
-  }
-};
-
-/** 安全取 parent path：长度不足时返回 null */
-const safeParentPath = (path: Path): Path | null => {
-  if (!path || path.length === 0) return null;
-  return Path.parent(path);
-};
-
-/** 安全取节点：路径不存在或异常时返回 null */
-const safeGetNode = (editor: Editor, path: Path | null): any => {
-  if (!path) return null;
-  if (!Editor.hasPath(editor, path)) return null;
-  try {
-    return Node.get(editor, path);
-  } catch {
-    return null;
-  }
-};
+import { Editor, Operation } from 'slate';
+import {
+  collectCardPathsForTextOperation,
+  handleCardDeleteBackward,
+  handleCardInsertNodeOperation,
+  handleCardRemoveNodeOperation,
+  pruneEmptyCardsAtPaths,
+  tryHandleCardInsertFragment,
+  tryHandleCardInsertText,
+} from './cardPluginBehavior';
 
 /**
- * 若给定 path 是 card-after 的内部 text 节点路径（[card, 2, 0]），
- * 返回它所属的 card 的 path 与节点；否则返回 null。
- */
-const findCardForCardAfterInner = (
-  editor: Editor,
-  innerPath: Path,
-): { cardPath: Path; cardAfterPath: Path } | null => {
-  const cardAfterPath = safeParentPath(innerPath);
-  if (!cardAfterPath) return null;
-  const cardPath = safeParentPath(cardAfterPath);
-  if (!cardPath) return null;
-  const cardNode = safeGetNode(editor, cardPath);
-  if (!cardNode || cardNode.type !== 'card') return null;
-  return { cardPath, cardAfterPath };
-};
-
-/**
- * 在 card-after 内的文本输入：把文字挪到 card 之后的新段落里，
- * card 本体保持原样，card-after 占位字符还原为零宽。
- */
-const redirectCardAfterText = (
-  editor: Editor,
-  innerPath: Path,
-  text: string,
-): boolean => {
-  const ctx = findCardForCardAfterInner(editor, innerPath);
-  if (!ctx) return false;
-
-  Editor.withoutNormalizing(editor, () => {
-    const afterCardPath = Path.next(ctx.cardPath);
-    Transforms.insertNodes(
-      editor,
-      { type: 'paragraph', children: [{ text }] } as any,
-      { at: afterCardPath },
-    );
-    const newTextPath = [...afterCardPath, 0];
-    Transforms.select(editor, {
-      anchor: { path: newTextPath, offset: text.length },
-      focus: { path: newTextPath, offset: text.length },
-    });
-    clearCardAreaText(editor, ctx.cardAfterPath);
-  });
-  return true;
-};
-
-/**
- * 在 card-after 内的片段插入：把整个 fragment 挪到 card 之后，
- * card 本体保持原样，card-after 占位字符还原为零宽。
- */
-const redirectCardAfterFragment = (
-  editor: Editor,
-  innerPath: Path,
-  fragment: any,
-): boolean => {
-  const ctx = findCardForCardAfterInner(editor, innerPath);
-  if (!ctx) return false;
-
-  Editor.withoutNormalizing(editor, () => {
-    Transforms.insertNodes(editor, fragment, {
-      at: Path.next(ctx.cardPath),
-      select: true,
-    });
-    // 与 insertText 对称：清掉 card-after 内可能残留的非零宽文本
-    clearCardAreaText(editor, ctx.cardAfterPath);
-  });
-  return true;
-};
-
-/**
- * 在 card-after 内的节点插入：把节点挪到 card 之后。
- */
-const redirectCardAfterNode = (
-  editor: Editor,
-  innerPath: Path,
-  node: any,
-): boolean => {
-  const ctx = findCardForCardAfterInner(editor, innerPath);
-  if (!ctx) return false;
-
-  Transforms.insertNodes(editor, node, {
-    at: Path.next(ctx.cardPath),
-  });
-  return true;
-};
-
-/**
- * 处理卡片相关节点的操作
+ * Card 块：用 Slate 推荐的 editor 方法覆写处理输入，apply 仅保留 Operation 级逻辑。
  *
- * @param editor - Slate编辑器实例
- * @param operation - 要处理的操作
- * @param apply - 原始的apply函数
- * @returns 如果操作被处理则返回true，否则返回false
- *
- * @description
- * 处理以下卡片相关操作:
- * - 删除卡片节点 (remove_node)，包括card、card-before和card-after
- * - 在卡片内插入节点 (insert_node)：card-before 阻止；card-after 重定向到卡后
- * - 检查并删除空卡片
- *
- * 备注：用户键盘输入走 editor.insertText / editor.insertFragment 入口，
- * 已经在那里拦截并跑了 redirect 逻辑，不会再走到 apply 这里的 insert_text。
- * 仅当外部代码直接 `editor.apply({ type: 'insert_text', ... })` 时才会触发
- * apply 层的 card-before 阻止分支（card-after 重定向已不必要，简化掉）。
- */
-const handleCardOperation = (
-  editor: Editor,
-  operation: Operation,
-  apply: (op: Operation) => void,
-): boolean => {
-  if (operation.type === 'remove_node') {
-    const { node } = operation;
-
-    // 删除card时，直接删除整个卡片，并保证文档非空
-    if (node.type === 'card') {
-      apply(operation);
-      ensureNonEmptyEditor(editor);
-      return true;
-    }
-
-    // 删除 card-after：定位到父 card，直接 emit 一个 card 的 remove_node，
-    // 绕过 Transforms.removeNodes(parent) 的二次链路，避免嵌套触发
-    if (node.type === 'card-after') {
-      const cardPath = safeParentPath(operation.path);
-      const cardNode = safeGetNode(editor, cardPath);
-      if (cardPath && cardNode && cardNode.type === 'card') {
-        apply({
-          type: 'remove_node',
-          path: cardPath,
-          node: cardNode,
-        });
-        ensureNonEmptyEditor(editor);
-        return true;
-      }
-      // 不在 card 内（schema 异常）→ 让原 apply 兜底
-      apply(operation);
-      return true;
-    }
-
-    // 删除 card-before：和 card-after 同等处理，整张卡片一起删，
-    // 避免留下 [content, card-after] 这种残缺结构
-    if (node.type === 'card-before') {
-      const cardPath = safeParentPath(operation.path);
-      const cardNode = safeGetNode(editor, cardPath);
-      if (cardPath && cardNode && cardNode.type === 'card') {
-        apply({
-          type: 'remove_node',
-          path: cardPath,
-          node: cardNode,
-        });
-        ensureNonEmptyEditor(editor);
-        return true;
-      }
-      apply(operation);
-      return true;
-    }
-
-    // 检查操作后的父级是否为空卡片，如果是则删除
-    const parentPath = safeParentPath(operation.path);
-    if (parentPath) {
-      const parentNode = safeGetNode(editor, parentPath);
-      if (parentNode && parentNode.type === 'card' && isCardEmpty(parentNode)) {
-        Transforms.removeNodes(editor, { at: parentPath });
-        ensureNonEmptyEditor(editor);
-        return true;
-      }
-    }
-  }
-
-  if (operation.type === 'insert_text') {
-    // editor.insertText 已处理用户键入路径下的 card-after 重定向；
-    // 此处仅作为防御层：直接 editor.apply({ type: 'insert_text', ... }) 进入
-    // card-before / card-after 时一律阻止，避免占位 span 被写入字符。
-    const parentPath = safeParentPath(operation.path);
-    const parentNode = safeGetNode(editor, parentPath);
-    if (
-      parentNode?.type === 'card-before' ||
-      parentNode?.type === 'card-after'
-    ) {
-      return true;
-    }
-  }
-
-  if (operation.type === 'insert_node') {
-    const parentPath = safeParentPath(operation.path);
-    const parentNode = safeGetNode(editor, parentPath);
-
-    // card-before 不允许任何节点插入
-    if (parentNode?.type === 'card-before') {
-      return true;
-    }
-
-    // card-after 的节点插入会放到卡片后面
-    if (parentNode?.type === 'card-after') {
-      if (redirectCardAfterNode(editor, operation.path, operation.node)) {
-        return true;
-      }
-      // 不在 card 内（异常 schema）→ 退回到 parent 路径插入
-      if (parentPath) {
-        Transforms.insertNodes(editor, operation.node, { at: parentPath });
-        return true;
-      }
-    }
-  }
-
-  return false;
-};
-
-/**
- * 扩展编辑器以处理卡片节点的操作和行为
- *
- * @param editor - 要扩展的Slate编辑器实例
- * @returns 增强后的编辑器实例，能够处理卡片相关操作
- *
- * @description
- * 该插件重写编辑器的 `apply`、`insertText`、`insertFragment` 和 `deleteBackward` 方法，
- * 添加对卡片节点的特殊处理逻辑，包括：
- * - 卡片节点的删除、插入和文本操作
- * - 卡片空检查逻辑
- * - 卡片区域的文本和片段插入处理
+ * - insertText / insertFragment / deleteBackward：card-before 禁写、card-after 重定向到卡后
+ * - apply：remove_node、insert_node，以及文本变更后的空 card 清理
  */
 export const withCardPlugin = (editor: Editor) => {
-  const { apply, insertText, insertFragment, deleteBackward } = editor;
+  const { apply, deleteBackward, insertFragment, insertText } = editor;
 
   editor.apply = (operation: Operation) => {
-    // 尝试处理卡片相关操作
-    if (handleCardOperation(editor, operation, apply)) {
+    if (
+      operation.type === 'remove_node' &&
+      handleCardRemoveNodeOperation(editor, operation, apply)
+    ) {
       return;
     }
 
-    // 记录操作前可能涉及的卡片路径，用于操作后检查
-    let cardPathsToCheck: Path[] = [];
-
-    if (operation.type === 'remove_text' || operation.type === 'insert_text') {
-      if (operation.path && operation.path.length > 0) {
-        try {
-          // 向上查找是否在卡片内
-          let currentPath = operation.path;
-          while (currentPath.length > 0) {
-            const node = Node.get(editor, currentPath);
-            if (node && node.type === 'card') {
-              cardPathsToCheck.push(currentPath);
-              break;
-            }
-            currentPath = Path.parent(currentPath);
-          }
-        } catch (error) {
-          // 如果无法获取节点，忽略错误
-        }
-      }
+    if (
+      operation.type === 'insert_node' &&
+      handleCardInsertNodeOperation(editor, operation)
+    ) {
+      return;
     }
 
-    // 执行原始操作
+    const cardPathsToCheck =
+      operation.type === 'remove_text' || operation.type === 'insert_text'
+        ? collectCardPathsForTextOperation(editor, operation.path)
+        : [];
+
     apply(operation);
 
-    // 操作执行后，检查涉及的卡片是否变空
-    for (const cardPath of cardPathsToCheck) {
-      const cardNode = safeGetNode(editor, cardPath);
-      if (cardNode && cardNode.type === 'card' && isCardEmpty(cardNode)) {
-        Transforms.removeNodes(editor, { at: cardPath });
-        ensureNonEmptyEditor(editor);
-      }
+    if (cardPathsToCheck.length > 0) {
+      pruneEmptyCardsAtPaths(editor, cardPathsToCheck);
     }
   };
 
   editor.insertText = (text: string) => {
-    const { selection } = editor;
-    if (selection && Range.isCollapsed(selection)) {
-      const parentPath = safeParentPath(selection.anchor.path);
-      const parentNode = safeGetNode(editor, parentPath);
-
-      // card-before 不允许任何文本输入
-      if (parentNode?.type === 'card-before') {
-        return;
-      }
-
-      // card-after 的输入会插入到卡片后面的新段落中
-      if (parentNode?.type === 'card-after') {
-        if (redirectCardAfterText(editor, selection.anchor.path, text)) {
-          return;
-        }
-        // 不在标准 card 结构内 → 走默认 insertText
-      }
+    if (!tryHandleCardInsertText(editor, text, insertText)) {
+      insertText(text);
     }
-
-    insertText(text);
   };
 
-  editor.insertFragment = (fragment: any) => {
-    const { selection } = editor;
-    if (selection && Range.isCollapsed(selection)) {
-      const parentPath = safeParentPath(selection.anchor.path);
-      const parentNode = safeGetNode(editor, parentPath);
-
-      // card-before 不允许任何片段插入
-      if (parentNode?.type === 'card-before') {
-        return;
-      }
-
-      // card-after 的片段插入会放到卡片后面
-      if (parentNode?.type === 'card-after') {
-        if (redirectCardAfterFragment(editor, selection.anchor.path, fragment)) {
-          return;
-        }
-        // 不在标准 card 结构内 → 走默认 insertFragment
-      }
+  editor.insertFragment = (fragment: Node[]) => {
+    if (!tryHandleCardInsertFragment(editor, fragment, insertFragment)) {
+      insertFragment(fragment);
     }
-
-    insertFragment(fragment);
   };
 
-  editor.deleteBackward = (unit: any) => {
-    const { selection } = editor;
-
-    if (
-      selection &&
-      hasRange(editor, selection) &&
-      Range.isCollapsed(selection)
-    ) {
-      const parentPath = safeParentPath(selection.anchor.path);
-      const parentNode = safeGetNode(editor, parentPath);
-
-      // 在 card-before 内 Backspace 静默忽略（前面没有任何可删内容）
-      if (parentNode?.type === 'card-before') {
-        return;
-      }
-      // 在 card-after 内 Backspace 改为两阶段：
-      //   第一次：把光标挪到 card 内容尾部，给用户一个"将要删除什么"的反馈机会
-      //   第二次：用户在 content 内继续 Backspace，按正常文字/void 删除路径走
-      // content 全删空后会触发自动空卡片清理，整张 card 才消失
-      if (parentNode?.type === 'card-after') {
-        const cardAfterPath = parentPath!;
-        const cardPath = safeParentPath(cardAfterPath);
-        const cardNode = safeGetNode(editor, cardPath);
-        if (
-          cardPath &&
-          cardNode?.type === 'card' &&
-          Array.isArray(cardNode.children) &&
-          cardNode.children.length >= 2
-        ) {
-          // content 节点 = card-after 之前的兄弟
-          const contentIndex = cardAfterPath[cardAfterPath.length - 1] - 1;
-          if (contentIndex >= 0) {
-            const contentPath = [...cardPath, contentIndex];
-            if (Editor.hasPath(editor, contentPath)) {
-              Transforms.select(editor, Editor.end(editor, contentPath));
-              return;
-            }
-          }
-          // 没有 content 节点，直接删整张卡片
-          Transforms.removeNodes(editor, { at: cardPath });
-          ensureNonEmptyEditor(editor);
-          return;
-        }
-      }
+  editor.deleteBackward = (unit) => {
+    if (!handleCardDeleteBackward(editor, unit, deleteBackward)) {
+      deleteBackward(unit);
     }
-    deleteBackward(unit);
   };
 
   return editor;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Refactors `withCardPlugin` to follow the same Slate-recommended pattern as the recent code/tag plugin refactor: behavior in dedicated helpers, editor method overrides for user input, and a minimal `apply` hook for operation-level card semantics.

## Changes

- Added `cardPluginBehavior.ts` with card-before/card-after redirect, remove_node coalescing, and empty-card pruning
- **Removed** `apply` interception for `insert_text` (handled via `insertText` / `insertFragment`)
- **Kept** `apply` for `remove_node`, `insert_node`, and post–text-mutation empty card cleanup
- Slim `withCardPlugin.ts` wires `insertText`, `insertFragment`, `deleteBackward`, and `apply`
- Updated `withCardPlugin.test.ts` and added `cardPluginBehavior.test.ts`

## Testing

```bash
pnpm exec vitest run \
  src/MarkdownEditor/editor/plugins/__tests__/withCardPlugin.test.ts \
  src/MarkdownEditor/editor/plugins/__tests__/cardPluginBehavior.test.ts
```

All 11 tests pass.

## Related

Complements #598 (code/tag plugin refactor).

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c3d46d1-60dc-464f-b858-e988d0f41fb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c3d46d1-60dc-464f-b858-e988d0f41fb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

