### PR TITLE
chore: set up Cursor Cloud dev environment + AGENTS.md cloud notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -953,3 +953,16 @@ pnpm run build
 
 - 详细开发指南请参考 `docs/development/` 目录下的文档
 - 遇到问题请查阅 GitHub Issues 或 Discussions
+
+---
+
+## Cursor Cloud specific instructions
+
+> 面向后续 cloud agent 的运行时须知。VM 启动时已执行 update script（`corepack enable` → `corepack prepare pnpm@9.15.9 --activate` → `pnpm install --frozen-lockfile`），依赖已就绪，无需重复安装。环境已自带 Node 22 与 pnpm 9.15.9。
+
+- **运行应用**：本仓库的「应用」即文档站点。用 `pnpm dev`（等同 `pnpm start`）启动，监听 `http://localhost:8000`。建议在 tmux 会话内长驻运行。
+- **首屏编译延迟（非 bug）**：dumi/umi 是 SPA，首次请求会触发按需编译，初始 HTML 仅返回 `Umi Loading...` 外壳，需等待数秒前端才渲染出内容；`curl` 拿到 200 不代表页面已可交互。
+- **组件路由**：组件页路径由文档 frontmatter 生成，并非全部能从组件名直接拼出（例如 `MarkdownEditor` 的 URL 与 `/components/markdown-editor` 不一定一致）。直接猜 URL 可能 404，优先点顶部「组件」再走左侧栏导航。
+- **测试范围**：`pnpm test` 默认跑精简集（见 `vitest.config.ts` 的 exclude）。验证单个组件用 `pnpm test -- src/<Component>` 更快；全量用 `pnpm run test:full`（已带 `--max-old-space-size=8192`）。
+- **E2E**：`pnpm run test:e2e` 需先 `pnpm run playwright:install`（下载 Chromium，未纳入 update script）。
+- **校验顺序**：提交前依次 `pnpm run lint`、`pnpm tsc`、相关 `pnpm test`，与 `.husky/pre-commit`（eslint + stylelint）一致。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

为 `ant-design/agentic-ui` 配置 Cursor Cloud Agent 开发环境，并验证工具链与文档站点可运行。

## 环境配置

- VM 已自带 **Node 22**（v22.14.0）、**corepack 0.34.6**、**pnpm 9.15.9**。
- Update script（VM 启动时自动执行，幂等）：
  ```
  corepack enable
  corepack prepare pnpm@9.15.9 --activate
  pnpm install --frozen-lockfile
  ```

## 变更内容

- `AGENTS.md`：新增 `## Cursor Cloud specific instructions` 段落，记录运行时须知（dev 站点地址、SPA 首屏编译延迟、组件路由 frontmatter 生成、测试范围、E2E 需先装 Playwright Chromium 等非显而易见的注意事项）。

> 未改动任何业务代码，仅追加面向后续 cloud agent 的文档说明。

## 验证

- ✅ `pnpm install` / `pnpm install --frozen-lockfile`（幂等，Already up to date）
- ✅ `pnpm run lint`（eslint + stylelint）
- ✅ `pnpm tsc`
- ✅ `pnpm test -- src/ToolUseBar`（4 files / 50 tests passed）
- ✅ `pnpm dev` → `http://localhost:8000` 文档站点可访问，并在 `MarkdownInputField` 演示中成功输入文本（hello-world 交互）

### Hello-world 演示

[agentic_ui_docs_hello_world.mp4](https://cursor.com/agents/bc-731e1cfc-3300-47a9-8ffa-a04bd6e2be2d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagentic_ui_docs_hello_world.mp4)

[Agentic UI docs homepage](https://cursor.com/agents/bc-731e1cfc-3300-47a9-8ffa-a04bd6e2be2d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_homepage.webp)
[Typed text in MarkdownInputField](https://cursor.com/agents/bc-731e1cfc-3300-47a9-8ffa-a04bd6e2be2d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmarkdown_input_typed.webp)

> Submitted by Cursor

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-731e1cfc-3300-47a9-8ffa-a04bd6e2be2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-731e1cfc-3300-47a9-8ffa-a04bd6e2be2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

