### PR TITLE
fix(MarkdownInputField): fix duplicate IME text after newline shortcut

### DIFF
--- a/src/MarkdownEditor/editor/utils/__tests__/isImeComposing.test.ts
+++ b/src/MarkdownEditor/editor/utils/__tests__/isImeComposing.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { createEditor, Editor, Transforms } from 'slate';
 import {
   commitImeCompositionTextIfMissing,
+  getEditorTextSnapshot,
   IME_PROCESSING_KEY_CODE,
   isImeComposing,
   markImeEnterCommitGuard,
@@ -58,6 +59,19 @@ describe('isImeComposing', () => {
   });
 });
 
+describe('getEditorTextSnapshot', () => {
+  it('应读取光标所在段落文本而非首段', () => {
+    const editor = createEditor();
+    editor.children = [
+      { type: 'paragraph', children: [{ text: '第一行' }] },
+      { type: 'paragraph', children: [{ text: '第二行' }] },
+    ];
+    Transforms.select(editor, { path: [1, 0], offset: 3 });
+
+    expect(getEditorTextSnapshot(editor)).toBe('第二行');
+  });
+});
+
 describe('commitImeCompositionTextIfMissing', () => {
   it('Slate 已写入时不重复插入', async () => {
     const editor = createEditor();
@@ -78,6 +92,19 @@ describe('commitImeCompositionTextIfMissing', () => {
     expect(getSnapshot(editor)).toBe('');
     await Promise.resolve();
     expect(getSnapshot(editor)).toBe('，');
+  });
+
+  it('换行后 Slate 已写入时不重复插入（#628）', async () => {
+    const editor = createEditor();
+    editor.children = [
+      { type: 'paragraph', children: [{ text: '第一行' }] },
+      { type: 'paragraph', children: [{ text: '世界' }] },
+    ];
+    Transforms.select(editor, { path: [1, 0], offset: 2 });
+
+    commitImeCompositionTextIfMissing(editor, '世界', getSnapshot);
+    await Promise.resolve();
+    expect(getSnapshot(editor)).toBe('世界');
   });
 });
 

--- a/src/MarkdownEditor/editor/utils/isImeComposing.ts
+++ b/src/MarkdownEditor/editor/utils/isImeComposing.ts
@@ -1,15 +1,12 @@
 import { Editor, Range } from 'slate';
 
-/** 读取编辑器首段纯文本，供 IME commit 回退比对 */
+/** 读取光标所在文本节点的纯文本，供 IME commit 回退比对 */
 export function getEditorTextSnapshot(
-  editor: { children: unknown[] } | null | undefined,
+  editor: Editor | null | undefined,
 ): string {
-  if (!editor?.children?.length) return '';
+  if (!editor?.selection) return '';
   try {
-    const paragraph = editor.children[0] as {
-      children?: Array<{ text?: string }>;
-    };
-    return paragraph.children?.map((c) => c.text ?? '').join('') ?? '';
+    return Editor.string(editor, editor.selection.focus.path);
   } catch {
     return '';
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Fixes [#628](https://github.com/antdigital-ai/agentic-ui/issues/628).

In `MarkdownInputField`, after using the newline shortcut (e.g. Shift+Enter) while using a Chinese IME, subsequent Chinese input was inserted twice.

## Root cause

`commitImeCompositionTextIfMissing` compares text before/after `compositionend` to decide whether Slate already committed IME text. The snapshot helper `getEditorTextSnapshot` only read the **first paragraph**, so after a newline the cursor sits in a later paragraph while the snapshot still reflected paragraph 0. Slate had already written the composed text, but the helper thought nothing changed and called `Editor.insertText` again — producing duplicate characters.

## Fix

- Update `getEditorTextSnapshot` to read the text node at the current selection focus path via `Editor.string`.
- Add regression tests for multi-paragraph editors (#628 scenario).

## Testing

- `pnpm test -- src/MarkdownEditor/editor/utils/__tests__/isImeComposing.test.ts` (11 tests passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d08e813-8a6a-45de-91c8-8c161f8e8e8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d08e813-8a6a-45de-91c8-8c161f8e8e8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

