### PR TITLE
fix(test): 修复单元与 E2E 测试在 Windows 下的稳定性问题

### DIFF
--- a/_test_helpers/pages/MarkdownEditorPage.ts
+++ b/_test_helpers/pages/MarkdownEditorPage.ts
@@ -4,6 +4,7 @@ import { Locator, Page, expect } from '@playwright/test';
 import { PLAYWRIGHT_FIXTURE_DEMOS } from '../constants/playwrightDemoRoutes';
 import { gotoDumiDemo } from '../utils/e2eNavigation';
 import { getDumiDemoContentRoot } from '../utils/dumiDemoFrame';
+import { E2E_POLL_TIMEOUT_MS } from '../utils/e2eTimeouts';
 
 /** 与 `markdown.matchInputToNode` 等输入规则联用时，逐字输入的默认间隔（ms） */
 const DEFAULT_INPUT_RULE_TYPE_DELAY_MS = 25;
@@ -87,7 +88,7 @@ export class MarkdownEditorPage {
           return content.length > 0;
         },
         {
-          timeout: 3000,
+          timeout: E2E_POLL_TIMEOUT_MS,
           message: '等待文本输入完成',
         },
       )
@@ -180,7 +181,7 @@ export class MarkdownEditorPage {
           return content.includes(text);
         },
         {
-          timeout: 3000,
+          timeout: E2E_POLL_TIMEOUT_MS,
           message: `等待文本 "${text}" 出现`,
         },
       )

--- a/_test_helpers/setupTests.ts
+++ b/_test_helpers/setupTests.ts
@@ -6,8 +6,32 @@ import { vi } from 'vitest';
 import { setupLottieMock } from './_mocks_/lottieMock';
 import { setupGlobalMocks } from './_mocks_/sharedMocks';
 
+// antd Anchor/Tabs 等组件的 scrollTo 动画在 teardown 后仍可能触发 rAF/setTimeout；
+// happy-dom 未暴露全局 Document 时，回调里 `instanceof Document` 会抛未捕获异常。
+const { noopAntdScrollTo } = vi.hoisted(() => ({
+  noopAntdScrollTo: vi.fn((_y: number, options?: { callback?: () => void }) => {
+    options?.callback?.();
+  }),
+}));
+
+vi.mock('antd/lib/_util/scrollTo', () => ({
+  default: noopAntdScrollTo,
+}));
+
+vi.mock('antd/es/_util/scrollTo', () => ({
+  default: noopAntdScrollTo,
+}));
+
 // happy-dom 会自动创建完整的 window/document，无需手动覆盖。
 MotionGlobalConfig.skipAnimations = true;
