### PR TITLE
style(code): add border to code-editor-container and move styles to CSS

### DIFF
--- a/src/MarkdownEditor/editor/code.css
+++ b/src/MarkdownEditor/editor/code.css
@@ -45,3 +45,27 @@
 .code-editor-content .ace-chaos {
   background: transparent;
 }
+
+.code-editor-container {
+  padding: 1px;
+  box-sizing: border-box;
+  border: 1px solid var(--color-gray-border-light);
+  border-radius: var(--radius-card-base, 12px);
+  box-shadow: var(--shadow-control-base, 0 1px 2px rgba(20, 22, 28, 0.06));
+  background-color: var(--color-gray-bg-page-light, #fafafa);
+  color: var(--color-gray-text-default, rgba(20, 22, 28, 0.88));
+}
+
+.code-editor-container--show-border {
+  background-color: rgba(59, 130, 246, 0.1);
+  border-color: var(--color-primary-control-fill-primary);
+}
+
+.code-editor-container--hide {
+  margin-bottom: 0;
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  height: 0;
+  opacity: 0;
+}

--- a/src/Plugins/code/components/CodeContainer.tsx
+++ b/src/Plugins/code/components/CodeContainer.tsx
@@ -5,6 +5,7 @@
 
 import classNames from 'clsx';
 import React, { ReactNode, useRef } from 'react';
+import '../../../MarkdownEditor/editor/code.css';
 import { CodeNode } from '../../../MarkdownEditor/el';
 
 interface CodeContainerProps {
@@ -49,26 +50,15 @@ export function CodeContainer({
           e.stopPropagation();
           onEditorClick();
         }}
-        style={{
-          padding: hide ? 1 : 1,
-          marginBottom: hide ? 0 : undefined,
-          boxShadow:
-            'var(--shadow-control-base, 0 1px 2px rgba(20, 22, 28, 0.06))',
-          borderRadius: 'var(--radius-card-base, 12px)',
-          backgroundColor: showBorder
-            ? 'rgba(59, 130, 246, 0.1)'
-            : hide
-              ? 'transparent'
-              : 'var(--color-gray-bg-page-light, #fafafa)',
-          color: 'var(--color-gray-text-default, rgba(20, 22, 28, 0.88))',
-          height: hide ? 0 : 'auto',
-          opacity: hide ? 0 : 1,
-        }}
         data-frontmatter={safeElement.frontmatter ? '' : undefined}
         className={classNames(
           'ace-container',
           'code-editor-container',
           'drag-el',
+          {
+            'code-editor-container--show-border': showBorder,
+            'code-editor-container--hide': hide,
+          },
         )}
       >
         {children}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Moves `code-editor-container` inline styles from `CodeContainer.tsx` into `code.css`, adds a default `1px` border using design tokens, and uses modifier classes for focus/hide states.

## Changes

- **`src/MarkdownEditor/editor/code.css`**: New `.code-editor-container` base styles (border, shadow, radius, background) plus `--show-border` and `--hide` modifiers.
- **`src/Plugins/code/components/CodeContainer.tsx`**: Removes inline `style`; applies modifier classes; imports `code.css` so MarkdownRenderer-only paths still receive styles.

## Behavior

- Default: `border: 1px solid var(--color-gray-border-light)` with existing card shadow/background tokens.
- Selected (`showBorder`): blue-tinted background + primary border color.
- Hidden (`hide`): transparent border, no shadow, collapsed height/opacity (unchanged semantics).

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2eea9d4d-5fcf-4235-ae5b-01b483a34ef2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2eea9d4d-5fcf-4235-ae5b-01b483a34ef2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

