### PR TITLE
fix(MarkdownEditor): fix readonly streaming defects in Slate and Markdown render modes

### DIFF
--- a/src/MarkdownEditor/BaseMarkdownEditorSlate.tsx
+++ b/src/MarkdownEditor/BaseMarkdownEditorSlate.tsx
@@ -299,6 +299,15 @@ const BaseMarkdownEditorSlate: React.FC<MarkdownEditorProps> = (props) => {
     setSchema(initSchemaValue);
   }, [initSchemaValue]);
 
+  // 只读流式：外部通过 initValue 累加时 initSchemaValue 会变，但 Slate initialNote 仅随 instance 重置。
+  // 与 ThoughtChainList/MarkdownEditorUpdate 一致，用 updateNodeList 同步文档树，避免中间态 schema 残留堆叠。
+  useEffect(() => {
+    if (!readonly) {
+      return;
+    }
+    store.updateNodeList(initSchemaValue);
+  }, [readonly, initSchemaValue, store]);
+
   // toc 关闭时无人消费 schema，无需 setState 触发整树 re-render；
   // toc 开启时延迟到稳定后再更新，TOC 跟随节奏可接受地放慢。
   const tocEnabled = toc !== false;

--- a/src/MarkdownEditor/editor/utils/isImeComposing.ts
+++ b/src/MarkdownEditor/editor/utils/isImeComposing.ts
@@ -27,8 +27,10 @@ export interface ImeKeyboardEventLike {
   nativeEvent: { isComposing?: boolean };
 }
 
+/**
  * compositionend 后标记：下一记 Enter 多为确认选字，勿触发发送或 / 快捷面板。
  * 仅消费一次；未命中时应在双 rAF 后调用 clearImeEnterCommitGuard 清除。
+ */
 export function markImeEnterCommitGuard(): void {
   imeEnterCommitGuardPending = true;
 }

--- a/src/MarkdownRenderer/__tests__/markdownReactShared.test.ts
+++ b/src/MarkdownRenderer/__tests__/markdownReactShared.test.ts
@@ -107,6 +107,14 @@ describe('splitMarkdownBlocks', () => {
     const result = splitMarkdownBlocks(md);
     expect(result.length).toBe(1);
   });
+
+  it('splits heading from following table without blank line', () => {
+    const md = '# Title\n| a | b |\n| - | - |\n| 1 | 2 |';
+    const result = splitMarkdownBlocks(md);
+    expect(result.length).toBe(2);
+    expect(result[0]).toBe('# Title');
+    expect(result[1]).toBe('| a | b |\n| - | - |\n| 1 | 2 |');
+  });
 });
 
 describe('createHastProcessor', () => {

--- a/src/MarkdownRenderer/markdownReactShared.ts
+++ b/src/MarkdownRenderer/markdownReactShared.ts
@@ -769,6 +769,8 @@ const renderMarkdownBlock = (
   }
 };
 
+import { isGfmTableLine } from './streaming/gfmTableLine';
+
 const LIST_ITEM_PATTERN = /^(\s*)([-+*]|\d+[.)]) /;
 const BLOCKQUOTE_PATTERN = /^\s*>/;
 const HTML_COMMENT_PATTERN = /^\s*<!--/;
@@ -840,6 +842,19 @@ const splitMarkdownBlocks = (content: string): string[] => {
 
     inList = LIST_ITEM_PATTERN.test(line) || (inList && /^\s+\S/.test(line));
     inBlockquote = BLOCKQUOTE_PATTERN.test(line);
+
+    // AI 流式输出常见「标题 → 表格」无空行；表格单独成块避免末块 reparse 连带标题闪烁
+    if (
+      current.length > 0 &&
+      isGfmTableLine(line) &&
+      !isGfmTableLine(lastNonEmptyLine()) &&
+      !HTML_COMMENT_PATTERN.test(lastNonEmptyLine())
+    ) {
+      blocks.push(current.join('\n'));
+      current = [];
+      inList = false;
+      inBlockquote = false;
+    }
 
     current.push(line);
   }

--- a/src/MarkdownRenderer/streaming/__tests__/lastBlockThrottle.test.ts
+++ b/src/MarkdownRenderer/streaming/__tests__/lastBlockThrottle.test.ts
@@ -19,4 +19,16 @@ describe('shouldReparseLastBlock', () => {
     const next = '```js\nx\n```\nmore';
     expect(shouldReparseLastBlock(prev, next, true)).toBe(false);
   });
+
+  it('流式末块在 GFM 表格内不因 | 或 - 立即重 parse', () => {
+    const prev = '| a | b |\n| - | - |\n| 1';
+    const next = '| a | b |\n| - | - |\n| 1 |';
+    expect(shouldReparseLastBlock(prev, next, true)).toBe(false);
+  });
+
+  it('流式末块在 GFM 表格内换行仍立即重 parse', () => {
+    const prev = '| a | b |';
+    const next = '| a | b |\n| - | - |';
+    expect(shouldReparseLastBlock(prev, next, true)).toBe(true);
+  });
 });