+
+if (typeof globalThis.Document === 'undefined' && typeof document !== 'undefined') {
+  Object.defineProperty(globalThis, 'Document', {
+    configurable: true,
+    writable: true,
+    value: document.constructor,
+  });
+}
 
 // Mock ace-builds 模块，避免在测试环境中加载真实的 ace 库
 vi.mock('ace-builds/src-noconflict/ext-modelist', () => ({

--- a/e2e/markdowneditor-basic.spec.ts
+++ b/e2e/markdowneditor-basic.spec.ts
@@ -65,8 +65,8 @@ test.describe('MarkdownEditor 基础功能', () => {
     await markdownEditorPage.expectContainsText('End');
 
     // 移动到开头并插入
-    await markdownEditorPage.pressKey('Home');
     await markdownEditorPage.focus();
+    await markdownEditorPage.pressKey('Home');
     await markdownEditorPage.editableInput.type('Prefix ', { delay: 0 });
     await markdownEditorPage.expectContainsText('Prefix');
     await markdownEditorPage.expectContainsText('Middle Content');

--- a/e2e/markdowneditor-basic.spec.ts
+++ b/e2e/markdowneditor-basic.spec.ts
@@ -66,6 +66,7 @@ test.describe('MarkdownEditor 基础功能', () => {
 
     // 移动到开头并插入
     await markdownEditorPage.pressKey('Home');
+    await markdownEditorPage.focus();
     await markdownEditorPage.editableInput.type('Prefix ', { delay: 0 });
     await markdownEditorPage.expectContainsText('Prefix');
     await markdownEditorPage.expectContainsText('Middle Content');

--- a/scripts/strip-utf8-bom.mjs
+++ b/scripts/strip-utf8-bom.mjs
@@ -112,7 +112,7 @@ export function runStripUtf8Bom(options = {}) {
     if (!hasUtf8Bom(buf)) {
       continue;
     }
-    const rel = relative(root, file);
+    const rel = relative(root, file).replace(/\\/g, '/');
     withBom.push(rel);
     if (!checkOnly && !dryRun) {
       writeFileSync(file, stripUtf8Bom(buf));

--- a/src/Components/Robot/__tests__/RobotLotties.test.tsx
+++ b/src/Components/Robot/__tests__/RobotLotties.test.tsx
@@ -6,6 +6,10 @@ import { BlowingWindLottie } from '../lotties/BlowingWindLottie';
 import { BouncingLottie } from '../lotties/BouncingLottie';
 import { PeekLottie } from '../lotties/PeekLottie';
 
+vi.mock('../../../lotties/useAsyncLottieData', () => ({
+  useAsyncLottieData: () => ({ v: '5.6.9' }),
+}));
+
 vi.mock('lottie-react', () => ({
   default: ({
     animationData,
@@ -16,9 +20,9 @@ vi.mock('lottie-react', () => ({
     ...props
   }: any) => (
     <div
-      data-testid="lottie-animation"
-      data-loop={loop}
-      data-autoplay={autoplay}
+      data-testid="lottie-mock"
+      data-loop={String(loop)}
+      data-autoplay={String(autoplay)}
       data-animation={animationData ? 'loaded' : 'empty'}
       style={style}
       className={className}

--- a/src/MarkdownEditor/__tests__/editor/elements/Image/ReadonlyEditorImage.test.tsx
+++ b/src/MarkdownEditor/__tests__/editor/elements/Image/ReadonlyEditorImage.test.tsx
@@ -9,6 +9,15 @@ vi.mock('../../../../editor/utils/dom', () => ({
   getMediaType: vi.fn(() => 'image'),
 }));
 
+vi.mock('../../../../editor/store', () => ({
+  useEditorStore: vi.fn(() => ({
+    editorProps: {},
+    readonly: true,
+    store: {},
+    typewriter: false,
+  })),
+}));
+
 vi.mock('../../../../editor/utils', async (importOriginal) => {
   const mod = await importOriginal<typeof import('../../../../editor/utils')>();
   const origUseGetSetState = mod.useGetSetState;

--- a/src/MarkdownEditor/editor/editorStoreContext.ts
+++ b/src/MarkdownEditor/editor/editorStoreContext.ts
@@ -1,0 +1,8 @@
+import { createContext } from 'react';
+
+import type { EditorStoreContextType } from './store';
+
+/** 与 store.ts 解耦，供 FncLeaf 等只读路径使用，避免 vi.mock('editor/store') 遮蔽 Context */
+export const EditorStoreContext = createContext<EditorStoreContextType | null>(
+  null,
+);

--- a/src/MarkdownEditor/editor/elements/FncLeaf/index.tsx
+++ b/src/MarkdownEditor/editor/elements/FncLeaf/index.tsx
@@ -6,7 +6,7 @@ import { RenderLeafProps } from 'slate-react';
 import { useRefFunction } from '../../../../Hooks/useRefFunction';
 import { isMobileDevice } from '../../../../MarkdownInputField/AttachmentButton/utils';
 import { MarkdownEditorProps } from '../../../types';
-import { useEditorStore } from '../../store';
+import { EditorStoreContext } from '../../store';
 import {
   extractFootnoteDefinitionIdentifier,
   formatFootnoteRefDisplayLabel,
@@ -38,7 +38,7 @@ export const FncLeaf = ({
   const mdEditorBaseClass = context?.getPrefixCls('agentic-md-editor-content');
   const isMobile = isMobileDevice();
   const hasFnc = leaf.fnc || leaf.identifier;
-  const { store } = useEditorStore();
+  const store = useContext(EditorStoreContext)?.store;
   const [mobileModalOpen, setMobileModalOpen] = useState(false);
 
   const resolvedIdentifier = useMemo(

--- a/src/MarkdownEditor/editor/elements/FncLeaf/index.tsx
+++ b/src/MarkdownEditor/editor/elements/FncLeaf/index.tsx
@@ -6,7 +6,7 @@ import { RenderLeafProps } from 'slate-react';
 import { useRefFunction } from '../../../../Hooks/useRefFunction';
 import { isMobileDevice } from '../../../../MarkdownInputField/AttachmentButton/utils';
 import { MarkdownEditorProps } from '../../../types';
-import { EditorStoreContext } from '../../store';
+import { EditorStoreContext } from '../../editorStoreContext';
 import {
   extractFootnoteDefinitionIdentifier,
   formatFootnoteRefDisplayLabel,

--- a/src/MarkdownEditor/editor/store.ts
+++ b/src/MarkdownEditor/editor/store.ts
@@ -31,7 +31,11 @@ import type { ParserMarkdownToSlateNodeConfig } from './parser/parserMarkdownToS
 import type { MarkdownToHtmlOptions } from './utils/markdownToHtml';
 import { markdownToHtmlSync } from './utils/markdownToHtml';
 import type { EditorSelChangePayload } from './utils/editorSelChange';
-const { createContext, useContext } = React;
+import { EditorStoreContext } from './editorStoreContext';
+
+export { EditorStoreContext };
+
+const { useContext } = React;
 
 /**
  * 编辑器上下文接口
@@ -97,10 +101,6 @@ export interface EditorStoreContextType {
   /** Markdown容器引用 */
   markdownContainerRef: React.MutableRefObject<HTMLDivElement | null>;
 }
-
-export const EditorStoreContext = createContext<EditorStoreContextType | null>(
-  null,
-);
 
 /**
  * 获取编辑器存储上下文的Hook

--- a/src/Plugins/chart/__tests__/ChartRender.test.tsx
+++ b/src/Plugins/chart/__tests__/ChartRender.test.tsx
@@ -5,6 +5,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from '@testing-library/react';
 import { ConfigProvider } from 'antd';
 import React from 'react';
@@ -14,54 +15,20 @@ import { I18nContext } from '../../../I18n';
 vi.mock('antd', async (importOriginal) => {
   const actual = await importOriginal<typeof import('antd')>();
   const React = await import('react');
-  const { useState, cloneElement, isValidElement } = React;
-
-  function MockPopover({
-    content,
-    children,
-    open: controlledOpen,
-    onOpenChange,
-    trigger = 'hover',
-  }: {
-    content?: React.ReactNode;
-    children?: React.ReactNode;
-    open?: boolean;
-    onOpenChange?: (open: boolean) => void;
-    trigger?: string | string[];
-  }) {
-    const [internalOpen, setInternalOpen] = useState(false);
-    const isClickTrigger =
-      trigger === 'click' ||
-      (Array.isArray(trigger) && trigger.includes('click'));
-    const open = controlledOpen ?? internalOpen;
-    const setOpen = (next: boolean) => {
-      setInternalOpen(next);
-      onOpenChange?.(next);
-    };
-
-    const child = isValidElement(children)
-      ? cloneElement(children as React.ReactElement<{ onClick?: React.MouseEventHandler }>, {
-          onClick: (e: React.MouseEvent) => {
-            if (isClickTrigger) {
-              setOpen(!open);
-            }
-            (children as React.ReactElement<{ onClick?: React.MouseEventHandler }>)
-              .props?.onClick?.(e);
-          },
-        })
-      : children;
-
-    return (
-      <div data-testid="chart-config-popover">
-        {child}
-        {open ? <div className="ant-popover-content">{content}</div> : null}
-      </div>
-    );
-  }
-
   return {
     ...actual,
-    Popover: MockPopover,
+    Popover: ({
+      content,
+      children,
+    }: {
+      content?: React.ReactNode;
+      children?: React.ReactNode;
+    }) => (
+      <div data-testid="chart-config-popover">
+        {children}
+        <div className="ant-popover-content">{content}</div>
+      </div>
+    ),
   };
 });
 
@@ -252,10 +219,12 @@ describe('ChartRender', () => {
     await waitFor(
       () => {
         const form =
-          document.body.querySelector('.ant-agentic-chart-config-form') ||
-          document.body.querySelector('.ant-popover-content form') ||
-          document.body.querySelector('.ant-form') ||
-          document.body.querySelector('form');
+          document.querySelector(
+            '[data-testid="chart-config-popover"] .ant-popover-content .ant-agentic-chart-config-form',
+          ) ||
+          document.querySelector(
+            '[data-testid="chart-config-popover"] .ant-popover-content form',
+          );
         expect(form).not.toBeNull();
         expect(form).toBeInTheDocument();
       },
@@ -263,9 +232,27 @@ describe('ChartRender', () => {
     );
   };
 
+  const getChartConfigSubmitButton = async () =>
+    waitFor(
+      () => {
+        const popoverContent = document.querySelector(
+          '[data-testid="chart-config-popover"] .ant-popover-content',
+        );
+        expect(popoverContent).toBeInTheDocument();
+
+        const submitButton =
+          popoverContent?.querySelector('button.ant-btn-primary') ||
+          popoverContent?.querySelector('button[type="submit"]');
+        expect(submitButton).toBeTruthy();
+        return submitButton as HTMLElement;
+      },
+      { timeout: 8000 },
+    );
+
   beforeEach(() => {
     vi.clearAllMocks();
     runtimeMountSequence = 0;
+    document.body.innerHTML = '';
     // 设置测试环境，但允许图表渲染
     process.env.NODE_ENV = 'test-chart';
     // 确保 window 对象存在
@@ -1176,14 +1163,10 @@ describe('ChartRender', () => {
         fireEvent.mouseDown(xSelects[1]);
       }
 
-      const submitBtn =
-        document.body.querySelector('button.ant-btn-primary') ||
-        screen.queryByRole('button', { name: '更新' });
-      if (submitBtn) {
-        await act(async () => {
-          fireEvent.click(submitBtn);
-        });
-      }
+      const submitBtn = await getChartConfigSubmitButton();
+      await act(async () => {
+        fireEvent.click(submitBtn);
+      });
     });
 
     it('提交配置后应该重新挂载图表运行时，避免底层图表实例复用旧配置', async () => {
@@ -1203,11 +1186,9 @@ describe('ChartRender', () => {
 
       await openChartConfigForm();
 
-      const submitButton =
-        document.body.querySelector('button.ant-btn-primary') ||
-        screen.getByRole('button', { name: '更新' });
+      const submitButton = await getChartConfigSubmitButton();
       await act(async () => {
-        fireEvent.click(submitButton!);
+        fireEvent.click(submitButton);
       });
 
       await waitFor(() => {
@@ -1340,9 +1321,12 @@ describe('ChartRender', () => {
         </I18nContext.Provider>,
       );
 
-      // 应该只渲染有效的列
-      expect(screen.getByText('Name')).toBeInTheDocument();
-      expect(screen.getByText('Valid')).toBeInTheDocument();
+      const descriptionView = document.querySelector('.ant-descriptions');
+      expect(descriptionView).toBeInTheDocument();
+
+      // 应该只渲染有效的列（限定在 Descriptions 组件内，避免工具栏配置表单干扰）
+      expect(within(descriptionView as HTMLElement).getByText('Name')).toBeInTheDocument();
+      expect(within(descriptionView as HTMLElement).getByText('Valid')).toBeInTheDocument();
     });
   });
 });

--- a/src/Plugins/chart/__tests__/ChartRender.test.tsx
+++ b/src/Plugins/chart/__tests__/ChartRender.test.tsx
@@ -6,9 +6,65 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react';
+import { ConfigProvider } from 'antd';
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { I18nContext } from '../../../I18n';
+
+vi.mock('antd', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('antd')>();
+  const React = await import('react');
+  const { useState, cloneElement, isValidElement } = React;
+
+  function MockPopover({
+    content,
+    children,
+    open: controlledOpen,
+    onOpenChange,
+    trigger = 'hover',
+  }: {
+    content?: React.ReactNode;
+    children?: React.ReactNode;
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+    trigger?: string | string[];
+  }) {
+    const [internalOpen, setInternalOpen] = useState(false);
+    const isClickTrigger =
+      trigger === 'click' ||
+      (Array.isArray(trigger) && trigger.includes('click'));
+    const open = controlledOpen ?? internalOpen;
+    const setOpen = (next: boolean) => {
+      setInternalOpen(next);
+      onOpenChange?.(next);
+    };
+
+    const child = isValidElement(children)
+      ? cloneElement(children as React.ReactElement<{ onClick?: React.MouseEventHandler }>, {
+          onClick: (e: React.MouseEvent) => {
+            if (isClickTrigger) {
+              setOpen(!open);
+            }
+            (children as React.ReactElement<{ onClick?: React.MouseEventHandler }>)
+              .props?.onClick?.(e);
+          },
+        })
+      : children;
+
+    return (
+      <div data-testid="chart-config-popover">
+        {child}
+        {open ? <div className="ant-popover-content">{content}</div> : null}
+      </div>
+    );
+  }
+
+  return {
+    ...actual,
+    Popover: MockPopover,
+  };
+});
+
 import { ChartRender } from '../ChartRender';
 
 vi.mock('../../../Hooks/useIntersectionOnce', () => ({
@@ -180,6 +236,31 @@ describe('ChartRender', () => {
       fullScreen: '全屏',
     } as any,
     language: 'zh-CN' as const,
+  };
+
+  const renderChart = (ui: React.ReactElement) =>
+    render(<ConfigProvider>{ui}</ConfigProvider>);
+
+  const openChartConfigForm = async () => {
+    await screen.findByTestId('bar-chart', {}, { timeout: 3000 });
+
+    const configTrigger = screen.getByRole('button', { name: '配置图表' });
+    await act(async () => {
+      fireEvent.click(configTrigger);
+    });
+
+    await waitFor(
+      () => {
+        const form =
+          document.body.querySelector('.ant-agentic-chart-config-form') ||
+          document.body.querySelector('.ant-popover-content form') ||
+          document.body.querySelector('.ant-form') ||
+          document.body.querySelector('form');
+        expect(form).not.toBeNull();
+        expect(form).toBeInTheDocument();
+      },
+      { timeout: 8000 },
+    );
   };
 
   beforeEach(() => {
@@ -1079,29 +1160,13 @@ describe('ChartRender', () => {
     });
 
     it('应该打开配置 Popover、触发表单 X/Y 的 stopPropagation 并提交（833, 847, 851, 871, 888）', async () => {
-      render(
+      renderChart(
         <I18nContext.Provider value={mockI18n}>
           <ChartRender {...defaultProps} />
         </I18nContext.Provider>,
       );
 
-      await screen.findByTestId('bar-chart', {}, { timeout: 3000 });
-
-      const configTrigger = screen.getByRole('button', { name: '配置图表' });
-      await act(async () => {
-        fireEvent.click(configTrigger);
-      });
-
-      await waitFor(
-        () => {
-          const form =
-            document.body.querySelector('.ant-form') ||
-            document.body.querySelector('form');
-          expect(form).not.toBeNull();
-          expect(form).toBeInTheDocument();
-        },
-        { timeout: 2000 },
-      );
+      await openChartConfigForm();
 
       const xSelects = document.body.querySelectorAll('.ant-select-selector');
       if (xSelects.length >= 1) {
@@ -1111,7 +1176,9 @@ describe('ChartRender', () => {
         fireEvent.mouseDown(xSelects[1]);
       }
 
-      const submitBtn = document.body.querySelector('button.ant-btn-primary');
+      const submitBtn =
+        document.body.querySelector('button.ant-btn-primary') ||
+        screen.queryByRole('button', { name: '更新' });
       if (submitBtn) {
         await act(async () => {
           fireEvent.click(submitBtn);
@@ -1120,7 +1187,7 @@ describe('ChartRender', () => {
     });
 
     it('提交配置后应该重新挂载图表运行时，避免底层图表实例复用旧配置', async () => {
-      render(
+      renderChart(
         <I18nContext.Provider value={mockI18n}>
           <ChartRender {...defaultProps} />
         </I18nContext.Provider>,
@@ -1134,24 +1201,11 @@ describe('ChartRender', () => {
       const mountIdBeforeSubmit =
         chartBeforeSubmit.getAttribute('data-mount-id');
 
-      const configTrigger = screen.getByRole('button', { name: '配置图表' });
-      await act(async () => {
-        fireEvent.click(configTrigger);
-      });
+      await openChartConfigForm();
 
-      await waitFor(
-        () => {
-          const submitButton = document.body.querySelector(
-            'button.ant-btn-primary',
-          );
-          expect(submitButton).toBeInTheDocument();
-        },
-        { timeout: 2000 },
-      );
-
-      const submitButton = document.body.querySelector(
-        'button.ant-btn-primary',
-      );
+      const submitButton =
+        document.body.querySelector('button.ant-btn-primary') ||
+        screen.getByRole('button', { name: '更新' });
       await act(async () => {
         fireEvent.click(submitButton!);
       });

--- a/src/Plugins/code/components/ThinkBlock.tsx
+++ b/src/Plugins/code/components/ThinkBlock.tsx
@@ -15,8 +15,7 @@ import { MessagesContext } from '../../../Bubble/MessagesContent/BubbleContext';
 import { I18nContext } from '../../../I18n';
 import {
   EditorStoreContext,
-  useEditorStore,
-} from '../../../MarkdownEditor/editor/store';
+} from '../../../MarkdownEditor/editor/editorStoreContext';
 import { getSlateElementPlainText } from '../../../MarkdownEditor/editor/utils/codeBlockPlainText';
 import { EditorUtils } from '../../../MarkdownEditor/editor/utils/editorUtils';
 import { CodeNode, ElementProps } from '../../../MarkdownEditor/el';
@@ -87,9 +86,10 @@ const restoreCodeBlocks = (content: string): string => {
 export function ThinkBlock(props: ThinkBlockProps) {
   const { element } = props;
   const { locale } = useContext(I18nContext);
-  const { editorProps } = useContext(EditorStoreContext) || {};
+  const editorStore = useContext(EditorStoreContext);
+  const { editorProps, markdownEditorRef = { current: null } } =
+    editorStore || {};
   const { message } = useContext(MessagesContext);
-  const { markdownEditorRef } = useEditorStore();
   const thinkBlockContext = useContext(ThinkBlockContext);
 
   // 获取当前 Bubble 的 isFinished 状态

--- a/src/__tests__/ciBuildEnvironment.test.ts
+++ b/src/__tests__/ciBuildEnvironment.test.ts
@@ -51,20 +51,42 @@ describe('CI 构建环境配置', () => {
     const MIN_WEBSERVER_TIMEOUT_MS = 360 * 1000;
     const playwrightConfig = readRepoFile('playwright.config.ts');
 
-    /** 解析 webServer 块内 `timeout: N` 或 `timeout: N * M` 形式的毫秒值 */
+    /** 解析 webServer 块内 timeout 毫秒值（含三元表达式各分支） */
     const resolveWebServerTimeoutMs = (source: string): number | null => {
       const webServerIndex = source.indexOf('webServer');
       if (webServerIndex === -1) {
         return null;
       }
       const scoped = source.slice(webServerIndex);
-      const match = scoped.match(/timeout:\s*(\d+)\s*(?:\*\s*(\d+))?/);
-      if (!match) {
+      const timeoutIndex = scoped.indexOf('timeout:');
+      if (timeoutIndex === -1) {
         return null;
       }
-      const base = Number(match[1]);
-      const factor = match[2] ? Number(match[2]) : 1;
-      return base * factor;
+      const timeoutScoped = scoped.slice(timeoutIndex);
+      const parseTimeoutExpr = (expr: string): number | null => {
+        const match = expr.match(/^\s*(\d+)\s*(?:\*\s*(\d+))?/);
+        if (!match) {
+          return null;
+        }
+        const base = Number(match[1]);
+        const factor = match[2] ? Number(match[2]) : 1;
+        return base * factor;
+      };
+
+      const ternaryMatch = timeoutScoped.match(
+        /timeout:\s*[^?]+\?\s*([^:]+)\s*:\s*([^,}\n]+)/,
+      );
+      if (ternaryMatch) {
+        const branchValues = [ternaryMatch[1], ternaryMatch[2]]
+          .map((branch) => parseTimeoutExpr(branch.trim()))
+          .filter((value): value is number => value !== null);
+        if (branchValues.length === 0) {
+          return null;
+        }
+        return Math.max(...branchValues);
+      }
+
+      return parseTimeoutExpr(timeoutScoped.slice('timeout:'.length));
     };
 
     it('应配置 webServer 自动启动命令', () => {


### PR DESCRIPTION
- FncLeaf 只读 Markdown 路径不再强依赖 EditorStoreContext

- strip-utf8-bom 输出路径统一为正斜杠以兼容 Windows

- CI 回归测试支持解析 playwright 三元 timeout 配置

- RobotLotties 测试 mock 对齐 createLottieComponent 约定

- E2E Home/End 导航 flaky 修复并统一 MarkdownEditor 轮询超时