### PR TITLE
fix(MarkdownEditor): 修复 IME 重复输入与 tag chip 光标无法移动问题

### DIFF
--- a/src/MarkdownEditor/__tests__/editor/useKeyboard.test.tsx
+++ b/src/MarkdownEditor/__tests__/editor/useKeyboard.test.tsx
@@ -985,8 +985,426 @@ describe('useKeyboard Hook Tests', () => {
         keyboardHandler(arrowLeftEvent);
       });
 
-      // 由于已存在 FEFF，不应该插入新的
-      expect(arrowLeftEvent.preventDefault).not.toHaveBeenCalled();
+      // BOM 已存在：preventDefault 并将光标移到 BOM 节点末尾，不再重复插入
+      expect(arrowLeftEvent.preventDefault).toHaveBeenCalled();
+      expect(editor.selection).toEqual({
+        anchor: { path: [0, 1], offset: 1 },
+        focus: { path: [0, 1], offset: 1 },
+      });
+    });
+  });
+
+  describe('Error handling and robustness', () => {
+    it('should handle malformed editor state gracefully', () => {
+      // 设置异常的编辑器状态
+      editor.children = [
+        {
+          type: 'unknown' as any,
+          children: [{ text: 'test' }],
+        },
+      ];
+
+      const { result } = renderHook(() =>
+        useKeyboard(store, editorRef, mockProps),
+      );
+      const keyboardHandler = result.current;
+
+      expect(() => {
+        act(() => {
+          const keyEvent = createKeyboardEvent('a');
+          keyboardHandler(keyEvent);
+        });
+      }).not.toThrow();
+    });
+
+    it('should handle null or undefined editor gracefully', () => {
+      const nullEditorRef = { current: null as any };
+
+      expect(() => {
+        renderHook(() => useKeyboard(store, nullEditorRef, mockProps));
+      }).not.toThrow();
+    });
+
+    it('should handle rapid key sequences', () => {
+      const { result } = renderHook(() =>
+        useKeyboard(store, editorRef, mockProps),
+      );
+      const keyboardHandler = result.current;
+
+      // 模拟快速按键序列
+      const keys = ['a', 'b', 'c', 'Enter', 'Backspace'];
+
+      expect(() => {
+        act(() => {
+          keys.forEach((key) => {
+            const keyEvent = createKeyboardEvent(key);
+            keyboardHandler(keyEvent);
+          });
+        });
+      }).not.toThrow();
+    });
+  });
+
+  describe('Performance considerations', () => {
+    it('should memoize keyboard handler properly', () => {
+      const { result, rerender } = renderHook(() =>
+        useKeyboard(store, editorRef, mockProps),
+      );
+      const firstHandler = result.current;
+
+      // Rerender without changing dependencies
+      rerender();
+      const secondHandler = result.current;
+
+      // Handler should be memoized
+      expect(firstHandler).toBe(secondHandler);
+    });
+
+    it('should handle large text content efficiently', () => {
+      // 创建大量文本内容
+      const largeText = 'a'.repeat(10000);
+      editor.children = [
+        {
+          type: 'paragraph',
+          children: [{ text: largeText }],
+        },
+      ];
+
+      Transforms.select(editor, {
+        anchor: { path: [0, 0], offset: largeText.length },
+        focus: { path: [0, 0], offset: largeText.length },
+      });
+
+      const { result } = renderHook(() =>
+        useKeyboard(store, editorRef, mockProps),
+      );
+      const keyboardHandler = result.current;
+
+      const startTime = performance.now();
+
+      act(() => {
+        const keyEvent = createKeyboardEvent('a');
+        keyboardHandler(keyEvent);
+      });
+
+      const endTime = performance.now();
+
+      // 操作应该在合理时间内完成（100ms）
+      expect(endTime - startTime).toBeLessThan(100);
+    });
+  });
+
+  describe('Integration with other features', () => {
+    it('should work correctly with different editor configurations', () => {
+      const customProps: MarkdownEditorProps = {
+        textAreaProps: {
+          enable: true,
+          placeholder: 'Custom placeholder',
+        },
+        markdown: {
+          matchInputToNode: false,
+        },
+      };
+
+      const { result } = renderHook(() =>
+        useKeyboard(store, editorRef, customProps),
+      );
+      const keyboardHandler = result.current;
+
+      expect(typeof keyboardHandler).toBe('function');
+    });
+
+    it('should handle nested list structures', () => {
+      // 重置 mock 计数
+      mockSetOpenInsertCompletion.mockClear();
+
+      editor.children = [
+        {
+          type: 'list',
+          children: [
+            {
+              type: 'list-item',
+              children: [
+                {
+                  type: 'paragraph',
+                  children: [{ text: '/command' }],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      // 设置光标在嵌套列表中
+      Transforms.select(editor, {
+        anchor: { path: [0, 0, 0, 0], offset: 8 },
+        focus: { path: [0, 0, 0, 0], offset: 8 },
+      });
+
+      const { result } = renderHook(() =>
+        useKeyboard(store, editorRef, mockProps),
+      );
+      const keyboardHandler = result.current;
+      const keyEvent = createKeyboardEvent('a');
+
+      act(() => {
+        keyboardHandler(keyEvent);
+      });
+
+      // 由于需要特定的条件才能触发插入补全，我们验证基本功能
+      expect(typeof keyboardHandler).toBe('function');
+      // 验证函数执行没有抛出错误
+    });
+  });
+
+  describe('Chip (tag leaf) cursor navigation', () => {
+    it('ArrowLeft at tag offset 0 without BOM inserts BOM before chip', () => {
+      editor.children = [
+        {
+          type: 'paragraph',
+          children: [
+            { text: 'before ' },
+            { text: 'tag', tag: true },
+            { text: ' after' },
+          ],
+        },
+      ];
+
+      Transforms.select(editor, {
+        anchor: { path: [0, 1], offset: 0 },
+        focus: { path: [0, 1], offset: 0 },
+      });
+
+      const { result } = renderHook(() =>
+        useKeyboard(store, editorRef, mockProps),
+      );
+      const arrowLeftEvent = createKeyboardEvent('ArrowLeft');
+
+      act(() => {
+        result.current(arrowLeftEvent);
+      });
+
+      expect(arrowLeftEvent.preventDefault).toHaveBeenCalled();
+      // Slate normalizer merges the inserted BOM text with the adjacent plain text node.
+      // Result: children[0].text = 'before ﻿' (merged), children[1] = chip.
+      const firstText = (editor.children[0] as any).children[0].text;
+      expect(firstText).toContain('﻿');
+    });
+
+    it('ArrowLeft at tag offset 0 with BOM already present moves cursor to BOM end', () => {
+      editor.children = [
+        {
+          type: 'paragraph',
+          children: [
+            { text: 'before ' },
+            { text: '﻿' },
+            { text: 'tag', tag: true },
+            { text: ' after' },
+          ],
+        },
+      ];
+
+      Transforms.select(editor, {
+        anchor: { path: [0, 2], offset: 0 },
+        focus: { path: [0, 2], offset: 0 },
+      });
+
+      const { result } = renderHook(() =>
+        useKeyboard(store, editorRef, mockProps),
+      );
+      const arrowLeftEvent = createKeyboardEvent('ArrowLeft');
+
+      act(() => {
+        result.current(arrowLeftEvent);
+      });
+
+      expect(arrowLeftEvent.preventDefault).toHaveBeenCalled();
+      expect(editor.selection).toEqual({
+        anchor: { path: [0, 1], offset: 1 },
+        focus: { path: [0, 1], offset: 1 },
+      });
+    });
+
+    it('ArrowLeft inside tag at non-zero offset jumps to end of node before chip', () => {
+      editor.children = [
+        {
+          type: 'paragraph',
+          children: [
+            { text: 'before ' },
+            { text: 'tag', tag: true },
+            { text: ' after' },
+          ],
+        },
+      ];
+
+      Transforms.select(editor, {
+        anchor: { path: [0, 1], offset: 2 },
+        focus: { path: [0, 1], offset: 2 },
+      });
+
+      const { result } = renderHook(() =>
+        useKeyboard(store, editorRef, mockProps),
+      );
+      const arrowLeftEvent = createKeyboardEvent('ArrowLeft');
+
+      act(() => {
+        result.current(arrowLeftEvent);
+      });
+
+      expect(arrowLeftEvent.preventDefault).toHaveBeenCalled();
+      expect(editor.selection).toEqual({
+        anchor: { path: [0, 0], offset: 7 },
+        focus: { path: [0, 0], offset: 7 },
+      });
+    });
+
+    it('ArrowLeft at start of non-tag node skips chip to node before chip', () => {
+      editor.children = [
+        {
+          type: 'paragraph',
+          children: [
+            { text: 'before ' },
+            { text: 'tag', tag: true },
+            { text: ' after' },
+          ],
+        },
+      ];
+
+      Transforms.select(editor, {
+        anchor: { path: [0, 2], offset: 0 },
+        focus: { path: [0, 2], offset: 0 },
+      });
+
+      const { result } = renderHook(() =>
+        useKeyboard(store, editorRef, mockProps),
+      );
+      const arrowLeftEvent = createKeyboardEvent('ArrowLeft');
+
+      act(() => {
+        result.current(arrowLeftEvent);
+      });
+
+      expect(arrowLeftEvent.preventDefault).toHaveBeenCalled();
+      expect(editor.selection).toEqual({
+        anchor: { path: [0, 0], offset: 7 },
+        focus: { path: [0, 0], offset: 7 },
+      });
+    });
+
+    it('ArrowRight at end of leaf before chip jumps cursor past chip to trailing node', () => {
+      editor.children = [
+        {
+          type: 'paragraph',
+          children: [
+            { text: 'before ' },
+            { text: 'tag', tag: true },
+            { text: ' after' },
+          ],
+        },
+      ];
+
+      Transforms.select(editor, {
+        anchor: { path: [0, 0], offset: 7 },
+        focus: { path: [0, 0], offset: 7 },
+      });
+
+      const { result } = renderHook(() =>
+        useKeyboard(store, editorRef, mockProps),
+      );
+      const arrowRightEvent = createKeyboardEvent('ArrowRight');
+
+      act(() => {
+        result.current(arrowRightEvent);
+      });
+
+      expect(arrowRightEvent.preventDefault).toHaveBeenCalled();
+      expect(editor.selection).toEqual({
+        anchor: { path: [0, 2], offset: 0 },
+        focus: { path: [0, 2], offset: 0 },
+      });
+    });
+
+    it('ArrowRight in middle of leaf before chip does not jump over chip', () => {
+      editor.children = [
+        {
+          type: 'paragraph',
+          children: [
+            { text: 'before ' },
+            { text: 'tag', tag: true },
+            { text: ' after' },
+          ],
+        },
+      ];
+
+      Transforms.select(editor, {
+        anchor: { path: [0, 0], offset: 3 },
+        focus: { path: [0, 0], offset: 3 },
+      });
+
+      const { result } = renderHook(() =>
+        useKeyboard(store, editorRef, mockProps),
+      );
+      const arrowRightEvent = createKeyboardEvent('ArrowRight');
+
+      act(() => {
+        result.current(arrowRightEvent);
+      });
+
+      expect(arrowRightEvent.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('ArrowRight at end of leaf when next sibling is not a chip does not prevent default', () => {
+      editor.children = [
+        {
+          type: 'paragraph',
+          children: [{ text: 'hello' }, { text: ' world' }],
+        },
+      ];
+
+      Transforms.select(editor, {
+        anchor: { path: [0, 0], offset: 5 },
+        focus: { path: [0, 0], offset: 5 },
+      });
+
+      const { result } = renderHook(() =>
+        useKeyboard(store, editorRef, mockProps),
+      );
+      const arrowRightEvent = createKeyboardEvent('ArrowRight');
+
+      act(() => {
+        result.current(arrowRightEvent);
+      });
+
+      expect(arrowRightEvent.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('ArrowRight inserts trailing space when chip is the last child and jumps past it', () => {
+      editor.children = [
+        {
+          type: 'paragraph',
+          children: [{ text: 'before ' }, { text: 'tag', tag: true }],
+        },
+      ];
+
+      Transforms.select(editor, {
+        anchor: { path: [0, 0], offset: 7 },
+        focus: { path: [0, 0], offset: 7 },
+      });
+
+      const { result } = renderHook(() =>
+        useKeyboard(store, editorRef, mockProps),
+      );
+      const arrowRightEvent = createKeyboardEvent('ArrowRight');
+
+      act(() => {
+        result.current(arrowRightEvent);
+      });
+
+      expect(arrowRightEvent.preventDefault).toHaveBeenCalled();
+      // A trailing space node is inserted after the chip
+      const children = (editor.children[0] as any).children;
+      expect(children.length).toBe(3);
+      expect(children[2].text).toBe(' ');
     });
   });
 

--- a/src/MarkdownEditor/editor/Editor.tsx
+++ b/src/MarkdownEditor/editor/Editor.tsx
@@ -960,6 +960,26 @@ export const SlateMarkdownEditor = React.memo((props: MEditorProps) => {
   const onCompositionStart = () => {
     lastCompositionDataRef.current = '';
     activateInputComposition();
+
+    // Re-anchor Slate selection from the actual DOM caret position.
+    // Without this, consecutive IME words in the same line cause Slate's
+    // internal composition range to drift: it still points at the previous
+    // candidate span, so insertCompositionText appends instead of replacing.
+    try {
+      const domSel = window.getSelection();
+      if (domSel && domSel.rangeCount > 0) {
+        const slateRange = ReactEditor.toSlateRange(
+          markdownEditorRef.current,
+          domSel,
+          { exactMatch: false, suppressThrow: true },
+        );
+        if (slateRange) {
+          Transforms.select(markdownEditorRef.current, slateRange);
+        }
+      }
+    } catch {
+      // DOM/Slate range conversion can fail in edge cases; ignore
+    }
   };
 
   /**
@@ -975,6 +995,7 @@ export const SlateMarkdownEditor = React.memo((props: MEditorProps) => {
       activateInputComposition();
       return;
     }
+
     if (
       markdownContainerRef.current &&
       !markdownContainerRef.current.hasAttribute('data-composition')

--- a/src/MarkdownEditor/editor/elements/TagPopup/index.tsx
+++ b/src/MarkdownEditor/editor/elements/TagPopup/index.tsx
@@ -466,6 +466,7 @@ export const TagPopup = (props: RenderProps) => {
     onClick: (e: any) => {
       onSelect?.(e.key?.trim() || '', currentNodePath.current || []);
       suggestionContext?.setOpen?.(false);
+      setOpen(false);
     },
   } as MenuProps;
 

--- a/src/MarkdownEditor/editor/elements/index.tsx
+++ b/src/MarkdownEditor/editor/elements/index.tsx
@@ -474,7 +474,13 @@ const MLeafComponent = (
                 if (!markdownEditorRef.current) return;
                 if (!path?.length) return;
                 try {
-                  const nextPath = Path.next(path);
+                  // The ﻿ insert above shifted the chip one position forward.
+                  // Use chipNewPath (not the original path) to find what comes after.
+                  const chipNewPath = [
+                    ...path.slice(0, -1),
+                    path[path.length - 1] + 1,
+                  ];
+                  const nextPath = Path.next(chipNewPath);
                   if (!Editor.hasPath(markdownEditorRef.current, nextPath)) {
                     Transforms.insertNodes(
                       markdownEditorRef.current,
@@ -485,8 +491,8 @@ const MLeafComponent = (
                     );
                   } else {
                     Transforms.select(markdownEditorRef.current, {
-                      anchor: Editor.end(markdownEditorRef.current, path),
-                      focus: Editor.end(markdownEditorRef.current, path),
+                      anchor: Editor.start(markdownEditorRef.current, nextPath),
+                      focus: Editor.start(markdownEditorRef.current, nextPath),
                     });
                   }
                 } catch {

--- a/src/MarkdownEditor/editor/plugins/useKeyboard.ts
+++ b/src/MarkdownEditor/editor/plugins/useKeyboard.ts
@@ -203,36 +203,147 @@ export const useKeyboard = (
 
       if (e.key.toLowerCase().startsWith('arrow')) {
         if (['ArrowUp', 'ArrowDown'].includes(e.key)) return;
-        // 处理 tag 前的空格插入
         if (e.key === 'ArrowLeft') {
           const selection = markdownEditorRef.current.selection;
           if (selection && Range.isCollapsed(selection)) {
-            const [node] = Editor.nodes(markdownEditorRef.current, {
-              at: selection.focus.path,
-              match: (n) => n.tag === true,
-            });
+            const alFocusPath = selection.focus.path;
+            const alOffset = selection.focus.offset;
+            try {
+              const [node] = Editor.nodes(markdownEditorRef.current, {
+                at: alFocusPath,
+                match: (n) => (n as any).tag === true,
+              });
 
-            if (node) {
-              const [, tagPath] = node;
-              const offset = selection.focus.offset;
-              // 当光标在 tag 开始位置时，检查前面是否需要插入空格
-              if (offset === 0) {
-                const [prevNode] =
-                  Editor.previous(markdownEditorRef.current, { at: tagPath }) ||
-                  [];
-                if (!prevNode || !(prevNode as any).text?.endsWith('\uFEFF')) {
-                  e.preventDefault();
-                  Transforms.insertNodes(
-                    markdownEditorRef.current,
-                    [{ text: '\uFEFF' }],
-                    {
+              if (node) {
+                const [, tagPath] = node;
+                const offset = alOffset;
+                if (offset === 0) {
+                  const [prevNode, prevPath] =
+                    Editor.previous(markdownEditorRef.current, {
                       at: tagPath,
-                      select: true,
-                    },
-                  );
+                    }) || [];
+                  if (!prevNode || !(prevNode as any).text?.endsWith('\uFEFF')) {
+                    e.preventDefault();
+                    Transforms.insertNodes(
+                      markdownEditorRef.current,
+                      [{ text: '\uFEFF' }],
+                      { at: tagPath, select: true },
+                    );
+                    return;
+                  }
+                  // BOM 已存在：将光标移到 BOM 节点末尾
+                  if (prevPath) {
+                    e.preventDefault();
+                    Transforms.select(markdownEditorRef.current, {
+                      anchor: Editor.end(markdownEditorRef.current, prevPath),
+                      focus: Editor.end(markdownEditorRef.current, prevPath),
+                    });
+                  }
+                  return;
+                } else {
+                  // 光标在 chip 内部非零位置：直接跳到 chip 之前
+                  e.preventDefault();
+                  const [, alPrevPath] =
+                    Editor.previous(markdownEditorRef.current, {
+                      at: tagPath,
+                    }) || [];
+                  if (alPrevPath) {
+                    Transforms.select(markdownEditorRef.current, {
+                      anchor: Editor.end(markdownEditorRef.current, alPrevPath),
+                      focus: Editor.end(markdownEditorRef.current, alPrevPath),
+                    });
+                  }
                   return;
                 }
+              } else if (alOffset === 0 && Path.hasPrevious(alFocusPath)) {
+                // 光标在非 tag 节点起始位置：检查前一个兄弟是否是 chip，是则跳过
+                const alPrevSibPath = Path.previous(alFocusPath);
+                if (Editor.hasPath(markdownEditorRef.current, alPrevSibPath)) {
+                  const [alPrevSibNode] = Editor.leaf(
+                    markdownEditorRef.current,
+                    alPrevSibPath,
+                  );
+                  if ((alPrevSibNode as any).tag) {
+                    e.preventDefault();
+                    if (Path.hasPrevious(alPrevSibPath)) {
+                      const alPrevPrevPath = Path.previous(alPrevSibPath);
+                      if (
+                        Editor.hasPath(
+                          markdownEditorRef.current,
+                          alPrevPrevPath,
+                        )
+                      ) {
+                        Transforms.select(markdownEditorRef.current, {
+                          anchor: Editor.end(
+                            markdownEditorRef.current,
+                            alPrevPrevPath,
+                          ),
+                          focus: Editor.end(
+                            markdownEditorRef.current,
+                            alPrevPrevPath,
+                          ),
+                        });
+                      }
+                    }
+                    return;
+                  }
+                }
               }
+            } catch (_err) {}
+          }
+        }
+
+        // When cursor is at the end of the leaf before a tag leaf, ArrowRight
+        // jumps directly to the node after the chip, bypassing the
+        // contentEditable=false DOM so Slate selection updates correctly.
+        if (e.key === 'ArrowRight') {
+          const selection = markdownEditorRef.current.selection;
+          if (selection && Range.isCollapsed(selection)) {
+            const { path: focusPath, offset } = selection.focus;
+            try {
+              const [leafNode] = Editor.leaf(
+                markdownEditorRef.current,
+                focusPath,
+              );
+              const leafText = (leafNode as any).text ?? '';
+              if (!(leafNode as any).tag && offset === leafText.length) {
+                const nextSiblingPath = Path.next(focusPath);
+                if (
+                  Editor.hasPath(markdownEditorRef.current, nextSiblingPath)
+                ) {
+                  const [nextNode] = Editor.leaf(
+                    markdownEditorRef.current,
+                    nextSiblingPath,
+                  );
+                  if ((nextNode as any).tag) {
+                    e.preventDefault();
+                    const afterTagPath = Path.next(nextSiblingPath);
+                    if (
+                      Editor.hasPath(markdownEditorRef.current, afterTagPath)
+                    ) {
+                      Transforms.select(markdownEditorRef.current, {
+                        anchor: Editor.start(
+                          markdownEditorRef.current,
+                          afterTagPath,
+                        ),
+                        focus: Editor.start(
+                          markdownEditorRef.current,
+                          afterTagPath,
+                        ),
+                      });
+                    } else {
+                      Transforms.insertNodes(
+                        markdownEditorRef.current,
+                        [{ text: ' ' }],
+                        { at: afterTagPath, select: true },
+                      );
+                    }
+                    return;
+                  }
+                }
+              }
+            } catch {
+              // ignore
             }
           }
         }


### PR DESCRIPTION
## 问题

1. **IME 重复输入**：中文输入法下连续输入并选词（如输入「你好」后空格确认），文本出现重复（「你好你好」）。
2. **Tag chip 光标卡死**：通过 `@`/`/` 唤起技能选择框并选择技能后，键盘方向键无法将光标移动到 chip 前后。

## 修复内容

### IME 重复输入（`Editor.tsx`）

`onCompositionStart` 时通过 `window.getSelection()` 读取 DOM caret 位置，经 `ReactEditor.toSlateRange` 转换后调用 `Transforms.select` 重新锚定 Slate selection。这样 composition 结束时 Slate 插入文字的起点是正确的，不会因前一次 selection 漂移而产生重复。

### Tag chip 光标导航（`useKeyboard.ts` / `elements/index.tsx` / `TagPopup/index.tsx`）

| 场景 | 修复行为 |
|------|----------|
| ArrowLeft 在 chip 起始位置（无 BOM） | 在 chip 前插入 `\uFEFF` 占位符，光标停在 BOM 末尾 |
| ArrowLeft 在 chip 起始位置（BOM 已存在） | preventDefault 并将光标移至 BOM 末尾 |
| ArrowLeft 在 chip 内部非零偏移 | 跳到 chip 前一节点末尾 |
| ArrowLeft 在非 tag 节点起始位置，前兄弟是 chip | 跳过 chip 到 chip 前一节点末尾 |
| ArrowRight 在 chip 前叶子末尾 | 跳到 chip 后节点起始位置 |
| ArrowRight，chip 为最后子节点 | 自动插入尾随空格并将光标移入 |
| 选中技能后 dropdown 关闭 | menu onClick 中补充 `setOpen(false)` 关闭本地下拉态 |
| BOM 插入后 chip 路径前移 | `elements/index.tsx` 用 `chipNewPath`（path+1）定位 chip 之后节点，光标停在 `Editor.start` |

### 测试

`useKeyboard.test.tsx` 共 58 个用例全部通过，覆盖以上 chip 光标导航场景与 BOM 已存在/未存在分支。

## 分支信息

- 基于 `upstream/main` 最新代码（`991731469`）
- 单个 commit：`48e5fdfee`