--- a/src/MarkdownRenderer/streaming/gfmTableLine.ts
+++ b/src/MarkdownRenderer/streaming/gfmTableLine.ts
@@ -1,0 +1,21 @@
+/** GFM 表格行：`| a | b |` */
+const GFM_TABLE_ROW_PATTERN = /^\s*\|(.+\|)+\s*$/;
+
+/** GFM 表格分隔行：`| --- | --- |` 或 `|:---|:---:|---:|` */
+const GFM_TABLE_SEPARATOR_PATTERN = /^\s*\|(\s*:?-+:?\s*\|)+\s*$/;
+
+export const isGfmTableLine = (line: string): boolean =>
+  GFM_TABLE_ROW_PATTERN.test(line) || GFM_TABLE_SEPARATOR_PATTERN.test(line);
+
+/** 流式末块是否仍在 GFM 表格行内（从末尾向前扫描连续表格行） */
+export const endsInsideGfmTable = (source: string): boolean => {
+  const lines = source.split('\n');
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i];
+    if (line === '') {
+      continue;
+    }
+    return isGfmTableLine(line);
+  }
+  return false;
+};

--- a/src/MarkdownRenderer/streaming/lastBlockThrottle.ts
+++ b/src/MarkdownRenderer/streaming/lastBlockThrottle.ts
@@ -1,7 +1,9 @@
+import { endsInsideGfmTable } from './gfmTableLine';
 import { endsInsideUnclosedFence } from './fenceTracker';
 
 const LAST_BLOCK_THROTTLE_CHARS = 20;
 const BLOCK_BOUNDARY_TRIGGERS = /[\n`|#>*\-!~]/;
+const TABLE_STREAMING_BOUNDARY_TRIGGERS = /[\n#>*!~]/;
 // inline 起始字符出现在行首或空白后时立即重 parse，避免 `<a` / `_em` / `[link`
 // 等增量在 < 20 字符时被节流卡住、用户看到半成品 DOM
 const INLINE_CONTEXT_TRIGGERS = /(?:^|\s)[$[<_]/;
@@ -22,6 +24,12 @@ export const shouldReparseLastBlock = (
   if (endsInsideUnclosedFence(newSource)) return true;
   const added = newSource.slice(prevParsedSource.length);
   if (added.length >= LAST_BLOCK_THROTTLE_CHARS) return true;
+  // 表格流式：`|` / `-` 每个字符都触发 reparse 会导致整表卸载重挂；仅换行等边界符立即重算
+  if (endsInsideGfmTable(newSource)) {
+    if (TABLE_STREAMING_BOUNDARY_TRIGGERS.test(added)) return true;
+    if (INLINE_CONTEXT_TRIGGERS.test(added)) return true;
+    return false;
+  }
   if (BLOCK_BOUNDARY_TRIGGERS.test(added)) return true;
   if (INLINE_CONTEXT_TRIGGERS.test(added)) return true;
   return false;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [#627](https://github.com/antdigital-ai/agentic-ui/issues/627): `BaseMarkdownEditor` in readonly mode could not reliably render AI streaming markdown in either `renderMode`.

## Root causes (from issue)

| Mode | Symptom | Root cause |
| --- | --- | --- |
| `slate` (default) | List items duplicate/stack during streaming | `initialNote` only resets on `instance` change; `initSchemaValue` updates from `initValue` were not synced to Slate document |
| `markdown` | Table + surrounding heading/list flicker heavily | Heading→table often shares one tail block; `BLOCK_BOUNDARY_TRIGGERS` re-parsed on every `\|` / `-` character |

## Changes

### Slate readonly (`renderMode='slate'`)
- In `BaseMarkdownEditorSlate`, when `readonly` is true, call `store.updateNodeList(initSchemaValue)` whenever `initSchemaValue` changes (same pattern as `ThoughtChainList/MarkdownEditorUpdate`).
- Prevents intermediate schema states from accumulating in the DOM during SSE chunk updates.

### Markdown readonly (`renderMode='markdown'`)
- **`splitMarkdownBlocks`**: split a new block when a GFM table line follows a non-table line (e.g. `# Title` → `| a | b |`), while keeping HTML comment + table pairs glued.
- **`shouldReparseLastBlock`**: when the tail block is inside a GFM table, do not immediately reparse on `\|` / `-`; rely on 20-char throttle and newline boundaries instead.

## Tests
- Added cases for heading/table split and table streaming throttle in `markdownReactShared.test.ts` and `lastBlockThrottle.test.ts`.

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b201bc29-83f8-4cc4-9a0e-206e57bd6f22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b201bc29-83f8-4cc4-9a0e-206e57bd6f22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

